### PR TITLE
feat: add `CartesianPoints` iteration order

### DIFF
--- a/src/Points/CartesianPoints.jl
+++ b/src/Points/CartesianPoints.jl
@@ -11,24 +11,73 @@ Conceptually, this structure combines the functionalities of `CartesianIndices` 
   indexing.
 - `lin_num_points::LI`: The `LinearIndices` used to convert from cartesian to linear
   indexing.
+- `iteration_order::NTuple{manifold_dim, Int}`: Used to determine the iteration order over
+	`cart_num_points`. If the `dim`-th entry has value `i`, then dimension `dim` will be the
+	`i`-th fastest changing index.
+- `permuted_cart_num_points::CI`: A permuted version of `cart_num_points` as given by
+	`iteration_order`.
+
+# Example
+```julia
+julia> points = Points.CartesianPoints(([1,2], [1,2,3]), (1,2));
+
+julia> for point in points
+           display(point)
+       end
+(1, 1)
+(2, 1)
+(1, 2)
+(2, 2)
+(1, 3)
+(2, 3)
+
+julia> points = Points.CartesianPoints(([1,2], [1,2,3]), (2,1));
+
+julia> for point in points
+           display(point)
+       end
+(1, 1)
+(1, 2)
+(1, 3)
+(2, 1)
+(2, 2)
+(2, 3)
+```
 """
 struct CartesianPoints{manifold_dim, T, CI, LI} <: AbstractPoints{manifold_dim}
     constituent_points::NTuple{manifold_dim, T}
     cart_num_points::CI
     lin_num_points::LI
+    iteration_order::NTuple{manifold_dim, Int}
+    permuted_cart_num_points::CI
 
     function CartesianPoints(
-        constituent_points::NTuple{manifold_dim, T}
+        constituent_points::NTuple{manifold_dim, T},
+        iteration_order::NTuple{manifold_dim, Int},
     ) where {manifold_dim, T <: AbstractVector}
+        constituent_num_points = map(length, constituent_points)
         cart_num_points = CartesianIndices(
-            ntuple(dim -> length(constituent_points[dim]), manifold_dim)
+            ntuple(dim -> constituent_num_points[dim], manifold_dim)
         )
         lin_num_points = LinearIndices(cart_num_points)
+        permuted_cart_num_points = CartesianIndices(
+            ntuple(dim -> constituent_num_points[iteration_order[dim]], manifold_dim)
+        )
 
         return new{manifold_dim, T, typeof(cart_num_points), typeof(lin_num_points)}(
-            constituent_points, cart_num_points, lin_num_points
+            constituent_points,
+            cart_num_points,
+            lin_num_points,
+            iteration_order,
+            permuted_cart_num_points,
         )
     end
+end
+
+function CartesianPoints(constituent_points::NTuple{manifold_dim}) where {manifold_dim}
+    iteration_order = ntuple(k -> k, manifold_dim)
+
+    return CartesianPoints(constituent_points, iteration_order)
 end
 
 Base.eltype(::CartesianPoints{manifold_dim, T}) where {manifold_dim, T} = eltype(T)
@@ -49,6 +98,21 @@ Returns the `LinearIndices` used to convert from cartesian to linear indexing.
 get_lin_num_points(points::CartesianPoints) = points.lin_num_points
 
 """
+	get_iteration_order(points::CartesianPoints)
+
+Returns the `iteration_order` order used to index `points`.
+"""
+get_iteration_order(points::CartesianPoints) = points.iteration_order
+
+"""
+	get_permuted_cart_num_points(points::CartesianPoints)
+
+Returns the permuted `cart_num_points` used to index `points`, as given by
+`iteration_order`.
+"""
+get_permuted_cart_num_points(points::CartesianPoints) = points.permuted_cart_num_points
+
+"""
     get_constituent_num_points(
       points::CartesianPoints{manifold_dim}
     ) where {manifold_dim}
@@ -61,8 +125,12 @@ function get_constituent_num_points(
     return size(get_cart_num_points(points))
 end
 
-function Base.getindex(points::CartesianPoints, i::Int)
-    return getindex(points, get_cart_num_points(points)[i])
+function Base.getindex(points::CartesianPoints{manifold_dim}, i::Int) where {manifold_dim}
+    unordered_point = get_permuted_cart_num_points(points)[i]
+    iteration_order = get_iteration_order(points)
+    ordered_point = ntuple(dim -> unordered_point[iteration_order[dim]], manifold_dim)
+
+    return getindex(points, ordered_point)
 end
 
 function Base.getindex(

--- a/src/Points/CartesianPoints.jl
+++ b/src/Points/CartesianPoints.jl
@@ -58,7 +58,7 @@ Returns the number of constituent points per manifold dimension.
 function get_constituent_num_points(
     points::CartesianPoints{manifold_dim}
 ) where {manifold_dim}
-    return Tuple(maximum(get_cart_num_points(points)))
+    return size(get_cart_num_points(points))
 end
 
 function Base.getindex(points::CartesianPoints, i::Int)

--- a/test/Points/CartesianPoints.jl
+++ b/test/Points/CartesianPoints.jl
@@ -25,4 +25,88 @@ for i in 1:3
     end
 end
 
+# Iteration order
+
+@test_throws MethodError Points.CartesianPoints((1:2, 1:2), (1, 2, 3))
+
+points = (1:2, 1:2, 1:2)
+order_1 = (1, 2, 3)
+order_2 = (1, 3, 2)
+order_3 = (2, 1, 3)
+order_4 = (2, 3, 1)
+order_5 = (3, 1, 2)
+order_6 = (3, 2, 1)
+points_0 = Points.CartesianPoints(points)
+points_1 = Points.CartesianPoints(points, order_1)
+points_2 = Points.CartesianPoints(points, order_2)
+points_3 = Points.CartesianPoints(points, order_3)
+points_4 = Points.CartesianPoints(points, order_4)
+points_5 = Points.CartesianPoints(points, order_5)
+points_6 = Points.CartesianPoints(points, order_6)
+num_points = Points.get_num_points(points_0)
+
+for p in 1:num_points
+    @test points_0[p] == points_1[p]
+end
+
+# points_1
+@test points_1[1] == (1, 1, 1)
+@test points_1[2] == (2, 1, 1)
+@test points_1[3] == (1, 2, 1)
+@test points_1[4] == (2, 2, 1)
+@test points_1[5] == (1, 1, 2)
+@test points_1[6] == (2, 1, 2)
+@test points_1[7] == (1, 2, 2)
+@test points_1[8] == (2, 2, 2)
+
+# points_2
+@test points_2[1] == (1, 1, 1)
+@test points_2[2] == (2, 1, 1)
+@test points_2[3] == (1, 1, 2)
+@test points_2[4] == (2, 1, 2)
+@test points_2[5] == (1, 2, 1)
+@test points_2[6] == (2, 2, 1)
+@test points_2[7] == (1, 2, 2)
+@test points_2[8] == (2, 2, 2)
+
+# points_3
+@test points_3[1] == (1, 1, 1)
+@test points_3[2] == (1, 2, 1)
+@test points_3[3] == (2, 1, 1)
+@test points_3[4] == (2, 2, 1)
+@test points_3[5] == (1, 1, 2)
+@test points_3[6] == (1, 2, 2)
+@test points_3[7] == (2, 1, 2)
+@test points_3[8] == (2, 2, 2)
+
+# points_4
+@test points_4[1] == (1, 1, 1)
+@test points_4[2] == (1, 1, 2)
+@test points_4[3] == (2, 1, 1)
+@test points_4[4] == (2, 1, 2)
+@test points_4[5] == (1, 2, 1)
+@test points_4[6] == (1, 2, 2)
+@test points_4[7] == (2, 2, 1)
+@test points_4[8] == (2, 2, 2)
+
+# points_5
+@test points_5[1] == (1, 1, 1)
+@test points_5[2] == (1, 2, 1)
+@test points_5[3] == (1, 1, 2)
+@test points_5[4] == (1, 2, 2)
+@test points_5[5] == (2, 1, 1)
+@test points_5[6] == (2, 2, 1)
+@test points_5[7] == (2, 1, 2)
+@test points_5[8] == (2, 2, 2)
+
+# points_6
+@test points_6[1] == (1, 1, 1)
+@test points_6[2] == (1, 1, 2)
+@test points_6[3] == (1, 2, 1)
+@test points_6[4] == (1, 2, 2)
+@test points_6[5] == (2, 1, 1)
+@test points_6[6] == (2, 1, 2)
+@test points_6[7] == (2, 2, 1)
+@test points_6[8] == (2, 2, 2)
+
 end


### PR DESCRIPTION
@apalha I think this should be what you need in terms of the iteration order.

For the part of evaluation a set of lower-dimensional points on a higher-dimensional object, my idea was to have, for example in the skeleton geometry file,
```julia
function evaluate(skel_geo::G{manifold_dim}, points::CartesianPoints{manifold_dim-1}, surface_id::Int)
    extra_point = get_extra_dim_point(skel_geo, surface_id)
    manifold_dim_points = CartesianPoints(vcat(points, extra_point))
    evaluate(get_parent_geo(skel_geo), manifold_dim_points)
    ...
```