### PR TITLE
Adds AbstractFormField #84

### DIFF
--- a/src/Forms/FormExpressions.jl
+++ b/src/Forms/FormExpressions.jl
@@ -114,9 +114,19 @@ function evaluate(form::AnalyticalFormField{manifold_dim, 1, G, E}, element_idx:
     form_eval = form.expression(x) # size: num_points x image_dim
 
     num_eval_points = size(x,1)
-    form_pullback = zeros(num_eval_points, manifold_dim)
-    for i = 1:num_eval_points
-        form_pullback[i,:] = form_eval[i,:] * J[i,:,:]
+    image_dim = length(form_eval)
+    form_pullback = Vector{Vector{Float64}}(undef, manifold_dim)
+    for j = 1:manifold_dim
+        form_pullback[j] = zeros(num_eval_points)
+    end
+    a = zeros(num_eval_points, manifold_dim)
+    for j = 1:image_dim
+        for i = 1:num_eval_points
+            a[i,:] .+= form_eval[j][i] .* J[i,j,:]
+        end
+    end
+    for j= 1:image_dim
+        form_pullback[j] = a[:,j]
     end
     
     form_indices = ones(Int, n_form_components)


### PR DESCRIPTION
@J15525 @dccabanas 

I spent the whole day doing the theoretical derivation of the pullback for general geometries and forms. I added it to the associated issue #84 . I managed to implement the analytical form field for 0-forms and n-forms on mappings between n-manifolds. Someone needs to take the theoretical derivation I did and extend this to k-forms.

I make it as a pull request, so that it is visible to everyone.

- Implemented only for 0-forms and n-forms on an n-dimensional manifold
- Updated the "test" for forms, with examples of construction of a 0-form and of a 2-form (in 2D) and their evaluation.