### PR TITLE
Mantis makie ext

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,19 +19,19 @@ ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [weakdeps]
-GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [extensions]
-GLMakieExt = "GLMakie"
+MakieExt = "Makie"
 
 [compat]
 Combinatorics = "1.1.0"
 FFTW = "1.10.0"
 FastGaussQuadrature = "1.0.0"
-GLMakie = "0.13"
 Graphs = "1.14.0"
 LaTeXStrings = "1.4.0"
 LinearAlgebra = "1.10"
+Makie = "0.24"
 Memoization = "0.2"
 MeshCore = "1.3.5"
 PolynomialBases = "0.4"

--- a/ext/MakieExt.jl
+++ b/ext/MakieExt.jl
@@ -1,7 +1,7 @@
-module GLMakieExt
+module MakieExt
 
 using Mantis
-using GLMakie
+using Makie
 
 function Mantis.Plot.plot_solution(
     fields::T,


### PR DESCRIPTION
Turns the GLMakie extension into a Makie extension, ensuring that it loads irrespectively of the Makie backend. We can easily do this as nothing in the extension is backend-specific.