### PR TITLE
feat: add constant form spaces

### DIFF
--- a/src/Forms/FormExpressions/ConstantFormSpaces.jl
+++ b/src/Forms/FormExpressions/ConstantFormSpaces.jl
@@ -152,8 +152,8 @@ Evaluate the basis function of a 0-form constant space at given canonical points
 function evaluate(
     ::ConstantFormSpace{manifold_dim, 0}, ::Int, xi::Points.AbstractPoints{manifold_dim}
 ) where {manifold_dim}
-    n_evaluation_points = prod(map(length, xi))
-    return [ones(Float64, n_evaluation_points, 1)], [[1]]
+    num_evaluation_points = Points.get_num_points(xi)
+    return [ones(Float64, num_evaluation_points, 1)], [[1]]
 end
 
 """
@@ -182,9 +182,9 @@ function evaluate(
     element_idx::Int,
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
-    num_evaluation_points = prod(map(length, xi))
+    num_evaluation_points = Points.get_num_points(xi)
     J = Geometry.jacobian(form_space.geometry, element_idx, xi)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
-    form_eval = [ones(Float64, n_evaluation_points, 1)]
+    form_eval = [ones(Float64, num_evaluation_points, 1)]
     form_eval[1][:] .*= LinearAlgebra.det.(J)
 
     return form_eval, [[1]]

--- a/src/Forms/FormExpressions/ConstantFormSpaces.jl
+++ b/src/Forms/FormExpressions/ConstantFormSpaces.jl
@@ -1,0 +1,195 @@
+############################################################################################
+#                                        Structure                                         #
+############################################################################################
+
+"""
+    ConstantFormSpace{manifold_dim, form_rank, G, L} <: AbstractFormSpace{manifold_dim, form_rank}
+
+Concrete implementation of a space for constant differential forms. For instance, this can 
+be used as a Lagrange multiplier enforcing a zero-average constraint on another differential form.
+
+# Fields
+- `geometry::G`: The geometry of the domain
+- `label::L`: Label for the constant form space
+
+# Type parameters
+- `manifold_dim`: Dimension of the manifold
+- `form_rank`: Rank of the differential form
+- `G`: Type of the geometry
+- `L`: Type of the label
+
+# Inner Constructors
+- `ConstantFormSpace(form_rank::Int, geometry::G, label::L)`: Constructor for constant
+    differential form spaces.
+"""
+struct ConstantFormSpace{manifold_dim, form_rank, G, L} <:
+        AbstractFormSpace{manifold_dim, form_rank, G, L}
+    geometry::G
+    label::L
+
+    """
+        ConstantFormSpace(
+            form_rank::Int, geometry::G, label::L
+        ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}, L <: AbstractString}
+
+    Constructor for constant differential form spaces.
+
+    # Arguments
+    - `form_rank::Int`: Differential form rank.
+    - `geometry::G`: The geometry of the domain.
+    - `label::L`: The label of the form space.
+
+    # Returns
+    - `ConstantFormSpace{manifold_dim, form_rank, G, L}`: The form space.
+    """
+    function ConstantFormSpace(
+        form_rank::Int,
+        geometry::G,
+        label::AbstractString
+    ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
+        if (form_rank ∉ Set([0, manifold_dim]))
+            throw(
+                ArgumentError(
+                    "Mantis.Forms.ConstantFormSpace: form_rank = $form_rank with " *
+                    "manifold_dim = $manifold_dim requires form_rank to be 0 or " *
+                    "manifold_dim.",
+                ),
+            )
+        end
+        return new{manifold_dim, form_rank, G, typeof(label)}(geometry, label)
+    end
+end
+
+############################################################################################
+#                                   Getters and setters                                    #
+############################################################################################
+
+"""
+    get_num_basis(::ConstantFormSpace)
+
+Get the number of basis functions for the constant form space.
+
+# Returns
+- `Int`: Number of basis functions (1).
+"""
+function get_num_basis(::ConstantFormSpace)
+    return 1
+end
+
+"""
+    get_num_basis(::ConstantFormSpace, ::Int)
+
+Get the number of basis functions for the constant form space on a specific element.
+
+# Arguments
+- `::ConstantFormSpace`: The constant form space.
+- `::Int`: The parametric element identifier.
+
+# Returns
+- `Int`: Number of basis functions (1).
+"""
+function get_num_basis(::ConstantFormSpace, ::Int)
+    return 1
+end
+
+"""
+    get_max_local_dim(::ConstantFormSpace)
+
+Get the maximum local dimension of the constant form space.
+
+# Returns
+- `Int`: Maximum local dimension (1).
+"""
+function get_max_local_dim(::ConstantFormSpace)
+    return 1
+end
+
+"""
+    get_estimated_nnz_per_elem(::ConstantFormSpace)
+
+Get the number of non-zero entries per element.
+
+# Returns
+- `Int`: Number of non-zeros per element (1).
+"""
+get_estimated_nnz_per_elem(::ConstantFormSpace) = 1
+
+"""
+    get_form(form_space::ConstantFormSpace)
+
+Return the form space itself.
+
+# Arguments
+- `form_space::ConstantFormSpace`: The constant form space.
+
+# Returns
+- `ConstantFormSpace`: The constant form space.
+"""
+get_form(form_space::ConstantFormSpace) = form_space
+
+############################################################################################
+#                                     Evaluate methods                                     #
+############################################################################################
+
+"""
+    evaluate(
+        ::ConstantFormSpace{manifold_dim, 0},
+        ::Int,
+        xi::Points.AbstractPoints{manifold_dim},
+    ) where {manifold_dim}
+
+Evaluate the basis function of a 0-form constant space at given canonical points `xi`.
+
+# Arguments
+- `::ConstantFormSpace{manifold_dim, 0}`: The constant 0-form space.
+- `::Int`: The parametric element identifier.
+- `xi::Points.AbstractPoints{manifold_dim}`: The set of canonical points.
+
+# Returns
+- `Vector{Matrix{Float64}}`: Vector containing a single `Matrix{Float64}` of ones of size
+    `(n_evaluation_points, 1)`.
+- `Vector{Vector{Int}}`: The basis function indices evaluated at the canonical coordinates
+    of the element, always equal to `[[1]]` in this case.
+"""
+function evaluate(
+    ::ConstantFormSpace{manifold_dim, 0},
+    ::Int,
+    xi::Points.AbstractPoints{manifold_dim},
+) where {manifold_dim}
+    n_evaluation_points = prod(map(length, xi))
+    return [ones(Float64, n_evaluation_points, 1)], [[1]]
+end
+
+"""
+    evaluate(
+        form_space::ConstantFormSpace{manifold_dim, manifold_dim},
+        element_idx::Int,
+        xi::Points.AbstractPoints{manifold_dim},
+    ) where {manifold_dim}
+
+Evaluate the basis function of a top-level (volume) constant form space at given canonical points
+`xi` mapped to the parametric element given by `element_idx`.
+
+# Arguments
+- `form_space::ConstantFormSpace{manifold_dim, manifold_dim}`: The constant volume form space.
+- `element_idx::Int`: The parametric element identifier.
+- `xi::Points.AbstractPoints{manifold_dim}`: The set of canonical points.
+
+# Returns
+- `Vector{Matrix{Float64}}`: Vector containing a single `Matrix{Float64}` of size
+    `(n_evaluation_points, 1)`, scaled by the determinant of the Jacobian at each point.
+- `Vector{Vector{Int}}`: The basis function indices evaluated at the canonical coordinates
+    of the element, always equal to `[[1]]` in this case.
+"""
+function evaluate(
+    form_space::ConstantFormSpace{manifold_dim, manifold_dim, G},
+    element_idx::Int,
+    xi::Points.AbstractPoints{manifold_dim},
+) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
+    n_evaluation_points = prod(map(length, xi))
+    J = Geometry.jacobian(form_space.geometry, element_idx, xi)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
+    form_eval = [ones(Float64, n_evaluation_points, 1)]
+    form_eval[1][:] .*= LinearAlgebra.det.(eachslice(J; dims=1))
+
+    return form_eval, [[1]]
+end

--- a/src/Forms/FormExpressions/ConstantFormSpaces.jl
+++ b/src/Forms/FormExpressions/ConstantFormSpaces.jl
@@ -3,10 +3,12 @@
 ############################################################################################
 
 """
-    ConstantFormSpace{manifold_dim, form_rank, G, L} <: AbstractFormSpace{manifold_dim, form_rank}
+    ConstantFormSpace{manifold_dim, form_rank, G, L} <:
+    AbstractFormSpace{manifold_dim, form_rank}
 
 Concrete implementation of a space for constant differential forms. For instance, this can
-be used as a Lagrange multiplier enforcing a zero-average constraint on another differential form.
+be used as a Lagrange multiplier enforcing a zero-average constraint on another
+differential form.
 
 # Fields
 - `geometry::G`: The geometry of the domain
@@ -29,8 +31,8 @@ struct ConstantFormSpace{manifold_dim, form_rank, G, L} <:
 
     """
         ConstantFormSpace(
-            form_rank::Int, geometry::G, label::L
-        ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}, L <: AbstractString}
+            form_rank::Int, geometry::G, label::AbstractString
+        ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
 
     Constructor for constant differential form spaces.
 
@@ -62,54 +64,12 @@ end
 #                                   Getters and setters                                    #
 ############################################################################################
 
-"""
-    get_num_basis(::ConstantFormSpace)
+get_num_basis(::ConstantFormSpace) = 1
 
-Get the number of basis functions for the constant form space.
+get_num_basis(::ConstantFormSpace, ::Int) = 1
 
-# Returns
-- `Int`: Number of basis functions (1).
-"""
-function get_num_basis(::ConstantFormSpace)
-    return 1
-end
+get_max_local_dim(::ConstantFormSpace) = 1
 
-"""
-    get_num_basis(::ConstantFormSpace, ::Int)
-
-Get the number of basis functions for the constant form space on a specific element.
-
-# Arguments
-- `::ConstantFormSpace`: The constant form space.
-- `::Int`: The parametric element identifier.
-
-# Returns
-- `Int`: Number of basis functions (1).
-"""
-function get_num_basis(::ConstantFormSpace, ::Int)
-    return 1
-end
-
-"""
-    get_max_local_dim(::ConstantFormSpace)
-
-Get the maximum local dimension of the constant form space.
-
-# Returns
-- `Int`: Maximum local dimension (1).
-"""
-function get_max_local_dim(::ConstantFormSpace)
-    return 1
-end
-
-"""
-    get_estimated_nnz_per_elem(::ConstantFormSpace)
-
-Get the number of non-zero entries per element.
-
-# Returns
-- `Int`: Number of non-zeros per element (1).
-"""
 get_estimated_nnz_per_elem(::ConstantFormSpace) = 1
 
 """
@@ -131,16 +91,16 @@ get_form(form_space::ConstantFormSpace) = form_space
 
 """
     evaluate(
-        ::ConstantFormSpace{manifold_dim, 0},
-        ::Int,
+        form_space::ConstantFormSpace{manifold_dim, 0},
+        element_id::Int,
         xi::Points.AbstractPoints{manifold_dim},
     ) where {manifold_dim}
 
 Evaluate the basis function of a 0-form constant space at given canonical points `xi`.
 
 # Arguments
-- `::ConstantFormSpace{manifold_dim, 0}`: The constant 0-form space.
-- `::Int`: The parametric element identifier.
+- `form_space::ConstantFormSpace{manifold_dim, 0}`: The constant 0-form space.
+- `element_id::Int`: The parametric element identifier.
 - `xi::Points.AbstractPoints{manifold_dim}`: The set of canonical points.
 
 # Returns
@@ -150,7 +110,9 @@ Evaluate the basis function of a 0-form constant space at given canonical points
     of the element, always equal to `[[1]]` in this case.
 """
 function evaluate(
-    ::ConstantFormSpace{manifold_dim, 0}, ::Int, xi::Points.AbstractPoints{manifold_dim}
+    form_space::ConstantFormSpace{manifold_dim, 0},
+    element_id::Int,
+    xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim}
     num_evaluation_points = Points.get_num_points(xi)
     return [ones(Float64, num_evaluation_points, 1)], [[1]]
@@ -158,17 +120,17 @@ end
 
 """
     evaluate(
-        form_space::ConstantFormSpace{manifold_dim, manifold_dim},
-        element_idx::Int,
+        form_space::ConstantFormSpace{manifold_dim, manifold_dim, G},
+        element_id::Int,
         xi::Points.AbstractPoints{manifold_dim},
-    ) where {manifold_dim}
+    ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
 
 Evaluate the basis function of a top-level (volume) constant form space at given canonical points
-`xi` mapped to the parametric element given by `element_idx`.
+`xi` mapped to the parametric element given by `element_id`.
 
 # Arguments
 - `form_space::ConstantFormSpace{manifold_dim, manifold_dim}`: The constant volume form space.
-- `element_idx::Int`: The parametric element identifier.
+- `element_id::Int`: The parametric element identifier.
 - `xi::Points.AbstractPoints{manifold_dim}`: The set of canonical points.
 
 # Returns
@@ -179,11 +141,11 @@ Evaluate the basis function of a top-level (volume) constant form space at given
 """
 function evaluate(
     form_space::ConstantFormSpace{manifold_dim, manifold_dim, G},
-    element_idx::Int,
+    element_id::Int,
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
     num_evaluation_points = Points.get_num_points(xi)
-    J = Geometry.jacobian(form_space.geometry, element_idx, xi)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
+    J = Geometry.jacobian(get_geometry(form_space), element_id, xi)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
     form_eval = [ones(Float64, num_evaluation_points, 1)]
     form_eval[1][:] .*= LinearAlgebra.det.(J)
 

--- a/src/Forms/FormExpressions/ConstantFormSpaces.jl
+++ b/src/Forms/FormExpressions/ConstantFormSpaces.jl
@@ -97,6 +97,14 @@ Return the geometry associated with the constant form space.
 """
 get_geometry(form_space::ConstantFormSpace) = form_space.geometry
 
+function get_fe_space(::ConstantFormSpace)
+    throw(
+        ArgumentError(
+            "ConstantFormSpace does not have an associated finite element space.",
+        ),
+    )
+end
+
 ############################################################################################
 #                                     Evaluate methods                                     #
 ############################################################################################
@@ -157,9 +165,9 @@ function evaluate(
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
     num_evaluation_points = Points.get_num_points(xi)
-    J = Geometry.jacobian(get_geometry(form_space), element_id, xi)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
+    _, sqrt_g = Geometry.metric(get_geometry(form_space), element_id, xi)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
     form_eval = [ones(Float64, num_evaluation_points, 1)]
-    form_eval[1][:] .*= LinearAlgebra.det.(J)
+    form_eval[1][:] .*= sqrt_g
 
     return form_eval, [[1]]
 end

--- a/src/Forms/FormExpressions/ConstantFormSpaces.jl
+++ b/src/Forms/FormExpressions/ConstantFormSpaces.jl
@@ -5,7 +5,7 @@
 """
     ConstantFormSpace{manifold_dim, form_rank, G, L} <: AbstractFormSpace{manifold_dim, form_rank}
 
-Concrete implementation of a space for constant differential forms. For instance, this can 
+Concrete implementation of a space for constant differential forms. For instance, this can
 be used as a Lagrange multiplier enforcing a zero-average constraint on another differential form.
 
 # Fields
@@ -23,7 +23,7 @@ be used as a Lagrange multiplier enforcing a zero-average constraint on another 
     differential form spaces.
 """
 struct ConstantFormSpace{manifold_dim, form_rank, G, L} <:
-        AbstractFormSpace{manifold_dim, form_rank, G, L}
+       AbstractFormSpace{manifold_dim, form_rank}
     geometry::G
     label::L
 
@@ -43,9 +43,7 @@ struct ConstantFormSpace{manifold_dim, form_rank, G, L} <:
     - `ConstantFormSpace{manifold_dim, form_rank, G, L}`: The form space.
     """
     function ConstantFormSpace(
-        form_rank::Int,
-        geometry::G,
-        label::AbstractString
+        form_rank::Int, geometry::G, label::AbstractString
     ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
         if (form_rank ∉ Set([0, manifold_dim]))
             throw(
@@ -152,9 +150,7 @@ Evaluate the basis function of a 0-form constant space at given canonical points
     of the element, always equal to `[[1]]` in this case.
 """
 function evaluate(
-    ::ConstantFormSpace{manifold_dim, 0},
-    ::Int,
-    xi::Points.AbstractPoints{manifold_dim},
+    ::ConstantFormSpace{manifold_dim, 0}, ::Int, xi::Points.AbstractPoints{manifold_dim}
 ) where {manifold_dim}
     n_evaluation_points = prod(map(length, xi))
     return [ones(Float64, n_evaluation_points, 1)], [[1]]

--- a/src/Forms/FormExpressions/ConstantFormSpaces.jl
+++ b/src/Forms/FormExpressions/ConstantFormSpaces.jl
@@ -5,7 +5,7 @@
 """
     ConstantFormSpace{manifold_dim, form_rank, G, L} <: AbstractFormSpace{manifold_dim, form_rank}
 
-Concrete implementation of a space for constant differential forms. For instance, this can 
+Concrete implementation of a space for constant scalar differential forms. For instance, this can 
 be used as a Lagrange multiplier enforcing a zero-average constraint on another differential form.
 
 # Fields
@@ -32,7 +32,7 @@ struct ConstantFormSpace{manifold_dim, form_rank, G, L} <:
             form_rank::Int, geometry::G, label::L
         ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}, L <: AbstractString}
 
-    Constructor for constant differential form spaces.
+    Constructor for constant, scalar differential form spaces.
 
     # Arguments
     - `form_rank::Int`: Differential form rank.
@@ -127,6 +127,19 @@ Return the form space itself.
 """
 get_form(form_space::ConstantFormSpace) = form_space
 
+"""
+    get_geometry(form_space::ConstantFormSpace)
+
+Return the geometry associated with the constant form space.
+
+# Arguments
+- `form_space::ConstantFormSpace`: The constant form space.
+
+# Returns
+- `G`: The geometry associated with the form space.
+"""
+get_geometry(form_space::ConstantFormSpace) = form_space.geometry
+
 ############################################################################################
 #                                     Evaluate methods                                     #
 ############################################################################################
@@ -187,7 +200,7 @@ function evaluate(
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
     n_evaluation_points = prod(map(length, xi))
-    J = Geometry.jacobian(form_space.geometry, element_idx, xi)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
+    J = Geometry.jacobian(get_geometry(form_space), element_idx, xi)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
     form_eval = [ones(Float64, n_evaluation_points, 1)]
     form_eval[1][:] .*= LinearAlgebra.det.(eachslice(J; dims=1))
 

--- a/src/Forms/FormExpressions/ConstantFormSpaces.jl
+++ b/src/Forms/FormExpressions/ConstantFormSpaces.jl
@@ -182,10 +182,10 @@ function evaluate(
     element_idx::Int,
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, G <: Geometry.AbstractGeometry{manifold_dim}}
-    n_evaluation_points = prod(map(length, xi))
+    num_evaluation_points = prod(map(length, xi))
     J = Geometry.jacobian(form_space.geometry, element_idx, xi)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
     form_eval = [ones(Float64, n_evaluation_points, 1)]
-    form_eval[1][:] .*= LinearAlgebra.det.(eachslice(J; dims=1))
+    form_eval[1][:] .*= LinearAlgebra.det.(J)
 
     return form_eval, [[1]]
 end

--- a/src/Forms/FormExpressions/FormExpressions.jl
+++ b/src/Forms/FormExpressions/FormExpressions.jl
@@ -3,4 +3,5 @@
 ############################################################################################
 
 include("FormSpaces.jl")
+include("ConstantFormSpaces.jl")
 include("FormFields.jl")

--- a/src/Forms/FormExpressions/FormSpaces.jl
+++ b/src/Forms/FormExpressions/FormSpaces.jl
@@ -99,7 +99,7 @@ mapped to the parametric element given by `element_idx`.
 # Arguments
 - `form_space::FormSpace{manifold_dim, form_rank, G}`: The differential form space.
 - `element_idx::Int`: The parametric element identifier.
-- `xi::NTuple{manifold_dim, Vector{Float64}`: The set of canonical points.
+- `xi::Points.AbstractPoints{manifold_dim}`: The set of canonical points.
 
 # Returns
 - `Vector{Matrix{Float64}}`: Vector of length equal to the number of components of the form,

--- a/src/Forms/FormExpressions/FormSpaces.jl
+++ b/src/Forms/FormExpressions/FormSpaces.jl
@@ -17,8 +17,8 @@ Concrete implementation of a function space for differential forms.
 - `F`: Type of the finite element space
 
 # Inner Constructors
-- `FormSpace(form_rank::Int,fem_space::F, label::AbstractString)`: Constructor for differential
-    form spaces.
+- `FormSpace(form_rank::Int,fem_space::F, label::AbstractString)`: Constructor for
+	differential form spaces.
 """
 struct FormSpace{manifold_dim, form_rank, F, L} <:
        AbstractFormSpace{manifold_dim, form_rank}
@@ -58,7 +58,7 @@ struct FormSpace{manifold_dim, form_rank, F, L} <:
                 ArgumentError(
                     "Mantis.Forms.FormSpace: form_rank = $form_rank with " *
                     "manifold_dim = $manifold_dim requires FE space with only one " *
-                    "component (got num_compoents = $num_components).",
+                    "component (got num_components = $num_components).",
                 ),
             )
         elseif (form_rank ∉ Set([0, manifold_dim])) && (num_components != manifold_dim)
@@ -66,7 +66,7 @@ struct FormSpace{manifold_dim, form_rank, F, L} <:
                 ArgumentError(
                     "Mantis.Forms.FormSpace: form_rank = $form_rank with " *
                     "manifold_dim = $manifold_dim requires a FE space with " *
-                    "num_components = $manifold_dim (got num_components = $num_components).",
+                    "num_components = $manifold_dim (got $num_components).",
                 ),
             )
         end
@@ -84,9 +84,13 @@ get_estimated_nnz_per_elem(form_space::FormSpace) = get_max_local_dim(form_space
 
 get_geometry(form_space::FormSpace) = FunctionSpaces.get_geometry(get_fe_space(form_space))
 
-get_num_basis(form_space::FormSpace) = FunctionSpaces.get_num_basis(get_fe_space(form_space))
+function get_num_basis(form_space::FormSpace)
+    return FunctionSpaces.get_num_basis(get_fe_space(form_space))
+end
 
-get_num_basis(form_space::FormSpace, element_id::Int) = FunctionSpaces.get_num_basis(get_fe_space(form_space), element_id)
+function get_num_basis(form_space::FormSpace, element_id::Int)
+    return FunctionSpaces.get_num_basis(get_fe_space(form_space), element_id)
+end
 
 ############################################################################################
 #                                     Evaluate methods                                     #

--- a/src/Forms/FormExpressions/FormSpaces.jl
+++ b/src/Forms/FormExpressions/FormSpaces.jl
@@ -82,6 +82,12 @@ get_form(form_space::FormSpace) = form_space
 
 get_estimated_nnz_per_elem(form_space::FormSpace) = get_max_local_dim(form_space)
 
+get_geometry(form_space::FormSpace) = FunctionSpaces.get_geometry(get_fe_space(form_space))
+
+get_num_basis(form_space::FormSpace) = FunctionSpaces.get_num_basis(get_fe_space(form_space))
+
+get_num_basis(form_space::FormSpace, element_id::Int) = FunctionSpaces.get_num_basis(get_fe_space(form_space), element_id)
+
 ############################################################################################
 #                                     Evaluate methods                                     #
 ############################################################################################

--- a/src/Forms/FormOperators/ExteriorDerivative.jl
+++ b/src/Forms/FormOperators/ExteriorDerivative.jl
@@ -325,6 +325,27 @@ function _evaluate_exterior_derivative(
     return local_d_form_basis_eval, form_basis_indices
 end
 
+############################################################################################
+#                                  Constant Form Space                                     #
+############################################################################################
+
+function _evaluate_exterior_derivative(
+    ::ConstantFormSpace{manifold_dim, 0},
+    ::Int,
+    xi::Points.AbstractPoints{manifold_dim},
+) where {manifold_dim}
+    # Preallocate memory for output array
+    n_derivative_form_components = manifold_dim
+    n_basis_functions = 1
+    n_evaluation_points = Points.get_num_points(xi)
+    local_d_form_basis_eval = [
+        zeros(Float64, n_evaluation_points, n_basis_functions) for
+        _ in 1:n_derivative_form_components
+    ]
+
+    return local_d_form_basis_eval, [[1]]
+end
+
 # #############################################################################################
 # #                                           dd                                              #
 # #############################################################################################

--- a/src/Forms/Forms.jl
+++ b/src/Forms/Forms.jl
@@ -343,7 +343,11 @@ space.
 - `Int`: The number of basis functions of the function space.
 """
 function get_num_basis(form_space::AbstractFormSpace)
-    return FunctionSpaces.get_num_basis(get_fe_space(form_space))
+    try 
+        return FunctionSpaces.get_num_basis(get_fe_space(form_space))
+    catch ArgumentError
+        return get_num_basis(get_form(form_space))
+    end
 end
 
 """

--- a/src/Forms/Forms.jl
+++ b/src/Forms/Forms.jl
@@ -163,7 +163,13 @@ Returns the geometry of the given form expression.
 # Returns
 - `<:Geometry.AbstractGeometry`: The geometry of the form expression.
 """
-get_geometry(form::AbstractForm) = FunctionSpaces.get_geometry(get_fe_space(form))
+function get_geometry(form::AbstractForm)
+    try
+        return FunctionSpaces.get_geometry(get_fe_space(form))
+    catch ArgumentError
+        return get_geometry(get_form(form))
+    end
+end
 
 """
     get_geometry(

--- a/src/Forms/Forms.jl
+++ b/src/Forms/Forms.jl
@@ -164,11 +164,7 @@ Returns the geometry of the given form expression.
 - `<:Geometry.AbstractGeometry`: The geometry of the form expression.
 """
 function get_geometry(form::AbstractForm)
-    try
-        return FunctionSpaces.get_geometry(get_fe_space(form))
-    catch ArgumentError
-        return get_geometry(get_form(form))
-    end
+    return get_geometry(get_form(form))
 end
 
 """
@@ -349,11 +345,7 @@ space.
 - `Int`: The number of basis functions of the function space.
 """
 function get_num_basis(form_space::AbstractFormSpace)
-    try 
-        return FunctionSpaces.get_num_basis(get_fe_space(form_space))
-    catch ArgumentError
-        return get_num_basis(get_form(form_space))
-    end
+    return get_num_basis(get_form(form_space))
 end
 
 """
@@ -369,7 +361,7 @@ the given form space.
 - `Int`: The number of basis functions at the given element.
 """
 function get_num_basis(form_space::AbstractFormSpace, element_id::Int)
-    return FunctionSpaces.get_num_basis(get_fe_space(form_space), element_id)
+    return get_num_basis(get_form(form_space), element_id)
 end
 
 ############################################################################################

--- a/test/Forms/ConstantFormSpaceTests.jl
+++ b/test/Forms/ConstantFormSpaceTests.jl
@@ -1,0 +1,74 @@
+module ConstantFormSpaceTests
+
+using Mantis
+using Test
+import LinearAlgebra
+
+const manifold_dim = 2
+const L = 1.0
+const num_elements_per_dim = 2
+const num_points_per_dim = 3
+const num_quad_points_per_dim = 2
+
+# Create a simple Cartesian geometry with random breakpoints
+breakpoints = ntuple(manifold_dim) do i
+    el_sizes = rand(num_elements_per_dim)
+    el_sizes ./= sum(el_sizes).* L
+    return cumsum([0.0; el_sizes])
+end
+geom = Geometry.CartesianGeometry(breakpoints)
+canonical_qrule = Quadrature.tensor_product_rule(
+    ntuple(i->num_quad_points_per_dim, manifold_dim), Quadrature.gauss_legendre
+)
+dΩ = Mantis.Quadrature.StandardQuadrature(canonical_qrule, Geometry.get_num_elements(geom))
+
+# Setup the form spaces, evaluate and check the results
+ξ = Points.CartesianPoints(ntuple(i->range(0.0, rand(), num_points_per_dim), manifold_dim))
+for form_rank in 0:manifold_dim
+    if form_rank ∉ Set([0, manifold_dim])
+        @test_throws ArgumentError Forms.ConstantFormSpace(form_rank, geom, "c")
+    else
+        form_space = Forms.ConstantFormSpace(form_rank, geom, "a")
+
+        # Check number of basis functions
+        @test Forms.get_num_basis(form_space) == 1
+
+        # Check number of basis functions for each element
+        for element_id in 1:Forms.get_num_elements(form_space)
+            @test Forms.get_num_basis(form_space, element_id) == 1
+        end
+
+        # Check max local dimension
+        @test Forms.get_max_local_dim(form_space) == 1
+
+        # Check estimated nnz per element
+        @test Forms.get_estimated_nnz_per_elem(form_space) == 1
+
+        # Check evaluate
+        for element_id in 1:Forms.get_num_elements(form_space)
+            eval, inds = Forms.evaluate(form_space, element_id, ξ)
+            if form_rank == 0
+                @test eval == [reshape([1.0 for _ in 1:Points.get_num_points(ξ)], :, 1)]
+                @test inds == [[1]]
+            elseif form_rank == manifold_dim
+                J = Geometry.jacobian(Forms.get_geometry(form_space), element_id, ξ)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
+                detJ =LinearAlgebra.det.(J)
+                @test eval == [reshape([detJ[i] for i in 1:Points.get_num_points(ξ)], :, 1)]
+                @test inds == [[1]]
+            end
+        end
+
+        # Check integral
+        ip = ∫(form_space ∧ ★(form_space), dΩ)
+        ip_eval = 0.0
+        for element_id in 1:Forms.get_num_elements(form_space)
+            ip_eval += sum(Forms.evaluate(ip, element_id)[1])
+        end
+        @test isapprox(ip_eval, L^manifold_dim, atol=1e-12)
+    end
+
+end
+
+
+
+end

--- a/test/Forms/ConstantFormSpaceTests.jl
+++ b/test/Forms/ConstantFormSpaceTests.jl
@@ -4,71 +4,215 @@ using Mantis
 using Test
 import LinearAlgebra
 
-const manifold_dim = 2
 const L = 1.0
 const num_elements_per_dim = 2
 const num_points_per_dim = 3
-const num_quad_points_per_dim = 2
 
-# Create a simple Cartesian geometry with random breakpoints
-breakpoints = ntuple(manifold_dim) do i
-    el_sizes = rand(num_elements_per_dim)
-    el_sizes ./= sum(el_sizes).* L
-    return cumsum([0.0; el_sizes])
-end
-geom = Geometry.CartesianGeometry(breakpoints)
-canonical_qrule = Quadrature.tensor_product_rule(
-    ntuple(i->num_quad_points_per_dim, manifold_dim), Quadrature.gauss_legendre
-)
-dΩ = Mantis.Quadrature.StandardQuadrature(canonical_qrule, Geometry.get_num_elements(geom))
+############################################################################################
+#                                         Cartesian geometry                               #
+############################################################################################
 
-# Setup the form spaces, evaluate and check the results
-ξ = Points.CartesianPoints(ntuple(i->range(0.0, rand(), num_points_per_dim), manifold_dim))
-for form_rank in 0:manifold_dim
-    if form_rank ∉ Set([0, manifold_dim])
-        @test_throws ArgumentError Forms.ConstantFormSpace(form_rank, geom, "c")
-    else
-        form_space = Forms.ConstantFormSpace(form_rank, geom, "a")
-
-        # Check number of basis functions
-        @test Forms.get_num_basis(form_space) == 1
-
-        # Check number of basis functions for each element
-        for element_id in 1:Forms.get_num_elements(form_space)
-            @test Forms.get_num_basis(form_space, element_id) == 1
-        end
-
-        # Check max local dimension
-        @test Forms.get_max_local_dim(form_space) == 1
-
-        # Check estimated nnz per element
-        @test Forms.get_estimated_nnz_per_elem(form_space) == 1
-
-        # Check evaluate
-        for element_id in 1:Forms.get_num_elements(form_space)
-            eval, inds = Forms.evaluate(form_space, element_id, ξ)
-            if form_rank == 0
-                @test eval == [reshape([1.0 for _ in 1:Points.get_num_points(ξ)], :, 1)]
-                @test inds == [[1]]
-            elseif form_rank == manifold_dim
-                J = Geometry.jacobian(Forms.get_geometry(form_space), element_id, ξ)  # Jₖⱼ = ∂Φᵏ\\∂ξⱼ
-                detJ =LinearAlgebra.det.(J)
-                @test eval == [reshape([detJ[i] for i in 1:Points.get_num_points(ξ)], :, 1)]
-                @test inds == [[1]]
-            end
-        end
-
-        # Check integral
-        ip = ∫(form_space ∧ ★(form_space), dΩ)
-        ip_eval = 0.0
-        for element_id in 1:Forms.get_num_elements(form_space)
-            ip_eval += sum(Forms.evaluate(ip, element_id)[1])
-        end
-        @test isapprox(ip_eval, L^manifold_dim, atol=1e-12)
+function test_cartesian(manifold_dim::Int, num_quad_points_per_dim::Int)
+    # Create a simple Cartesian geometry with random breakpoints
+    breakpoints = ntuple(manifold_dim) do i
+        el_sizes = 1.1.^(1:num_elements_per_dim)
+        el_sizes ./= sum(el_sizes)
+        el_sizes .*= L
+        return cumsum([0.0; el_sizes])
     end
+    geom = Geometry.CartesianGeometry(breakpoints)
+    canonical_qrule = Quadrature.tensor_product_rule(
+        ntuple(i->num_quad_points_per_dim, manifold_dim), Quadrature.gauss_legendre
+    )
+    dΩ = Mantis.Quadrature.StandardQuadrature(canonical_qrule, Geometry.get_num_elements(geom))
 
+    # Setup the form spaces, evaluate and check the results
+    ξ = Points.CartesianPoints(ntuple(i->range(0.0, rand(), num_points_per_dim), manifold_dim))
+    for form_rank in 0:manifold_dim
+        if form_rank ∉ Set([0, manifold_dim])
+            @test_throws ArgumentError Forms.ConstantFormSpace(form_rank, geom, "c")
+        else
+            form_space = Forms.ConstantFormSpace(form_rank, geom, "a")
+
+            # Check number of basis functions
+            @test Forms.get_num_basis(form_space) == 1
+
+            # Check number of basis functions for each element
+            for element_id in 1:Forms.get_num_elements(form_space)
+                @test Forms.get_num_basis(form_space, element_id) == 1
+            end
+
+            # Check max local dimension
+            @test Forms.get_max_local_dim(form_space) == 1
+
+            # Check estimated nnz per element
+            @test Forms.get_estimated_nnz_per_elem(form_space) == 1
+
+            # Check evaluate
+            for element_id in 1:Forms.get_num_elements(form_space)
+                eval, inds = Forms.evaluate(form_space, element_id, ξ)
+                if form_rank == 0
+                    @test eval == [reshape([1.0 for _ in 1:Points.get_num_points(ξ)], :, 1)]
+                    @test inds == [[1]]
+                elseif form_rank == manifold_dim
+                    _, sqrt_g = Geometry.metric(geom, element_id, ξ)
+                    @test isapprox(eval[1], reshape(sqrt_g, :, 1), atol=1e-12)
+                    @test inds == [[1]]
+                end
+            end
+
+            # Check derivative
+            if form_rank == 0
+                d_form_space = d(form_space)
+                @test Forms.get_num_basis(d_form_space) == 1
+                for element_id in 1:Forms.get_num_elements(form_space)
+                    d_eval, d_inds = Forms.evaluate(d_form_space, element_id, ξ)
+                    for i in 1:manifold_dim
+                        @test d_eval[i] == reshape([0.0 for _ in 1:Points.get_num_points(ξ)], :, 1)
+                    end
+                    @test d_inds == [[1]]
+                end
+            end
+
+            # Check integral
+            if form_rank == 0
+                integral = ∫(★(form_space), dΩ)
+            else
+                integral = ∫(form_space, dΩ)
+            end
+            integral_Eval = 0.0
+            for element_id in 1:Forms.get_num_elements(form_space)
+                integral_Eval += sum(Forms.evaluate(integral, element_id)[1])
+            end
+            @test isapprox(integral_Eval, L^manifold_dim, atol=1e-12)
+        end
+
+    end
 end
 
+@testset "Cartesian Geometry" begin
+    for manifold_dim in 1:3
+        for num_quad_points_per_dim in 1:5
+            test_cartesian(manifold_dim, num_quad_points_per_dim)
+        end
+    end
+end
+
+############################################################################################
+#                                         Mapped geometry                                  #
+############################################################################################
+
+const manifold_dim = 2
+const r = 1.0
+const Δr = 0.1
+
+function mapping(x::AbstractVector)
+    return [x[1].*cos(x[2]*π/2), x[1].*sin(x[2]*π/2)]
+end
+function dmapping(x::AbstractVector)
+    return [cos(x[2]*π/2) -x[1]*sin(x[2]*π/2)*π/2;
+            sin(x[2]*π/2) x[1]*cos(x[2]*π/2)*π/2]
+end
+dimension = (2, 2)
+curved_mapping = Geometry.Mapping(dimension, mapping, dmapping)
+
+breakpoints = (LinRange(Δr, r, 4), LinRange(0.0, 1.0, 4))
+geom = Geometry.CartesianGeometry(breakpoints)
+mapped_geometry = Geometry.MappedGeometry(geom, curved_mapping)
+
+reference_directory_tree = ["test", "data", "reference", "Plot"]
+output_directory_tree = ["test", "data", "output", "Plot"]
+output_filename = "mytemp_hemisphere.vtu"
+output_file = Mantis.GeneralHelpers.export_path(output_directory_tree, output_filename)
+Plot.plot(
+    mapped_geometry;
+    vtk_filename=output_file[1:(end - 4)],
+    n_subcells=1,
+    degree=4,
+    ascii=false,
+    compress=false,
+)
+
+surface_area = π * (r^2 - Δr^2)/4
+
+function test_mapped(num_quad_points_per_dim::Int)
+    
+    canonical_qrule = Quadrature.tensor_product_rule(
+        ntuple(i->num_quad_points_per_dim, manifold_dim), Quadrature.gauss_legendre
+    )
+    dΩ = Mantis.Quadrature.StandardQuadrature(canonical_qrule, Geometry.get_num_elements(mapped_geometry))
+
+    # Setup the form spaces, evaluate and check the results
+    ξ = Points.CartesianPoints(ntuple(i->range(0.0, rand(), num_points_per_dim), manifold_dim))
+    for form_rank in 0:manifold_dim
+        if form_rank ∉ Set([0, manifold_dim])
+            @test_throws ArgumentError Forms.ConstantFormSpace(form_rank, mapped_geometry, "c")
+        else
+            form_space = Forms.ConstantFormSpace(form_rank, mapped_geometry, "a")
+            α = Mantis.Forms.FormField(form_space, "α")
+            α.coefficients .= 1.0
+            
+            # Check number of basis functions
+            @test Forms.get_num_basis(form_space) == 1
+
+            # Check number of basis functions for each element
+            for element_id in 1:Forms.get_num_elements(form_space)
+                @test Forms.get_num_basis(form_space, element_id) == 1
+            end
+
+            # Check max local dimension
+            @test Forms.get_max_local_dim(form_space) == 1
+
+            # Check estimated nnz per element
+            @test Forms.get_estimated_nnz_per_elem(form_space) == 1
+
+            # Check evaluate
+            for element_id in 1:Forms.get_num_elements(form_space)
+                eval, inds = Forms.evaluate(form_space, element_id, ξ)
+                if form_rank == 0
+                    @test eval == [reshape([1.0 for _ in 1:Points.get_num_points(ξ)], :, 1)]
+                    @test inds == [[1]]
+                elseif form_rank == manifold_dim
+                    _, sqrt_g = Geometry.metric(mapped_geometry, element_id, ξ)
+                    @test isapprox(eval[1], reshape(sqrt_g, :, 1), atol=1e-12)
+                    @test inds == [[1]]
+                end
+            end
+
+            # Check derivative
+            if form_rank == 0
+                d_form_space = d(form_space)
+                @test Forms.get_num_basis(d_form_space) == 1
+                for element_id in 1:Forms.get_num_elements(form_space)
+                    d_eval, d_inds = Forms.evaluate(d_form_space, element_id, ξ)
+                    for i in 1:manifold_dim
+                        @test d_eval[i] == reshape([0.0 for _ in 1:Points.get_num_points(ξ)], :, 1)
+                    end
+                    @test d_inds == [[1]]
+                end
+            end
+
+            # Check integral
+            if form_rank == 0
+                integral = ∫(★(α), dΩ)
+            else
+                integral = ∫(α, dΩ)
+            end
+            integral_Eval = 0.0
+            for element_id in 1:Forms.get_num_elements(form_space)
+                integral_Eval += sum(Forms.evaluate(integral, element_id)[1])
+            end
+            @test isapprox(integral_Eval, surface_area, atol=1e-12)
+        end
+
+    end
+end
+
+@testset "Mapped Geometry" begin
+    for num_quad_points_per_dim in 2:5
+        test_mapped(num_quad_points_per_dim)
+    end
+end
 
 
 end

--- a/test/Forms/ConstantFormSpaceTests.jl
+++ b/test/Forms/ConstantFormSpaceTests.jl
@@ -27,16 +27,16 @@ function test_cartesian(manifold_dim::Int, num_quad_points_per_dim::Int)
     dΩ = Mantis.Quadrature.StandardQuadrature(canonical_qrule, Geometry.get_num_elements(geom))
 
     # Setup the form spaces, evaluate and check the results
-    ξ = Points.CartesianPoints(ntuple(i->range(0.0, rand(), num_points_per_dim), manifold_dim))
+    ξ = Points.CartesianPoints(ntuple(i->range(0.0, 1.0, num_points_per_dim), manifold_dim))
     for form_rank in 0:manifold_dim
         if form_rank ∉ Set([0, manifold_dim])
             @test_throws ArgumentError Forms.ConstantFormSpace(form_rank, geom, "c")
         else
             form_space = Forms.ConstantFormSpace(form_rank, geom, "a")
-
+        
             # Check number of basis functions
             @test Forms.get_num_basis(form_space) == 1
-
+            
             # Check number of basis functions for each element
             for element_id in 1:Forms.get_num_elements(form_space)
                 @test Forms.get_num_basis(form_space, element_id) == 1
@@ -107,31 +107,19 @@ const r = 1.0
 const Δr = 0.1
 
 function mapping(x::AbstractVector)
-    return [x[1].*cos(x[2]*π/2), x[1].*sin(x[2]*π/2)]
+    return [x[1].*cos(x[2]*π/2), x[1].*sin(x[2]*π/2), 1.0]
 end
 function dmapping(x::AbstractVector)
     return [cos(x[2]*π/2) -x[1]*sin(x[2]*π/2)*π/2;
-            sin(x[2]*π/2) x[1]*cos(x[2]*π/2)*π/2]
+            sin(x[2]*π/2) x[1]*cos(x[2]*π/2)*π/2;
+            0.0 0.0]
 end
-dimension = (2, 2)
+dimension = (2, 3)
 curved_mapping = Geometry.Mapping(dimension, mapping, dmapping)
 
 breakpoints = (LinRange(Δr, r, 4), LinRange(0.0, 1.0, 4))
 geom = Geometry.CartesianGeometry(breakpoints)
 mapped_geometry = Geometry.MappedGeometry(geom, curved_mapping)
-
-reference_directory_tree = ["test", "data", "reference", "Plot"]
-output_directory_tree = ["test", "data", "output", "Plot"]
-output_filename = "mytemp_hemisphere.vtu"
-output_file = Mantis.GeneralHelpers.export_path(output_directory_tree, output_filename)
-Plot.plot(
-    mapped_geometry;
-    vtk_filename=output_file[1:(end - 4)],
-    n_subcells=1,
-    degree=4,
-    ascii=false,
-    compress=false,
-)
 
 surface_area = π * (r^2 - Δr^2)/4
 
@@ -143,14 +131,12 @@ function test_mapped(num_quad_points_per_dim::Int)
     dΩ = Mantis.Quadrature.StandardQuadrature(canonical_qrule, Geometry.get_num_elements(mapped_geometry))
 
     # Setup the form spaces, evaluate and check the results
-    ξ = Points.CartesianPoints(ntuple(i->range(0.0, rand(), num_points_per_dim), manifold_dim))
+    ξ = Points.CartesianPoints(ntuple(i->range(0.0, 1.0, num_points_per_dim), manifold_dim))
     for form_rank in 0:manifold_dim
         if form_rank ∉ Set([0, manifold_dim])
             @test_throws ArgumentError Forms.ConstantFormSpace(form_rank, mapped_geometry, "c")
         else
             form_space = Forms.ConstantFormSpace(form_rank, mapped_geometry, "a")
-            α = Mantis.Forms.FormField(form_space, "α")
-            α.coefficients .= 1.0
             
             # Check number of basis functions
             @test Forms.get_num_basis(form_space) == 1
@@ -194,9 +180,9 @@ function test_mapped(num_quad_points_per_dim::Int)
 
             # Check integral
             if form_rank == 0
-                integral = ∫(★(α), dΩ)
+                integral = ∫(★(form_space), dΩ)
             else
-                integral = ∫(α, dΩ)
+                integral = ∫(form_space, dΩ)
             end
             integral_Eval = 0.0
             for element_id in 1:Forms.get_num_elements(form_space)

--- a/test/Forms/runtests.jl
+++ b/test/Forms/runtests.jl
@@ -10,5 +10,8 @@ end
 @testset "FormOperators" verbose = true begin
     include("FormOperators/runtests.jl")
 end
+@testset "ConstantFormSpaces" verbose = true begin
+    include("ConstantFormSpaceTests.jl")
+end
 
 end


### PR DESCRIPTION
Add constant form 0- and n-form spaces that can be used as Lagrange multipliers, and assembled in the same manner as standard form spaces.