### PR TITLE
refactor: introduce an extension to GLMakie and update the Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,13 +11,11 @@ DisplayAs = "0b91fe84-8a4c-11e9-3e1d-67c38462b6d6"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
-GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
 MeshCore = "43a99bba-f459-4d0e-8139-f3df11d847d4"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -26,17 +24,23 @@ ReadVTK = "dc215faf-f008-4882-a9f7-a79a826fadc3"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Subscripts = "2b7f82d5-8785-4f63-971e-f18ddbeb808e"
 ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
+[weakdeps]
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+
+[extensions]
+GLMakieExt = "GLMakie"
+
 [compat]
 DisplayAs = "0.1.6"
+GLMakie = "0.13.8"
+Graphs = "1.14.0"
 LaTeXStrings = "1.4.0"
-Makie = "0.24.8"
 MeshCore = "1.3.5"
 PolynomialBases = "0.4.21"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/ext/GLMakieExt.jl
+++ b/ext/GLMakieExt.jl
@@ -1,0 +1,37 @@
+module GLMakieExt
+
+using Mantis
+using GLMakie
+
+function Mantis.Plot.plot_solution(
+    fields::T,
+    num_plot_points_per_element=25;
+    title="Solution",
+    xlabel="x",
+    ylabel=L"\phi(x)",
+) where {n_fields, T <: NTuple{n_fields, Forms.AbstractFormField{1}}}
+    fig = Figure()
+    ax = Axis(fig[1, 1]; title=title, xlabel=xlabel, ylabel=ylabel)
+
+    geometry = Forms.get_geometry(fields[1])
+
+    n_elements = Geometry.get_num_elements(geometry)
+    xi = Points.CartesianPoints((LinRange(0.0, 1.0, num_plot_points_per_element),))
+
+    colors = [:blue, :green, :red, :purple, :orange, :black, :pink, :brown]
+    for field_id in eachindex(fields)
+        field = fields[field_id]
+        color_i = colors[field_id]
+        for element_idx in 1:n_elements
+            form_eval, _ = Forms.evaluate(field, element_idx, xi)
+            x = Geometry.evaluate(geometry, element_idx, xi)
+
+            lines!(ax, x[:], form_eval[1]; color=color_i, label=field.label)
+        end
+    end
+    fig[1, 2] = Legend(fig, ax; marge=true, unique=true)
+
+    return fig
+end
+
+end

--- a/src/Forms/Forms.jl
+++ b/src/Forms/Forms.jl
@@ -14,7 +14,6 @@ import Combinatorics
 import LaTeXStrings
 import LinearAlgebra
 import SparseArrays
-import Subscripts
 
 ############################################################################################
 #                                         Exports                                          #

--- a/src/Plot/Plot.jl
+++ b/src/Plot/Plot.jl
@@ -7,7 +7,6 @@ The exported names are:
 module Plot
 
 import WriteVTK
-using GLMakie
 
 using ..GeneralHelpers
 using ..Points

--- a/src/Plot/PlotHelpers.jl
+++ b/src/Plot/PlotHelpers.jl
@@ -118,33 +118,5 @@ function export_form_fields_to_vtk(
     return nothing
 end
 
-function plot_solution(
-    fields::T,
-    num_plot_points_per_element=25;
-    title="Solution",
-    xlabel="x",
-    ylabel=L"\phi(x)",
-) where {n_fields, T <: NTuple{n_fields, Forms.AbstractFormField{1}}}
-    fig = Figure()
-    ax = Axis(fig[1, 1]; title=title, xlabel=xlabel, ylabel=ylabel)
-
-    geometry = Forms.get_geometry(fields[1])
-
-    n_elements = Geometry.get_num_elements(geometry)
-    xi = Points.CartesianPoints((LinRange(0.0, 1.0, num_plot_points_per_element),))
-
-    colors = [:blue, :green, :red, :purple, :orange, :black, :pink, :brown]
-    for field_id in eachindex(fields)
-        field = fields[field_id]
-        color_i = colors[field_id]
-        for element_idx in 1:n_elements
-            form_eval, _ = Forms.evaluate(field, element_idx, xi)
-            x = Geometry.evaluate(geometry, element_idx, xi)
-
-            lines!(ax, x[:], form_eval[1]; color=color_i, label=field.label)
-        end
-    end
-    fig[1, 2] = Legend(fig, ax; marge=true, unique=true)
-
-    return fig
-end
+# Only usable if GLMakie is also loaded.
+function plot_solution end


### PR DESCRIPTION
This pull request turns GLMakie into a 'weakdep'. This means that people can do `using Mantis` without requiring `GLMakie`. This has two main advantages:
1. No compilation of GLMakie needed if you don't use it.
2. Mantis can more easily be used on systems without screens (such as clusters).

We do have to be aware of our workflow. We have often used `julia --project` to directly use the Mantis environment. However, we should create a separate environment to which we add or dev Mantis. In this environment, you can add whatever package you want to use. Only if a package becomes a dependency of Mantis should it be put in the Mantis project.toml.

I also updated the Julia compatibility to v1.10 and higher, which is what we have been testing for (1.10 is the current LTS version). I also removed a dependency that was not used. We should update the project.toml a bit more, but I will do that in a separate pull-request.