### PR TITLE
modify plots to use tensor-product eval setup + enable higher-order wireframe exports

### DIFF
--- a/src/Plot/PlotKernel.jl
+++ b/src/Plot/PlotKernel.jl
@@ -99,7 +99,7 @@ function _plot(geometry::Geometry.AbstractGeometry{manifold_dim}, field::Union{N
         I_ref = node_ordering("line", degree)
 
         n_edges_per_element = length(edge_ordering)
-        n_total_edges = n_total_cells * n_edges_per_element
+        n_total_edges = n_total_elements * n_subcells * n_edges_per_element
         n_vertices_per_subedge = degree+1
         n_vertices_on_edges = n_total_edges * n_vertices_per_subedge
 
@@ -276,7 +276,7 @@ function _plot(form::Forms.AbstractFormExpression{manifold_dim, form_rank, G}, o
         I_ref = node_ordering("line", degree)
 
         n_edges_per_element = length(edge_ordering)
-        n_total_edges = n_total_cells * n_edges_per_element
+        n_total_edges = n_total_elements * n_subcells * n_edges_per_element
         n_vertices_per_subedge = degree+1
         n_vertices_on_edges = n_total_edges * n_vertices_per_subedge
 


### PR DESCRIPTION
* Changes the plotting routine so that we evaluate at all points on a subcell at once, instead of a loop over the points. The evaluate method should be more efficient this way since it can use the tensor-product setup of the points.
* Added an option to plots (subcell_wireframe) that also exports a higher-order representation of all curves that form the subcells

![deg2_torus](https://github.com/user-attachments/assets/b4e618ce-9634-44f8-9169-2ce0d58736fd)
