### PR TITLE
Fix mapped geometry

### DIFF
--- a/src/Geometry/MappedGeometry.jl
+++ b/src/Geometry/MappedGeometry.jl
@@ -246,18 +246,29 @@ function get_mapping(
 end
 
 function get_patch_and_local_element_id(
-    geometry::MappedGeometry{manifold_dim, image_dim, num_patches, T, G, Map},
-    element_id::Int=1,
+    geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map}, element_id::Int
 ) where {
     manifold_dim,
     image_dim,
     num_patches,
-    T,
-    G <: AbstractGeometry{manifold_dim, num_patches},
+    G <: AbstractGeometry{manifold_dim, image_dim, num_patches},
     Map,
 }
     patch_id = get_patch_id(geometry, element_id)
     return patch_id, element_id
+end
+function get_global_element_id(
+    geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map},
+    patch_id::Int,
+    local_element_id::Int,
+) where {
+    manifold_dim,
+    image_dim,
+    num_patches,
+    G <: AbstractGeometry{manifold_dim, image_dim, num_patches},
+    Map,
+}
+    return local_element_id
 end
 
 # Getters for numbers, sizes, shapes, lengths, etc.

--- a/src/Geometry/MappedGeometry.jl
+++ b/src/Geometry/MappedGeometry.jl
@@ -245,6 +245,21 @@ function get_mapping(
     return geometry.mapping[patch_id]
 end
 
+function get_patch_and_local_element_id(
+    geometry::MappedGeometry{manifold_dim, image_dim, num_patches, T, G, Map},
+    element_id::Int=1,
+) where {
+    manifold_dim,
+    image_dim,
+    num_patches,
+    T,
+    G <: AbstractGeometry{manifold_dim, num_patches},
+    Map,
+}
+    patch_id = get_patch_id(geometry, element_id)
+    return patch_id, element_id
+end
+
 # Getters for numbers, sizes, shapes, lengths, etc.
 function get_element_lengths(geometry::MappedGeometry, element_id::Int)
     patch_id, local_element_id = get_patch_and_local_element_id(geometry, element_id)

--- a/src/Geometry/MappedGeometry.jl
+++ b/src/Geometry/MappedGeometry.jl
@@ -246,7 +246,8 @@ function get_mapping(
 end
 
 """
-    get_patch_and_local_element_id(
+    get_base_patch_and_element_id(geometry::MappedGeometry, element_id::Int)
+    get_base_patch_and_element_id(
         geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map}, element_id::Int
     ) where {
         manifold_dim,
@@ -256,14 +257,14 @@ end
         Map,
     }
 
-Specialised version for `MappedGeometry` in the case that the base geometry is a
-multi-patch geometry.
-
-!!! warning
-    For this specific case, the returned `element_id` is still global! Call
-    `get_patch_and_local_element_id` on the base geometry itself to get the truly local id.
+Compute the `patch_id` and `element_id` for the base geometry, given the `element_id` of
+the `MappedGeometry`. Note that the returned `element_id` may still be global, depending on
+the type of base geometry.
 """
-function get_patch_and_local_element_id(
+function get_base_patch_and_element_id(geometry::MappedGeometry, element_id::Int)
+    return get_patch_and_local_element_id(geometry, element_id)
+end
+function get_base_patch_and_element_id(
     geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map}, element_id::Int
 ) where {
     manifold_dim,
@@ -272,58 +273,27 @@ function get_patch_and_local_element_id(
     G <: AbstractGeometry{manifold_dim, image_dim, num_patches},
     Map,
 }
-    patch_id = get_patch_id(geometry, element_id)
-    return patch_id, element_id
-end
-
-"""
-    get_global_element_id(
-        geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map},
-        patch_id::Int,
-        local_element_id::Int,
-    ) where {
-        manifold_dim,
-        image_dim,
-        num_patches,
-        G <: AbstractGeometry{manifold_dim, image_dim, num_patches},
-        Map,
-    }
-
-Specialised version for `MappedGeometry` in the case that the base geometry is a
-multi-patch geometry.
-
-!!! warning
-    For this specific case, the returned `element_id` is the given `local_element_id`! Call
-    `get_global_element_id` on the base geometry itself to get the truly global id.
-"""
-function get_global_element_id(
-    geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map},
-    patch_id::Int,
-    local_element_id::Int,
-) where {
-    manifold_dim,
-    image_dim,
-    num_patches,
-    G <: AbstractGeometry{manifold_dim, image_dim, num_patches},
-    Map,
-}
-    return local_element_id
+    # In this case, the base geometry is itself a multi-patch geometry with as many patches
+    # as the MappedGeometry. Its elements will thus match, and we don't have to compute a
+    # local element id here.
+    base_patch_id = get_patch_id(geometry, element_id)
+    return base_patch_id, element_id
 end
 
 # Getters for numbers, sizes, shapes, lengths, etc.
 function get_element_lengths(geometry::MappedGeometry, element_id::Int)
-    patch_id, local_element_id = get_patch_and_local_element_id(geometry, element_id)
-    return get_element_lengths(get_base_geometry(geometry, patch_id), local_element_id)
+    base_patch_id, base_element_id = get_base_patch_and_element_id(geometry, element_id)
+    return get_element_lengths(get_base_geometry(geometry, base_patch_id), base_element_id)
 end
 
 function get_element_measure(geometry::MappedGeometry, element_id::Int)
-    patch_id, local_element_id = get_patch_and_local_element_id(geometry, element_id)
-    return get_element_measure(get_base_geometry(geometry, patch_id), local_element_id)
+    base_patch_id, base_element_id = get_base_patch_and_element_id(geometry, element_id)
+    return get_element_measure(get_base_geometry(geometry, base_patch_id), base_element_id)
 end
 
 function get_element_vertices(geometry::MappedGeometry, element_id::Int)
-    patch_id, local_element_id = get_patch_and_local_element_id(geometry, element_id)
-    return get_element_vertices(get_base_geometry(geometry, patch_id), local_element_id)
+    base_patch_id, base_element_id = get_base_patch_and_element_id(geometry, element_id)
+    return get_element_vertices(get_base_geometry(geometry, base_patch_id), base_element_id)
 end
 
 # Evaluations and derivatives.
@@ -332,9 +302,9 @@ function evaluate(
     element_id::Int,
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, image_dim, num_patches, G, Map}
-    patch_id, local_element_id = get_patch_and_local_element_id(geometry, element_id)
-    x = evaluate(get_base_geometry(geometry, patch_id), local_element_id, xi)
-    x_mapped = evaluate(get_mapping(geometry, patch_id), x)
+    base_patch_id, base_element_id = get_base_patch_and_element_id(geometry, element_id)
+    x = evaluate(get_base_geometry(geometry, base_patch_id), base_element_id, xi)
+    x_mapped = evaluate(get_mapping(geometry, base_patch_id), x)
 
     return x_mapped
 end
@@ -345,12 +315,12 @@ function jacobian(
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, image_dim, num_patches, G, Map}
     # the Jacobian for the mapping from the elements to base geometry image
-    patch_id, local_element_id = get_patch_and_local_element_id(geometry, element_id)
-    base_geometry = get_base_geometry(geometry, patch_id)
-    J_1 = jacobian(base_geometry, local_element_id, xi)
-    x = evaluate(base_geometry, local_element_id, xi)
+    base_patch_id, base_element_id = get_base_patch_and_element_id(geometry, element_id)
+    base_geometry = get_base_geometry(geometry, base_patch_id)
+    J_1 = jacobian(base_geometry, base_element_id, xi)
+    x = evaluate(base_geometry, base_element_id, xi)
     # the mapping from the image of the  base geometry to the image of the mapping
-    J_2 = jacobian(get_mapping(geometry, patch_id), x)
+    J_2 = jacobian(get_mapping(geometry, base_patch_id), x)
 
     return J_2 .* J_1
 end
@@ -361,14 +331,14 @@ function hessian(
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, image_dim, num_patches}
     # Jacobian and Hessian of the base geometry
-    patch_id, local_element_id = get_patch_and_local_element_id(geometry, element_id)
-    base_geometry = get_base_geometry(geometry, patch_id)
-    x = evaluate(base_geometry, local_element_id, xi)
-    Jb = jacobian(base_geometry, local_element_id, xi)
-    Hb = hessian(base_geometry, local_element_id, xi)
+    base_patch_id, base_element_id = get_base_patch_and_element_id(geometry, element_id)
+    base_geometry = get_base_geometry(geometry, base_patch_id)
+    x = evaluate(base_geometry, base_element_id, xi)
+    Jb = jacobian(base_geometry, base_element_id, xi)
+    Hb = hessian(base_geometry, base_element_id, xi)
 
-    Jm = jacobian(get_mapping(geometry, patch_id), x)
-    Hm = hessian(get_mapping(geometry, patch_id), x)
+    Jm = jacobian(get_mapping(geometry, base_patch_id), x)
+    Hm = hessian(get_mapping(geometry, base_patch_id), x)
 
     return [
         ntuple(image_dim) do i

--- a/src/Geometry/MappedGeometry.jl
+++ b/src/Geometry/MappedGeometry.jl
@@ -245,6 +245,24 @@ function get_mapping(
     return geometry.mapping[patch_id]
 end
 
+"""
+    get_patch_and_local_element_id(
+        geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map}, element_id::Int
+    ) where {
+        manifold_dim,
+        image_dim,
+        num_patches,
+        G <: AbstractGeometry{manifold_dim, image_dim, num_patches},
+        Map,
+    }
+
+Specialised version for `MappedGeometry` in the case that the base geometry is a
+multi-patch geometry.
+
+!!! warning
+    For this specific case, the returned `element_id` is still global! Call
+    `get_patch_and_local_element_id` on the base geometry itself to get the truly local id.
+"""
 function get_patch_and_local_element_id(
     geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map}, element_id::Int
 ) where {
@@ -257,6 +275,27 @@ function get_patch_and_local_element_id(
     patch_id = get_patch_id(geometry, element_id)
     return patch_id, element_id
 end
+
+"""
+    get_global_element_id(
+        geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map},
+        patch_id::Int,
+        local_element_id::Int,
+    ) where {
+        manifold_dim,
+        image_dim,
+        num_patches,
+        G <: AbstractGeometry{manifold_dim, image_dim, num_patches},
+        Map,
+    }
+
+Specialised version for `MappedGeometry` in the case that the base geometry is a
+multi-patch geometry.
+
+!!! warning
+    For this specific case, the returned `element_id` is the given `local_element_id`! Call
+    `get_global_element_id` on the base geometry itself to get the truly global id.
+"""
 function get_global_element_id(
     geometry::MappedGeometry{manifold_dim, image_dim, num_patches, G, Map},
     patch_id::Int,

--- a/src/Geometry/MappedGeometry.jl
+++ b/src/Geometry/MappedGeometry.jl
@@ -262,6 +262,9 @@ the `MappedGeometry`. Note that the returned `element_id` may still be global, d
 the type of base geometry.
 """
 function get_base_patch_and_element_id(geometry::MappedGeometry, element_id::Int)
+    # This function is the default, which assumes that the base geometry is merely a
+    # collection of unconnected patches. In that case, we need to compute the patch-local
+    # element id to be able to evaluate the base geometry.
     return get_patch_and_local_element_id(geometry, element_id)
 end
 function get_base_patch_and_element_id(
@@ -275,7 +278,8 @@ function get_base_patch_and_element_id(
 }
     # In this case, the base geometry is itself a multi-patch geometry with as many patches
     # as the MappedGeometry. Its elements will thus match, and we don't have to compute a
-    # local element id here.
+    # local element id here, since this geometry expects a global element id (and global
+    # means the same thing on the base geometry as well as the MappedGeometry).
     base_patch_id = get_patch_id(geometry, element_id)
     return base_patch_id, element_id
 end

--- a/test/Geometry/MappedGeometryTests.jl
+++ b/test/Geometry/MappedGeometryTests.jl
@@ -74,12 +74,16 @@ function basic_tests(geometry, answers)
     @test (patch_id, local_element_id) == answers[9]
     @test Geometry.get_global_element_id(geometry, patch_id, local_element_id) ==
         answers[10]
+    base_patch_id, base_element_id = Geometry.get_base_patch_and_element_id(
+        geometry, answers[10]
+    )
+    @test (base_patch_id, base_element_id) == answers[11]
 
     @test all(
         all.([
             isapprox.(
-                Geometry.get_element_vertices(geometry, 1)[i], answers[11][i], rtol=1e-14
-            ) for i in eachindex(answers[11])
+                Geometry.get_element_vertices(geometry, 1)[i], answers[12][i], rtol=1e-14
+            ) for i in eachindex(answers[12])
         ]),
     )
 
@@ -160,7 +164,7 @@ mapping_I_obj = Geometry.Mapping((1, 1), mapping_I, dmapping_I)
 geometry1 = Geometry.MappedGeometry(
     Geometry.CartesianGeometry((LinRange(0.0, 1.0, 2),)), mapping_I_obj
 )
-answers_1 = (1, 1, 1, 1, (1,), 1, (1.0,), 1.0, (1, 1), 1, ((0.0, 1.0),))
+answers_1 = (1, 1, 1, 1, (1,), 1, (1.0,), 1.0, (1, 1), 1, (1, 1), ((0.0, 1.0),))
 basic_tests(geometry1, answers_1)
 
 # Mapped, explicit geometry and mapping per patch.
@@ -169,7 +173,18 @@ geom_slanted_2patch = Geometry.MappedGeometry(
     (mapping_patch_1_slanted, mapping_patch_2_slanted),
 )
 answers_geom_slanted_2patch = (
-    2, 46, 2, 2, (16, 30), 16, (0.25, 0.25), 0.0625, (1, 5), 5, ((0.0, 0.25), (0.0, 0.25))
+    2,
+    46,
+    2,
+    2,
+    (16, 30),
+    16,
+    (0.25, 0.25),
+    0.0625,
+    (1, 5),
+    5,
+    (1, 5),
+    ((0.0, 0.25), (0.0, 0.25)),
 )
 basic_tests(geom_slanted_2patch, answers_geom_slanted_2patch)
 
@@ -189,6 +204,7 @@ answers_geom_slanted_2patch_oneref = (
     1.0 / 24.0,
     (2, 2),
     26,
+    (2, 2),
     ((0.0, 0.25), (0.0, 1.0 / 6.0)),
 )
 basic_tests(geom_slanted_2patch_oneref, answers_geom_slanted_2patch_oneref)
@@ -214,6 +230,7 @@ answers_geom_slanted_2patch_onemap = (
     1 / 48,
     (2, 3),
     15,
+    (2, 3),
     ((0.0, 0.125), (0.0, 1.0 / 6.0)),
 )
 basic_tests(geom_slanted_2patch_onemap, answers_geom_slanted_2patch_onemap)
@@ -254,7 +271,7 @@ geo2mapped = Mantis.Geometry.MappedGeometry(
     (mapping_obj_1_geo2mapped, mapping_obj_2_geo2mapped),
 )
 answers_geo2mapped = (
-    2, 10, 2, 2, (4, 6), 4, (0.5, 0.5), 0.25, (2, 6), 6, ((0.0, 0.5), (0.0, 0.5))
+    2, 10, 2, 2, (4, 6), 4, (0.5, 0.5), 0.25, (2, 2), 6, (2, 6), ((0.0, 0.5), (0.0, 0.5))
 )
 basic_tests(geo2mapped, answers_geo2mapped)
 # Same geometry as above, but now implemented using a tuple of two patches as base geometry.
@@ -266,14 +283,25 @@ geo2mapped2 = Mantis.Geometry.MappedGeometry(
     (mapping_obj_1_geo2mapped, mapping_obj_2_geo2mapped),
 )
 answers_geo2mapped2 = (
-    2, 10, 2, 2, (4, 6), 4, (0.5, 0.5), 0.25, (2, 2), 6, ((0.0, 0.5), (0.0, 0.5))
+    2, 10, 2, 2, (4, 6), 4, (0.5, 0.5), 0.25, (2, 2), 6, (2, 2), ((0.0, 0.5), (0.0, 0.5))
 )
 basic_tests(geo2mapped2, answers_geo2mapped2)
 
 # Mapped, single mapping, single patch.
 geom_slanted_2patch_11 = Geometry.MappedGeometry(geom_cart_patch_1, mapping_patch_1_slanted)
 answers_geom_slanted_2patch_11 = (
-    1, 16, 2, 2, (16,), 16, (0.25, 0.25), 0.0625, (1, 16), 16, ((0.0, 0.25), (0.0, 0.25))
+    1,
+    16,
+    2,
+    2,
+    (16,),
+    16,
+    (0.25, 0.25),
+    0.0625,
+    (1, 16),
+    16,
+    (1, 16),
+    ((0.0, 0.25), (0.0, 0.25)),
 )
 basic_tests(geom_slanted_2patch_11, answers_geom_slanted_2patch_11)
 
@@ -297,7 +325,18 @@ ddgeo(x) = (
 mapping2to3 = Mantis.Geometry.Mapping((2, 3), geo, dgeo, ddgeo)
 geometry2to3 = Mantis.Geometry.MappedGeometry(geom_cart_patch_1, mapping2to3)
 answers_geometry2to3 = (
-    1, 16, 2, 3, (16,), 16, (0.25, 0.25), 0.0625, (1, 14), 14, ((0.0, 0.25), (0.0, 0.25))
+    1,
+    16,
+    2,
+    3,
+    (16,),
+    16,
+    (0.25, 0.25),
+    0.0625,
+    (1, 14),
+    14,
+    (1, 14),
+    ((0.0, 0.25), (0.0, 0.25)),
 )
 basic_tests(geometry2to3, answers_geometry2to3)
 
@@ -345,7 +384,18 @@ end
 # Curvilinear mapping
 geometrycurv = Geometry.create_curvilinear_square((0.0, 0.0), (1.0, 1.0), (4, 4))
 answers_geometrycurv = (
-    1, 16, 2, 2, (16,), 16, (0.25, 0.25), 0.0625, (1, 14), 14, ((0.0, 0.25), (0.0, 0.25))
+    1,
+    16,
+    2,
+    2,
+    (16,),
+    16,
+    (0.25, 0.25),
+    0.0625,
+    (1, 14),
+    14,
+    (1, 14),
+    ((0.0, 0.25), (0.0, 0.25)),
 )
 basic_tests(geometrycurv, answers_geometrycurv)
 

--- a/test/Geometry/MappedGeometryTests.jl
+++ b/test/Geometry/MappedGeometryTests.jl
@@ -218,6 +218,58 @@ answers_geom_slanted_2patch_onemap = (
 )
 basic_tests(geom_slanted_2patch_onemap, answers_geom_slanted_2patch_onemap)
 
+# Simple mapping (per patch), for a two patch geometry. The base geometry is itself a
+# multi-patch geometry.
+function mapping_patch_1_geo2mapped(x::AbstractVector{Float64})
+    # 0.0 <= x[1] <= 1.0 and 0.0 <= x[2] <= 1.0
+    return [-x[2], x[1]]
+end
+function dmapping_patch_1_geo2mapped(x::AbstractVector{Float64})
+    return [
+        [0.0 1.0]
+        [-1.0 0.0]
+    ]
+end
+mapping_obj_1_geo2mapped = Geometry.Mapping(
+    (2, 2), mapping_patch_1_geo2mapped, dmapping_patch_1_geo2mapped
+)
+function mapping_patch_2_geo2mapped(x::AbstractVector{Float64})
+    # 0.0 <= x[1] <= 1.0 and 0.0 <= x[2] <= 1.0
+    return [x[1], x[2]]
+end
+function dmapping_patch_2_geo2mapped(x::AbstractVector{Float64})
+    return [
+        [1.0 0.0]
+        [0.0 1.0]
+    ]
+end
+mapping_obj_2_geo2mapped = Geometry.Mapping(
+    (2, 2), mapping_patch_2_geo2mapped, dmapping_patch_2_geo2mapped
+)
+geo2mapped = Mantis.Geometry.MappedGeometry(
+    Mantis.Geometry.CartesianGeometry((
+        (LinRange(0.0, 1.0, 3), LinRange(0.0, 1.0, 3)),
+        (LinRange(0.0, 1.0, 3), LinRange(0.0, 1.0, 4)),
+    ),),
+    (mapping_obj_1_geo2mapped, mapping_obj_2_geo2mapped),
+)
+answers_geo2mapped = (
+    2, 10, 2, 2, (4, 6), 4, (0.5, 0.5), 0.25, (2, 6), 6, ((0.0, 0.5), (0.0, 0.5))
+)
+basic_tests(geo2mapped, answers_geo2mapped)
+# Same geometry as above, but now implemented using a tuple of two patches as base geometry.
+geo2mapped2 = Mantis.Geometry.MappedGeometry(
+    (
+        Mantis.Geometry.CartesianGeometry((LinRange(0.0, 1.0, 3), LinRange(0.0, 1.0, 3))),
+        Mantis.Geometry.CartesianGeometry((LinRange(0.0, 1.0, 3), LinRange(0.0, 1.0, 4))),
+    ),
+    (mapping_obj_1_geo2mapped, mapping_obj_2_geo2mapped),
+)
+answers_geo2mapped2 = (
+    2, 10, 2, 2, (4, 6), 4, (0.5, 0.5), 0.25, (2, 2), 6, ((0.0, 0.5), (0.0, 0.5))
+)
+basic_tests(geo2mapped2, answers_geo2mapped2)
+
 # Mapped, single mapping, single patch.
 geom_slanted_2patch_11 = Geometry.MappedGeometry(geom_cart_patch_1, mapping_patch_1_slanted)
 answers_geom_slanted_2patch_11 = (


### PR DESCRIPTION
During the topology work in #305, I found a bug in `MappedGeometry` that leads to the incorrect answer when using a base geometry that is already a multi-patch geometry (instead of a tuple of single-patch geometries).

The fix is to specialise the `get_patch_and_local_element_id` (and `get_global_element_id`) for the case where the base geometry is multi-patch. This means that, in this specific case, `get_patch_and_local_element_id` actually returns the global element id. I have tried to make this clear in the docstring.

I added a basic test where the different behaviour is tested.