### PR TITLE
Tensor add get element vertices

### DIFF
--- a/src/FunctionSpaces/FiniteElementSpaces/TensorProductSpaces.jl
+++ b/src/FunctionSpaces/FiniteElementSpaces/TensorProductSpaces.jl
@@ -276,7 +276,7 @@ function get_element_dimensions(tp_space::TensorProductSpace{manifold_dim, T}, e
         end
     end
 
-    return tuple(vertices...)::NTuple{manifold_dim, Float64}
+    return tuple(element_dimensions...)::NTuple{manifold_dim, Float64}
 end 
 
 """


### PR DESCRIPTION
I realized these methods were missing: 'get_element_vertices' and 'get_element_dimensions'