### PR TITLE
refactor: make labeling more consistent

### DIFF
--- a/src/Assemblers/WeakFormulations/HodgeLaplace/1-form.jl
+++ b/src/Assemblers/WeakFormulations/HodgeLaplace/1-form.jl
@@ -69,7 +69,7 @@ function solve_one_form_hodge_laplacian(X⁰, X¹, f¹, dΩ, bc_type="")
     end
 
     sol = vec(A \ b)
-    δu¹ₕ, u¹ₕ = Forms.build_form_fields((X⁰, X¹), sol; labels=("δu¹ₕ", "u¹ₕ"))
+    δu¹ₕ, u¹ₕ = Forms.build_form_fields((X⁰, X¹), sol)
 
     return δu¹ₕ, u¹ₕ
 end

--- a/src/Assemblers/WeakFormulations/HodgeLaplace/n-form.jl
+++ b/src/Assemblers/WeakFormulations/HodgeLaplace/n-form.jl
@@ -60,7 +60,7 @@ function solve_volume_form_hodge_laplacian(Xⁿ⁻¹, Xⁿ, fₑ, dΩ)
     weak_form = WeakForm(lhs_expressions, rhs_expressions, weak_form_inputs)
     A, b = assemble(weak_form)
     sol = vec(A \ b)
-    u¹ₕ, ϕ²ₕ = Forms.build_form_fields((Xⁿ⁻¹, Xⁿ), sol; labels=("u¹ₕ", "ϕ²ₕ"))
+    u¹ₕ, ϕ²ₕ = Forms.build_form_fields((Xⁿ⁻¹, Xⁿ), sol)
 
     return u¹ₕ, ϕ²ₕ
 end

--- a/src/Assemblers/WeakFormulations/L2Projection/L2Projection.jl
+++ b/src/Assemblers/WeakFormulations/L2Projection/L2Projection.jl
@@ -52,7 +52,7 @@ function solve_L2_projection(Xᵏ, fₑ, dΩ)
     weak_form = WeakForm(lhs_expressions, rhs_expressions, weak_form_inputs)
     A, b = assemble(weak_form)
     sol = vec(A \ b)
-    fₕ = Forms.build_form_field(Xᵏ, sol; label="fₕ")
+    fₕ = Forms.build_form_field(Xᵏ, sol)
 
     return fₕ
 end

--- a/src/Assemblers/WeakFormulations/MaxwellEigenvalue/MaxwellEigenvalue.jl
+++ b/src/Assemblers/WeakFormulations/MaxwellEigenvalue/MaxwellEigenvalue.jl
@@ -160,9 +160,11 @@ function solve_maxwell_eig(
 
     ωₕ² = (ωₕ²[(nullspace_offset + 1):end])[1:num_eig]
     u¹ₕ = Vector{Forms.FormField{2, 1}}(undef, num_eig)
+    original_label = Forms.get_label(X¹)
+    pad = ndigits(num_eig)
     for eig_id in 1:num_eig
-        subscript_str = join(Char(0x2080 + d) for d in reverse(digits(eig_id)))
-        u¹ₕ[eig_id] = Forms.FormField(X¹, "uₕ" * subscript_str)
+        subscript_str = join(Char(0x2080 + d) for d in reverse(digits(eig_id; pad=pad)))
+        u¹ₕ[eig_id] = Forms.FormField(X¹, original_label * subscript_str)
         u¹ₕ[eig_id].coefficients[non_boundary_rows_cols] .=
             real.(eig_vecs[:, nullspace_offset + eig_id])
     end
@@ -248,7 +250,7 @@ function solve_maxwell_eig(
         end
 
         complex = Forms.update_hierarchical_de_rham_complex(complex, H⁰)
-		geo = Forms.get_geometry(complex[1])
+        geo = Forms.get_geometry(complex[1])
         dΩₐ = Quadrature.StandardQuadrature(
             Quadrature.get_canonical_quadrature_rule(dΩₐ), Geometry.get_num_elements(geo)
         )

--- a/src/Forms/FormExpressions/FormFields.jl
+++ b/src/Forms/FormExpressions/FormFields.jl
@@ -57,24 +57,27 @@ struct FormField{manifold_dim, form_rank, FS, L} <:
             form_space, coefficients, label
         )
     end
+end
 
-    """
-        FormField(form_space::FS, label::String)
+"""
+    FormField(form_space::FS, label::String)
 
-    Construct a FormField with zero coefficients.
+Construct a FormField with zero coefficients.
 
-    # Arguments
-    - `form_space::FS`: The form space.
-    - `label::String`: Label for the form field.
+# Arguments
+- `form_space::FS`: The form space.
+- `label::String`: Label for the form field.
 
-    # Returns
-    - `FormField`: A new FormField instance with zero coefficients.
-    """
-    function FormField(form_space::FS, label::AbstractString) where {FS}
-        coefficients = zeros(get_num_basis(form_space))
-
-        return FormField(form_space, coefficients, label)
+# Returns
+- `FormField`: A new FormField instance with zero coefficients.
+"""
+function FormField(form_space::FS, label::Union{AbstractString, Nothing}=nothing) where {FS}
+    coefficients = zeros(get_num_basis(form_space))
+    if isnothing(label)
+        return FormField(form_space, coefficients, Forms.get_label(form_space))
     end
+
+    return FormField(form_space, coefficients, label)
 end
 
 """

--- a/src/Forms/FormsHelpers.jl
+++ b/src/Forms/FormsHelpers.jl
@@ -5,7 +5,7 @@ function build_form_field(
     form_space::AbstractFormSpace; label::Union{String, Nothing}=nothing
 )
     if isnothing(label)
-        return FormField(form_space, form_space.label)
+        return FormField(form_space, Forms.get_label(form_space))
     end
 
     return FormField(form_space, label)

--- a/src/Plot/PlotKernel.jl
+++ b/src/Plot/PlotKernel.jl
@@ -330,7 +330,7 @@ function _plot(
         vtkversion=:latest,
     ) do vtk
         vtk.version == "2.2"
-        vtk["point_data", WriteVTK.VTKPointData()] = point_data
+        vtk[Forms.get_label(form), WriteVTK.VTKPointData()] = point_data
     end
 
     ###################################
@@ -403,9 +403,8 @@ function _plot(
             end
         end
 
-        # chop is used to remove ".vtu" from the original filename
         WriteVTK.vtk_grid(
-            chop(vtk_filename; tail=4) * "_wireframe.vtu",
+            vtk_filename * "_wireframe.vtu",
             vertices_on_edges,
             edges;
             append=false,


### PR DESCRIPTION
These are a few small changes to make exporting to vtk more consistent.

Summary of changes:
  1. Make labels from `FormSpace` be reused by default in `Assemblers`.
  2. Replace "point_data" with `label` when exporting forms to vtk.