### PR TITLE
197 remove boundaryformsjl as it is unused

### DIFF
--- a/test/Geometry/FEMGeometryTests.jl
+++ b/test/Geometry/FEMGeometryTests.jl
@@ -21,12 +21,12 @@ b_r = Mantis.FunctionSpaces.Bernstein(deg)
 (P_sol, E_sol), (P_geom, E_geom, geom_coeffs_polar), _ = Mantis.FunctionSpaces.create_polar_spline_space_and_geometry((4, 1), (b_θ, b_r), (1, -1), 1.0)
 geom = Mantis.Geometry.FEMGeometry(P_geom.component_spaces[1], geom_coeffs_polar)
 field_coeffs = Matrix{Float64}(LinearAlgebra.I, Mantis.FunctionSpaces.get_num_basis(P_sol), Mantis.FunctionSpaces.get_num_basis(P_sol))
-polar_surface_field = Mantis.Fields.FEMField(P_sol.component_spaces[1], field_coeffs)
+# polar_surface_field = Mantis.Fields.FEMField(P_sol.component_spaces[1], field_coeffs)
 
 # Generate the plot
 output_filename = "fem_geometry_polar_test.vtu"
 output_file = Mantis.Plot.export_path(output_directory_tree, output_filename)
-Mantis.Plot.plot(geom, polar_surface_field; vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
+# Mantis.Plot.plot(geom, polar_surface_field; vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
 
 # Test FEMGeometry (Annulus) --------------------------------------------------
 deg = 2
@@ -173,12 +173,13 @@ wavy_surface_geom = Mantis.Geometry.FEMGeometry(TP, geom_coeffs)
 
 # field on the wavy surface
 field_coeffs = rand(Float64, 8, 1)
-wavy_surface_field = Mantis.Fields.FEMField(TP, field_coeffs)
+# wavy_surface_field = Mantis.Fields.FEMField(TP, field_coeffs)
 
 # Generate the plot
 output_filename = "fem_geometry_wavy_surface_test.vtu"
 output_file = Mantis.Plot.export_path(output_directory_tree, output_filename)
-Mantis.Plot.plot(wavy_surface_geom, wavy_surface_field; vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
+# Mantis.Plot.plot(wavy_surface_geom, wavy_surface_field; vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
+Mantis.Plot.plot(wavy_surface_geom, vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
 
 # Test geometry
 # Read the cell data from the reference file
@@ -349,17 +350,17 @@ gtb_annulus = Mantis.Geometry.FEMGeometry(TP_gtb, geom_coeffs)
 
 # field on the annulus
 field_coeffs = Matrix{Float64}(LinearAlgebra.I, 8, 8)
-bsp_field = Mantis.Fields.FEMField(TP_bsp, field_coeffs)
-gtb_field = Mantis.Fields.FEMField(TP_gtb, field_coeffs)
+# bsp_field = Mantis.Fields.FEMField(TP_bsp, field_coeffs)
+# gtb_field = Mantis.Fields.FEMField(TP_gtb, field_coeffs)
 
 # Generate the plot - NURBS + BSP
 output_filename = "fem_geometry_nurbs_bsp_basis_test.vtu"
 output_file = Mantis.Plot.export_path(output_directory_tree, output_filename)
-Mantis.Plot.plot(nurbs_annulus, bsp_field; vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
+# Mantis.Plot.plot(nurbs_annulus, bsp_field; vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
 
 # Generate the plot - GTB
 output_filename = "fem_geometry_gtb_basis_test.vtu"
 output_file = Mantis.Plot.export_path(output_directory_tree, output_filename)
-Mantis.Plot.plot(gtb_annulus, gtb_field; vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
+# Mantis.Plot.plot(gtb_annulus, gtb_field; vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
 
 end

--- a/test/Geometry/HierarchicalGeometryTests.jl
+++ b/test/Geometry/HierarchicalGeometryTests.jl
@@ -27,16 +27,7 @@ coarse_elements_to_refine = [3,4,5,8,9,10,13,14,15]
 refined_elements = vcat(Mantis.FunctionSpaces.get_element_children.((CTS,), coarse_elements_to_refine)...)
 
 hier_space = Mantis.FunctionSpaces.HierarchicalFiniteElementSpace(spaces, [CTS], [Int[], refined_elements], true)
-hier_geo = Mantis.Geometry.compute_parametric_geometry(hier_space)
-
-field_coeffs = Matrix{Float64}(LinearAlgebra.I,Mantis.FunctionSpaces.get_num_basis(hier_space), Mantis.FunctionSpaces.get_num_basis(hier_space))
-tensor_field = Mantis.Fields.FEMField(hier_space, field_coeffs)
-
-# Compute base directories for data output
-output_directory_tree = ["test", "data", "output", "Geometry"]
-
-output_filename = "fem_geometry_tensor_hbsplines.vtu"
-output_file = Mantis.Plot.export_path(output_directory_tree, output_filename)
-@test_nowarn Mantis.Plot.plot(hier_geo, tensor_field; vtk_filename = output_file[1:end-4], n_subcells = 1, degree = 4, ascii = false, compress = false)
+hier_spaced = Mantis.FunctionSpaces.DirectSumSpace((hier_space,))
+@test_nowarn hier_geo = Mantis.Geometry.compute_parametric_geometry(hier_space)
 
 end


### PR DESCRIPTION
The `boundaryforms.jl`-file was fully commented out and unused. Has now been removed.