### PR TITLE
chore: Change license from MIT to EUPL

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,4 +36,4 @@ keywords:
   - Mimetic Discretizations
   - Adaptive Mesh Refinement
 doi: 10.5281/zenodo.17495870
-license: MIT
+license: EUPL


### PR DESCRIPTION
Zenodo needs to also have EUPL as license, so we need to update the citation.cff file.