### PR TITLE
fix: correct export path

### DIFF
--- a/examples/src/Biharmonic.jl
+++ b/examples/src/Biharmonic.jl
@@ -393,13 +393,11 @@ dΩ_2D_analysis = Quadrature.StandardQuadrature(
 println("L2 error: ", Analysis.L2_norm(ϕ⁰_2D - ϕ⁰_exact_2D, dΩ_2D_analysis))
 
 # We can also write the output to a VTK file that can be visualized using a VTK viewer, such
-# as Paraview. Note that we export both the computed and exact solutions.
-output_filename_2D = "Biharmonic-0form-Homogeneous-Cartesian-$(length(p_2D))D"
-Mantis.Plot.export_form_fields_to_vtk(
-    (ϕ⁰_2D, ϕ⁰_exact_2D),
-    output_filename_2D;
-    output_directory_tree=["examples", "data", "output", "Biharmonic"],
-)
+# as Paraview. We can do this by running:
+# ```julia
+# output_filename_2D = "Biharmonic-0form-Homogeneous-Cartesian-$(length(p_2D))D"
+# Mantis.Plot.export_form_fields_to_vtk((ϕ⁰_2D, ϕ⁰_exact_2D), output_filename_2D)
+# ```
 
 # #### The 2D case on a more complicated geometry.
 
@@ -443,13 +441,6 @@ dΩ_2D_analysis_curv = Quadrature.StandardQuadrature(
 )
 
 println("L2 error: ", Analysis.L2_norm(ϕ⁰_2D_curv - ϕ⁰_exact_2D_curv, dΩ_2D_analysis_curv))
-
-output_filename_2D_curv = "Biharmonic-0form-Homogeneous-Curvilinear-$(length(p_2D))D"
-Mantis.Plot.export_form_fields_to_vtk(
-    (ϕ⁰_2D_curv, ϕ⁰_exact_2D_curv),
-    output_filename_2D_curv;
-    output_directory_tree=["examples", "data", "output", "Biharmonic"],
-)
 
 # #### Convergence studies for the 2D case.
 

--- a/examples/src/HodgeLaplacian.jl
+++ b/examples/src/HodgeLaplacian.jl
@@ -95,21 +95,12 @@ A, b = Assemblers.assemble(weak_form, bc)
 sol = vec(A \ b)
 ϕ⁰ = Forms.build_form_field(Λ⁰, sol)
 
-# We can now plot the solution using the `plot` function. This will write the output to a
-# VTK file that can be visualized using a VTK viewer, such as Paraview.
-
-data_folder = joinpath(dirname(dirname(pathof(Mantis))), "examples", "data")
-output_data_folder = joinpath(data_folder, "output", "HodgeLaplacian")
-output_filename = "HodgeLaplacian-0form-Dirichlet-2D.vtu"
-output_file = joinpath(output_data_folder, output_filename)
-Plot.plot(
-    ϕ⁰;
-    vtk_filename=output_file,
-    n_subcells=1,
-    degree=maximum(p),
-    ascii=false,
-    compress=false,
-)
+# We can also write the output to a VTK file that can be visualized using a VTK viewer, such
+# as Paraview. We can do this by running:
+# ```julia
+# output_filename = "HodgeLaplacian-0form-Dirichlet-2D.vtu"
+# Mantis.Plot.export_form_fields_to_vtk((ϕ⁰,), output_filename)
+# ```
 
 # ## Extensions
 
@@ -164,13 +155,3 @@ A_3D, b_3D = Assemblers.assemble(weak_form_3D, bc_3D)
 sol_3D = vec(A_3D \ b_3D)
 ϕ⁰_3D = Forms.build_form_field(Λ⁰_3D, sol_3D)
 
-output_filename_3D = "HodgeLaplacian-0form-Dirichlet-3D.vtu"
-output_file_3D = joinpath(output_data_folder, output_filename_3D)
-Plot.plot(
-    ϕ⁰_3D;
-    vtk_filename=output_file_3D,
-    n_subcells=1,
-    degree=maximum(p_3D),
-    ascii=false,
-    compress=false,
-)

--- a/src/GeneralHelpers/GeneralHelpers.jl
+++ b/src/GeneralHelpers/GeneralHelpers.jl
@@ -128,22 +128,21 @@ end
 # Export path helper function
 ####################################################
 """
-    export_path(output_directory_tree::Vector{String}, filename::String)
+    export_path(output_directory_tree::Vector, filename)
 
 Create a directory (if needed) and return the path to the output file.
 
 # Arguments
-- `output_directory_tree::Vector{String}`: A vector of strings representing the directory tree.
-- `filename::String`: The name of the output file.
+- `output_directory_tree::Vector`: A vector representing the directory tree.
+- `filename`: The name of the output file.
 
 # Example
-```julia
-output_file = export_path(["examples", "data", "output"], "output.vtk") # "examples/data/output/output.vtk"
+```@example
+output_file = export_path(["examples", "data", "output"], "output.vtu")
 ```
 """
-function export_path(output_directory_tree::Vector{String}, filename::String)
-	project_directory = dirname(Pkg.project().path)
-    output_directory = joinpath(project_directory, output_directory_tree...)
+function export_path(output_directory_tree::Vector, filename)
+    output_directory = joinpath(output_directory_tree...)
     output_file = joinpath(output_directory, filename)
 
     if !isdir(output_directory)

--- a/src/GeneralHelpers/GeneralHelpers.jl
+++ b/src/GeneralHelpers/GeneralHelpers.jl
@@ -2,7 +2,7 @@ module GeneralHelpers
 
 export integer_sums, get_derivative_idx, export_path
 
-import Combinatorics, Pkg
+import Combinatorics
 
 ####################################################
 # Integer sums and derivatives helper functions

--- a/src/GeneralHelpers/GeneralHelpers.jl
+++ b/src/GeneralHelpers/GeneralHelpers.jl
@@ -2,7 +2,7 @@ module GeneralHelpers
 
 export integer_sums, get_derivative_idx, export_path
 
-import Combinatorics
+import Combinatorics, Pkg
 
 ####################################################
 # Integer sums and derivatives helper functions
@@ -142,8 +142,8 @@ output_file = export_path(["examples", "data", "output"], "output.vtk") # "examp
 ```
 """
 function export_path(output_directory_tree::Vector{String}, filename::String)
-    Mantis_folder = dirname(dirname(pathof(parentmodule(GeneralHelpers))))
-    output_directory = joinpath(Mantis_folder, output_directory_tree...)
+	project_directory = dirname(Pkg.project().path)
+    output_directory = joinpath(project_directory, output_directory_tree...)
     output_file = joinpath(output_directory, filename)
 
     if !isdir(output_directory)

--- a/src/Plot/PlotHelpers.jl
+++ b/src/Plot/PlotHelpers.jl
@@ -1,5 +1,11 @@
 """
-    visualize_geometry(geo::Geometry.AbstractGeometry, filename::String; n_subcells::Int = 1, degree::Int = 4, output_directory_tree::Vector{String} = ["examples", "data", "output"])
+    export_geometry_to_vtk(
+		geo::Geometry.AbstractGeometry,
+		filename::String;
+		n_subcells::Int=1,
+		degree::Int=4,
+		output_directory_tree=[pwd()],
+	)
 
 Export the geometry to a VTK file.
 
@@ -8,14 +14,15 @@ Export the geometry to a VTK file.
 - `filename::String`: The name of the output file.
 - `n_subcells::Int`: The number of subcells to be used in the visualization.
 - `degree::Int`: The degree of the basis functions used in the visualization.
-- `output_directory_tree::Vector{String}`: A vector of strings representing the directory tree.
+- `output_directory_tree`: A vector of strings representing the directory tree. Defaults to
+	the current working directory.
 """
 function export_geometry_to_vtk(
     geo::Geometry.AbstractGeometry,
     filename::String;
     n_subcells::Int=1,
     degree::Int=4,
-    output_directory_tree::Vector{String}=["examples", "data", "output"],
+    output_directory_tree=[pwd()],
 )
     output_file = export_path(output_directory_tree, filename)
     plot(
@@ -31,7 +38,14 @@ function export_geometry_to_vtk(
 end
 
 """
-    export_form_fields_to_vtk(form_sols::Vector{Forms.AbstractForm}, var_names::Vector{String}, filename::String; n_subcells::Int = 1, degree::Int = 4, output_directory_tree::Vector{String} = ["examples", "data", "output"])
+    export_form_fields_to_vtk(
+		form_sols,
+		var_names,
+		filename;
+		n_subcells::Int=1,
+		degree::Int=4,
+		output_directory_tree=[pwd()],
+	)
 
 Export the form solutions to VTK files.
 
@@ -41,7 +55,8 @@ Export the form solutions to VTK files.
 - `filename::String`: The name of the output file.
 - `n_subcells::Int`: The number of subcells to be used in the visualization.
 - `degree::Int`: The degree of the basis functions used in the visualization.
-- `output_directory_tree::Vector{String}`: A vector of strings representing the directory tree.
+- `output_directory_tree`: A vector of strings representing the directory tree. Defaults to
+	the current working directory.
 """
 function export_form_fields_to_vtk(
     form_sols,
@@ -49,7 +64,7 @@ function export_form_fields_to_vtk(
     filename;
     n_subcells::Int=1,
     degree::Int=4,
-    output_directory_tree::Vector{String}=["examples", "data", "output"],
+    output_directory_tree=[pwd()],
 )
     for (form_sol, var_name) in zip(form_sols, var_names)
         println("Writing form '$var_name' to file ...")
@@ -68,7 +83,9 @@ function export_form_fields_to_vtk(
 end
 
 """
-    export_form_fields_to_vtk(form_sols::Vector{Forms.AbstractForm}, var_names::Vector{String}, filename::String; n_subcells::Int = 1, degree::Int = 4, output_directory_tree::Vector{String} = ["examples", "data", "output"])
+    export_form_fields_to_vtk(
+		form_sols, filename; n_subcells::Int=1, degree::Int=4, output_directory_tree=[pwd()]
+	)
 
 Export the form solutions to VTK files.
 
@@ -77,14 +94,10 @@ Export the form solutions to VTK files.
 - `filename::String`: The name of the output file.
 - `n_subcells::Int`: The number of subcells to be used in the visualization.
 - `degree::Int`: The degree of the basis functions used in the visualization.
-- `output_directory_tree::Vector{String}`: A vector of strings representing the directory tree.
+	output_directory_tree=[pwd()],
 """
 function export_form_fields_to_vtk(
-    form_sols,
-    filename;
-    n_subcells::Int=1,
-    degree::Int=4,
-    output_directory_tree::Vector{String}=["examples", "data", "output"],
+    form_sols, filename; n_subcells::Int=1, degree::Int=4, output_directory_tree=[pwd()]
 )
     for form in form_sols
         label = Forms.get_label(form)

--- a/test/Assemblers/AssemblerTestsHelpers.jl
+++ b/test/Assemblers/AssemblerTestsHelpers.jl
@@ -4,8 +4,12 @@ rtol = 10 * eps(Float64)
 atol = 1e-14
 
 # Compute base directories for data input and output
-const reference_directory_tree = ["test", "data", "reference", "Assemblers"]
-const output_directory_tree = ["test", "data", "output", "Assemblers"]
+const reference_directory_tree = [
+    dirname(dirname(pathof(Mantis))), "test", "data", "reference", "Assemblers"
+]
+const output_directory_tree = [
+    dirname(dirname(pathof(Mantis))), "test", "data", "output", "Assemblers"
+]
 
 function write_data(sub_dir::String, file_name::String, data)
     # Write the solution to an output file

--- a/test/GeneralHelpers/GeneralHelpers.jl
+++ b/test/GeneralHelpers/GeneralHelpers.jl
@@ -1,4 +1,4 @@
-module AbstractPointsTests
+module GeneralHelpersTests
 
 using Mantis
 using Test

--- a/test/GeneralHelpers/GeneralHelpers.jl
+++ b/test/GeneralHelpers/GeneralHelpers.jl
@@ -1,0 +1,21 @@
+module AbstractPointsTests
+
+using Mantis
+using Test
+
+@testset "export_path" begin
+    new_directory = [pwd(), "new", "directory"]
+    new_file = "new_file.vtu"
+    another_file = "another_file.vtu"
+    output_file = Mantis.GeneralHelpers.export_path(new_directory, new_file)
+    # Create a new directory
+    @test isdir(joinpath(new_directory...))
+    @test joinpath(new_directory..., new_file) == output_file
+    # Re-use a directory
+    output_file = Mantis.GeneralHelpers.export_path(new_directory, another_file)
+    @test joinpath(new_directory..., another_file) == output_file
+    # Remove created directory
+	rm(joinpath(new_directory[1:end-1]...); recursive=true)
+end
+
+end

--- a/test/GeneralHelpers/runtests.jl
+++ b/test/GeneralHelpers/runtests.jl
@@ -1,0 +1,9 @@
+module GeneralHelpersTests
+
+using Test
+
+@testset verbose = true "GeneralHelpers" begin
+    include("GeneralHelpers.jl")
+end
+
+end

--- a/test/Geometry/GeometryTestsHelpers.jl
+++ b/test/Geometry/GeometryTestsHelpers.jl
@@ -5,8 +5,12 @@ rtol = 10 * eps(Float64)
 atol = 1e-14
 
 # Compute base directories for data input and output
-reference_directory_tree = ["test", "data", "reference", "Geometry"]
-output_directory_tree = ["test", "data", "output", "Geometry"]
+reference_directory_tree = [
+    dirname(dirname(pathof(Mantis))), "test", "data", "reference", "Geometry"
+]
+output_directory_tree = [
+    dirname(dirname(pathof(Mantis))), "test", "data", "output", "Geometry"
+]
 
 function get_point_cell_data(directory_tree::Vector{String}, file_name::String)
     # Read the cell data from the reference file

--- a/test/Plot/FormPlotTests.jl
+++ b/test/Plot/FormPlotTests.jl
@@ -27,7 +27,7 @@ num_basis = Mantis.Forms.get_num_basis(zero_form_space)
 β².coefficients .= rand(length(β².coefficients))
 
 # Compute base directories for data input and output
-output_directory_tree = ["test","data","output","Plot"]
+output_directory_tree = [dirname(dirname(pathof(Mantis))), "test","data","output","Plot"]
 
 out_deg = maximum([1, maximum(degrees)])
 

--- a/test/Plot/GeometryPlotTests.jl
+++ b/test/Plot/GeometryPlotTests.jl
@@ -8,8 +8,8 @@ using Printf
 using Test
 
 # Compute directory trees for data input and output
-reference_directory_tree = ["test", "data", "reference", "Plot"]
-output_directory_tree = ["test", "data", "output", "Plot"]
+reference_directory_tree = [dirname(dirname(pathof(Mantis))), "test", "data", "reference", "Plot"]
+output_directory_tree = [dirname(dirname(pathof(Mantis))), "test","data","output","Plot"]
 
 # Test Plotting of 3D Geometry (torus) -------------------------------------------
 deg = 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,5 +9,6 @@ using Test
 @testset verbose=true "Forms" begin include("Forms/runtests.jl") end
 @testset verbose=true "Assembly" begin include("Assemblers/runtests.jl") end
 @testset verbose=true "Plot" begin include("Plot/runtests.jl") end
+@testset verbose=true "GeneralHelpers" begin include("GeneralHelpers/runtests.jl") end
 
 end; nothing


### PR DESCRIPTION
The `GeneralHelpers.export_path` method was incorrectly implemented. The use of
```julia
dirname(dirname(pathof(parentmodule(GeneralHelpers))))
```
does not give the desired output if `Mantis` is not ran from the source code.