### PR TITLE
359 bug cartesianpoints error with iteration order

### DIFF
--- a/src/Points/CartesianPoints.jl
+++ b/src/Points/CartesianPoints.jl
@@ -88,6 +88,10 @@ function CartesianPoints(
     return CartesianPoints(constituent_points...; iteration_order)
 end
 
+function CartesianPoints(constituent_points...; kwargs...)
+    return CartesianPoints(promote(map(collect, constituent_points)...)...; kwargs...)
+end
+
 Base.eltype(::CartesianPoints{manifold_dim, T}) where {manifold_dim, T} = eltype(T)
 
 """

--- a/src/Points/CartesianPoints.jl
+++ b/src/Points/CartesianPoints.jl
@@ -1,25 +1,25 @@
 """
-    CartesianPoints{manifold_dim, T, CI, LI} <: AbstractPoints{manifold_dim}
+    CartesianPoints{manifold_dim, T, CP, CI, LI} <: AbstractPoints{manifold_dim}
 
 Represents a set of points constructed from `manifold_dim` lists of uni-dimensional points.
 Conceptually, this structure combines the functionalities of `CartesianIndices` and
 `Iterators.product`.
 
 # Fields
-- `constituent_points::NTuple{manifold_dim, T}`: The set of points per manifold dimension.
+- `constituent_points::CP`: The set of points per manifold dimension.
 - `cart_num_points::CI`: The `CartesianIndices` used to convert from linear to cartesian
-  indexing.
+    indexing.
 - `lin_num_points::LI`: The `LinearIndices` used to convert from cartesian to linear
-  indexing.
+    indexing.
 - `iteration_order::NTuple{manifold_dim, Int}`: Used to determine the iteration order over
-	`cart_num_points`. If the `dim`-th entry has value `i`, then dimension `dim` will be the
-	`i`-th fastest changing index.
+    `cart_num_points`. If the `dim`-th entry has value `i`, then dimension `dim` will be the
+    `i`-th fastest changing index.
 - `permuted_cart_num_points::CI`: A permuted version of `cart_num_points` as given by
-	`iteration_order`.
+    `iteration_order`.
 
 # Example
 ```julia
-julia> points = Points.CartesianPoints(([1,2], [1,2,3]), (1,2));
+julia> points = Points.CartesianPoints([1,2], [1,2,3]; iteration_order=(1,2));
 
 julia> for point in points
            display(point)
@@ -31,7 +31,7 @@ julia> for point in points
 (1, 3)
 (2, 3)
 
-julia> points = Points.CartesianPoints(([1,2], [1,2,3]), (2,1));
+julia> points = Points.CartesianPoints([1,2], [1,2,3]; iteration_order=(2,1));
 
 julia> for point in points
            display(point)
@@ -44,13 +44,7 @@ julia> for point in points
 (2, 3)
 ```
 """
-struct CartesianPoints{
-        manifold_dim, 
-        T <: Real,
-        CP <:Tuple{Vararg{AbstractVector{T}, manifold_dim}}, 
-        CI, 
-        LI
-    } <: AbstractPoints{manifold_dim}
+struct CartesianPoints{manifold_dim, T, CP, CI, LI} <: AbstractPoints{manifold_dim}
     constituent_points::CP
     cart_num_points::CI
     lin_num_points::LI
@@ -59,9 +53,9 @@ struct CartesianPoints{
 
     function CartesianPoints(
         constituent_points::Vararg{AbstractVector{T}, manifold_dim};
-        iteration_order::NTuple{manifold_dim, Int}=ntuple(k -> k, manifold_dim)
-    ) where {manifold_dim, T<:Real}
-        constituent_num_points = map(length, constituent_points)  # this will always be a Tuple no need to convert  
+        iteration_order::NTuple{manifold_dim, Int}=ntuple(k -> k, manifold_dim),
+    ) where {manifold_dim, T <: Real}
+        constituent_num_points = map(length, constituent_points)
         cart_num_points = CartesianIndices(
             ntuple(dim -> constituent_num_points[dim], manifold_dim)
         )
@@ -71,7 +65,13 @@ struct CartesianPoints{
             ntuple(dim -> constituent_num_points[inv_iteration_order[dim]], manifold_dim)
         )
 
-        return new{manifold_dim, T, typeof(constituent_points), typeof(cart_num_points), typeof(lin_num_points)}(
+        return new{
+            manifold_dim,
+            T,
+            typeof(constituent_points),
+            typeof(cart_num_points),
+            typeof(lin_num_points),
+        }(
             constituent_points,
             cart_num_points,
             lin_num_points,
@@ -82,9 +82,9 @@ struct CartesianPoints{
 end
 
 function CartesianPoints(
-    constituent_points::NTuple{manifold_dim, T};
-    iteration_order::NTuple{manifold_dim, Int}=ntuple(k -> k, manifold_dim)
-    ) where {manifold_dim, T <: AbstractVector{<:Real}}
+    constituent_points::NTuple{manifold_dim, V};
+    iteration_order::NTuple{manifold_dim, Int}=ntuple(k -> k, manifold_dim),
+) where {manifold_dim, V <: AbstractVector{<:Real}}
     return CartesianPoints(constituent_points...; iteration_order)
 end
 

--- a/src/Points/CartesianPoints.jl
+++ b/src/Points/CartesianPoints.jl
@@ -44,28 +44,34 @@ julia> for point in points
 (2, 3)
 ```
 """
-struct CartesianPoints{manifold_dim, T, CI, LI} <: AbstractPoints{manifold_dim}
-    constituent_points::NTuple{manifold_dim, T}
+struct CartesianPoints{
+        manifold_dim, 
+        T <: Real,
+        CP <:Tuple{Vararg{AbstractVector{T}, manifold_dim}}, 
+        CI, 
+        LI
+    } <: AbstractPoints{manifold_dim}
+    constituent_points::CP
     cart_num_points::CI
     lin_num_points::LI
     iteration_order::NTuple{manifold_dim, Int}
     permuted_cart_num_points::CI
 
     function CartesianPoints(
-        constituent_points::NTuple{manifold_dim, T},
-        iteration_order::NTuple{manifold_dim, Int},
-    ) where {manifold_dim, T <: AbstractVector}
-        constituent_num_points = map(length, constituent_points)
+        constituent_points::Vararg{AbstractVector{T}, manifold_dim};
+        iteration_order::NTuple{manifold_dim, Int}=ntuple(k -> k, manifold_dim)
+    ) where {manifold_dim, T<:Real}
+        constituent_num_points = map(length, constituent_points)  # this will always be a Tuple no need to convert  
         cart_num_points = CartesianIndices(
             ntuple(dim -> constituent_num_points[dim], manifold_dim)
         )
         lin_num_points = LinearIndices(cart_num_points)
-		inv_iteration_order = invperm(iteration_order)
+        inv_iteration_order = invperm(iteration_order)
         permuted_cart_num_points = CartesianIndices(
             ntuple(dim -> constituent_num_points[inv_iteration_order[dim]], manifold_dim)
         )
 
-        return new{manifold_dim, T, typeof(cart_num_points), typeof(lin_num_points)}(
+        return new{manifold_dim, T, typeof(constituent_points), typeof(cart_num_points), typeof(lin_num_points)}(
             constituent_points,
             cart_num_points,
             lin_num_points,
@@ -75,10 +81,11 @@ struct CartesianPoints{manifold_dim, T, CI, LI} <: AbstractPoints{manifold_dim}
     end
 end
 
-function CartesianPoints(constituent_points::NTuple{manifold_dim}) where {manifold_dim}
-    iteration_order = ntuple(k -> k, manifold_dim)
-
-    return CartesianPoints(constituent_points, iteration_order)
+function CartesianPoints(
+    constituent_points::NTuple{manifold_dim, T};
+    iteration_order::NTuple{manifold_dim, Int}=ntuple(k -> k, manifold_dim)
+    ) where {manifold_dim, T <: AbstractVector{<:Real}}
+    return CartesianPoints(constituent_points...; iteration_order)
 end
 
 Base.eltype(::CartesianPoints{manifold_dim, T}) where {manifold_dim, T} = eltype(T)

--- a/src/Points/CartesianPoints.jl
+++ b/src/Points/CartesianPoints.jl
@@ -1,5 +1,5 @@
 """
-    CartesianPoints{manifold_dim, T, CP, CI, LI} <: AbstractPoints{manifold_dim}
+    CartesianPoints{manifold_dim, T, CP, CI, LI} <: AbstractPoints{manifold_dim, T}
 
 Represents a set of points constructed from `manifold_dim` lists of uni-dimensional points.
 Conceptually, this structure combines the functionalities of `CartesianIndices` and
@@ -44,7 +44,7 @@ julia> for point in points
 (2, 3)
 ```
 """
-struct CartesianPoints{manifold_dim, T, CP, CI, LI} <: AbstractPoints{manifold_dim}
+struct CartesianPoints{manifold_dim, T, CP, CI, LI} <: AbstractPoints{manifold_dim, T}
     constituent_points::CP
     cart_num_points::CI
     lin_num_points::LI
@@ -91,8 +91,6 @@ end
 function CartesianPoints(constituent_points...; kwargs...)
     return CartesianPoints(promote(map(collect, constituent_points)...)...; kwargs...)
 end
-
-Base.eltype(::CartesianPoints{manifold_dim, T}) where {manifold_dim, T} = eltype(T)
 
 """
     get_cart_num_points(points::CartesianPoints)

--- a/src/Points/CartesianPoints.jl
+++ b/src/Points/CartesianPoints.jl
@@ -60,8 +60,9 @@ struct CartesianPoints{manifold_dim, T, CI, LI} <: AbstractPoints{manifold_dim}
             ntuple(dim -> constituent_num_points[dim], manifold_dim)
         )
         lin_num_points = LinearIndices(cart_num_points)
+		inv_iteration_order = invperm(iteration_order)
         permuted_cart_num_points = CartesianIndices(
-            ntuple(dim -> constituent_num_points[iteration_order[dim]], manifold_dim)
+            ntuple(dim -> constituent_num_points[inv_iteration_order[dim]], manifold_dim)
         )
 
         return new{manifold_dim, T, typeof(cart_num_points), typeof(lin_num_points)}(

--- a/src/Points/CartesianPoints.jl
+++ b/src/Points/CartesianPoints.jl
@@ -52,10 +52,24 @@ struct CartesianPoints{manifold_dim, T, CP, CI, LI} <: AbstractPoints{manifold_d
     permuted_cart_num_points::CI
 
     function CartesianPoints(
-        constituent_points::Vararg{AbstractVector{T}, manifold_dim};
+        constituent_points::Vararg{AbstractVector, manifold_dim};
         iteration_order::NTuple{manifold_dim, Int}=ntuple(k -> k, manifold_dim),
-    ) where {manifold_dim, T <: Real}
+    ) where {manifold_dim}
+        iszero(manifold_dim) && throw(ArgumentError("Empty argument tuple."))
         constituent_num_points = map(length, constituent_points)
+        any(iszero, constituent_num_points) &&
+            throw(ArgumentError("Number of points must be non-empty."))
+        types = map(eltype, constituent_points)
+        T = promote_type(types...)
+        T <: Number || throw(ArgumentError("Points must be a subtype of `Number`."))
+        promoted_points = ntuple(manifold_dim) do k
+            if types[k] != T
+                return convert.(T, constituent_points[k])
+            end
+
+            return constituent_points[k]
+        end
+
         cart_num_points = CartesianIndices(
             ntuple(dim -> constituent_num_points[dim], manifold_dim)
         )
@@ -68,11 +82,11 @@ struct CartesianPoints{manifold_dim, T, CP, CI, LI} <: AbstractPoints{manifold_d
         return new{
             manifold_dim,
             T,
-            typeof(constituent_points),
+            typeof(promoted_points),
             typeof(cart_num_points),
             typeof(lin_num_points),
         }(
-            constituent_points,
+            promoted_points,
             cart_num_points,
             lin_num_points,
             iteration_order,
@@ -81,15 +95,8 @@ struct CartesianPoints{manifold_dim, T, CP, CI, LI} <: AbstractPoints{manifold_d
     end
 end
 
-function CartesianPoints(
-    constituent_points::NTuple{manifold_dim, V};
-    iteration_order::NTuple{manifold_dim, Int}=ntuple(k -> k, manifold_dim),
-) where {manifold_dim, V <: AbstractVector{<:Real}}
-    return CartesianPoints(constituent_points...; iteration_order)
-end
-
-function CartesianPoints(constituent_points...; kwargs...)
-    return CartesianPoints(promote(map(collect, constituent_points)...)...; kwargs...)
+function CartesianPoints(constituent_points::Tuple; kwargs...)
+    return CartesianPoints(constituent_points...; kwargs...)
 end
 
 """

--- a/src/Points/CartesianPoints.jl
+++ b/src/Points/CartesianPoints.jl
@@ -125,15 +125,11 @@ Returns the permuted `cart_num_points` used to index `points`, as given by
 get_permuted_cart_num_points(points::CartesianPoints) = points.permuted_cart_num_points
 
 """
-    get_constituent_num_points(
-      points::CartesianPoints{manifold_dim}
-    ) where {manifold_dim}
+    get_constituent_num_points(points::CartesianPoints)
 
 Returns the number of constituent points per manifold dimension.
 """
-function get_constituent_num_points(
-    points::CartesianPoints{manifold_dim}
-) where {manifold_dim}
+function get_constituent_num_points(points::CartesianPoints)
     return size(get_cart_num_points(points))
 end
 

--- a/src/Points/PointSet.jl
+++ b/src/Points/PointSet.jl
@@ -11,25 +11,31 @@ struct PointSet{manifold_dim, T, CP} <: AbstractPoints{manifold_dim, T}
     num_points::Int
 
     function PointSet(
-        constituent_points::Vararg{AbstractVector{T}, manifold_dim}
-    ) where {manifold_dim, T <: Real}
-        allequal(length, constituent_points) ||
+        constituent_points::Vararg{AbstractVector, manifold_dim}
+    ) where {manifold_dim}
+        iszero(manifold_dim) && throw(ArgumentError("Empty argument tuple."))
+        constituent_num_points = map(length, constituent_points)
+        any(iszero, constituent_num_points) &&
+            throw(ArgumentError("Number of points must be non-empty."))
+        allequal(constituent_num_points) ||
             throw(ArgumentError("Number of points in each dimension must match."))
-        num_points = length(constituent_points[1])
+        num_points = first(constituent_num_points)
+        types = map(eltype, constituent_points)
+        T = promote_type(types...)
+        T <: Number || throw(ArgumentError("Points must be a subtype of `Number`."))
+        promoted_points = ntuple(manifold_dim) do k
+            if types[k] != T
+                return convert.(T, constituent_points[k])
+            end
 
-        return new{manifold_dim, T, typeof(constituent_points)}(
-            constituent_points, num_points
-        )
+            return constituent_points[k]
+        end
+
+        return new{manifold_dim, T, typeof(promoted_points)}(promoted_points, num_points)
     end
 end
 
-function PointSet(
-    constituent_points::NTuple{manifold_dim, V}
-) where {manifold_dim, V <: AbstractVector{<:Real}}
-    return PointSet(constituent_points...)
-end
-
-PointSet(constituent_points...) = PointSet(promote(map(collect, constituent_points)...)...)
+PointSet(constituent_points::Tuple) = PointSet(constituent_points...)
 
 function PointSet(point_set::Vector{NTuple{manifold_dim, T}}) where {manifold_dim, T}
     # Split a list of n manifold_dim-dimensional points into manifold_dim lists of n points
@@ -38,17 +44,17 @@ function PointSet(point_set::Vector{NTuple{manifold_dim, T}}) where {manifold_di
         dim -> [point_set[point][dim] for point in 1:num_points], manifold_dim
     )
 
-    return PointSet(constituent_points)
+    return PointSet(constituent_points...)
 end
 
-function PointSet(point_set::Vector{Vector{T}}) where {T <: Real}
+function PointSet(point_set::Vector{Vector{T}}) where {T <: Number}
     # Split a list of n manifold_dim-dimensional points into manifold_dim lists of n points
     manifold_dim = length(first(point_set))
     constituent_points = ntuple(
         dim -> [point_set[point][dim] for point in 1:length(point_set)], manifold_dim
     )
 
-    return PointSet(constituent_points)
+    return PointSet(constituent_points...)
 end
 
 get_num_points(points::PointSet) = points.num_points

--- a/src/Points/PointSet.jl
+++ b/src/Points/PointSet.jl
@@ -1,5 +1,5 @@
 """
-    PointSet{manifold_dim, T} <: AbstractPoints{manifold_dim}
+    PointSet{manifold_dim, T} <: AbstractPoints{manifold_dim, T}
 
 Represents a set of points in `manifold_dim` dimensions.
 
@@ -50,8 +50,6 @@ function PointSet(point_set::Vector{Vector{T}}) where {T <: Real}
 
     return PointSet(constituent_points)
 end
-
-Base.eltype(::PointSet{manifold_dim, T}) where {manifold_dim, T} = eltype(T)
 
 get_num_points(points::PointSet) = points.num_points
 

--- a/src/Points/PointSet.jl
+++ b/src/Points/PointSet.jl
@@ -13,6 +13,8 @@ struct PointSet{manifold_dim, T, CP} <: AbstractPoints{manifold_dim, T}
     function PointSet(
         constituent_points::Vararg{AbstractVector{T}, manifold_dim}
     ) where {manifold_dim, T <: Real}
+        allequal(length, constituent_points) ||
+            throw(ArgumentError("Number of points in each dimension must match."))
         num_points = length(constituent_points[1])
 
         return new{manifold_dim, T, typeof(constituent_points)}(

--- a/src/Points/PointSet.jl
+++ b/src/Points/PointSet.jl
@@ -6,34 +6,47 @@ Represents a set of points in `manifold_dim` dimensions.
 # Fields
 - `constituent_points::NTuple{manifold_dim, T}`: The set of points per manifold dimension.
 """
-struct PointSet{manifold_dim, T} <: AbstractPoints{manifold_dim}
-    constituent_points::NTuple{manifold_dim, T}
+struct PointSet{manifold_dim, T, CP} <: AbstractPoints{manifold_dim, T}
+    constituent_points::CP
     num_points::Int
 
     function PointSet(
-        constituent_points::NTuple{manifold_dim, T}
-    ) where {manifold_dim, T <: AbstractVector}
+        constituent_points::Vararg{AbstractVector{T}, manifold_dim}
+    ) where {manifold_dim, T <: Real}
         num_points = length(constituent_points[1])
 
-        return new{manifold_dim, T}(constituent_points, num_points)
-    end
-
-    function PointSet(point_set::Vector{NTuple{manifold_dim, T}}) where {manifold_dim, T}
-        constituent_points = ntuple(
-            dim -> [point_set[point][dim] for point in 1:length(point_set)], manifold_dim
+        return new{manifold_dim, T, typeof(constituent_points)}(
+            constituent_points, num_points
         )
-
-        return PointSet(constituent_points)
     end
+end
 
-    function PointSet(point_set::Vector{Vector{T}}) where {T <: Number}
-        manifold_dim = length(point_set[1])
-        constituent_points = ntuple(
-            dim -> [point_set[point][dim] for point in 1:length(point_set)], manifold_dim
-        )
+function PointSet(
+    constituent_points::NTuple{manifold_dim, V}
+) where {manifold_dim, V <: AbstractVector{<:Real}}
+    return PointSet(constituent_points...)
+end
 
-        return PointSet(constituent_points)
-    end
+PointSet(constituent_points...) = PointSet(promote(map(collect, constituent_points)...)...)
+
+function PointSet(point_set::Vector{NTuple{manifold_dim, T}}) where {manifold_dim, T}
+    # Split a list of n manifold_dim-dimensional points into manifold_dim lists of n points
+    num_points = length(point_set)
+    constituent_points = ntuple(
+        dim -> [point_set[point][dim] for point in 1:num_points], manifold_dim
+    )
+
+    return PointSet(constituent_points)
+end
+
+function PointSet(point_set::Vector{Vector{T}}) where {T <: Real}
+    # Split a list of n manifold_dim-dimensional points into manifold_dim lists of n points
+    manifold_dim = length(first(point_set))
+    constituent_points = ntuple(
+        dim -> [point_set[point][dim] for point in 1:length(point_set)], manifold_dim
+    )
+
+    return PointSet(constituent_points)
 end
 
 Base.eltype(::PointSet{manifold_dim, T}) where {manifold_dim, T} = eltype(T)

--- a/src/Points/Points.jl
+++ b/src/Points/Points.jl
@@ -17,7 +17,7 @@ Supertype for all evaluable points.
 
 # Type parameters
 - `manifold_dim`: Dimension of the manifold where the points are evaluated.
-- `T`: The [`eltype`](@ref) of the points.
+- `T`: The `eltype` of the points; see `Base.eltype`.
 """
 abstract type AbstractPoints{manifold_dim, T} end
 

--- a/src/Points/Points.jl
+++ b/src/Points/Points.jl
@@ -11,14 +11,15 @@ module Points
 ############################################################################################
 
 """
-    AbstractPoints{manifold_dim}
+    AbstractPoints{manifold_dim, T}
 
 Supertype for all evaluable points.
 
 # Type parameters
 - `manifold_dim`: Dimension of the manifold where the points are evaluated.
+- `T`: The [`eltype`](@ref) of the points.
 """
-abstract type AbstractPoints{manifold_dim} end
+abstract type AbstractPoints{manifold_dim, T} end
 
 ############################################################################################
 #                                    Abstract Methods                                      #
@@ -82,11 +83,12 @@ function scale_and_shift_points(
     transformed_points = ntuple(
         dim -> constituent_points[dim] .* scalings[dim] .+ translations[dim], manifold_dim
     )
-	constructor = Base.typename(P).wrapper
+    constructor = Base.typename(P).wrapper
 
-	return constructor(transformed_points)
+    return constructor(transformed_points)
 end
 
+Base.eltype(::AbstractPoints{manifold_dim, T}) where {manifold_dim, T} = T
 Base.firstindex(points::AbstractPoints) = 1
 Base.lastindex(points::AbstractPoints) = get_num_points(points)
 Base.keys(points::AbstractPoints) = firstindex(points):lastindex(points)

--- a/test/Points/AbstractPoints.jl
+++ b/test/Points/AbstractPoints.jl
@@ -3,12 +3,14 @@ module AbstractPointsTests
 using Mantis
 using Test
 
-struct UnknownPoints{T} <: Points.AbstractPoints{1}
-    points::T
+struct UnknownPoints{N, T} <: Points.AbstractPoints{N, T}
+    points::NTuple{N, Vector{T}}
 end
 
-unknown_points = UnknownPoints("something")
+unknown_points = UnknownPoints(([1.0, 2.0],))
 
 @test_throws MethodError Points.get_num_points(unknown_points)
+@test isone(Points.get_manifold_dim(unknown_points))
+@test eltype(unknown_points) == Float64
 
 end

--- a/test/Points/CartesianPoints.jl
+++ b/test/Points/CartesianPoints.jl
@@ -27,7 +27,7 @@ end
 
 # Iteration order
 
-@test_throws MethodError Points.CartesianPoints((1:2, 1:2), (1, 2, 3))
+@test_throws TypeError Points.CartesianPoints(1:2, 1:2; iteration_order=(1, 2, 3))
 
 points = (1:2, 1:2, 1:2)
 order_1 = (1, 2, 3)
@@ -37,12 +37,12 @@ order_4 = (2, 3, 1)
 order_5 = (3, 1, 2)
 order_6 = (3, 2, 1)
 points_0 = Points.CartesianPoints(points)
-points_1 = Points.CartesianPoints(points, order_1)
-points_2 = Points.CartesianPoints(points, order_2)
-points_3 = Points.CartesianPoints(points, order_3)
-points_4 = Points.CartesianPoints(points, order_4)
-points_5 = Points.CartesianPoints(points, order_5)
-points_6 = Points.CartesianPoints(points, order_6)
+points_1 = Points.CartesianPoints(points; iteration_order=order_1)
+points_2 = Points.CartesianPoints(points; iteration_order=order_2)
+points_3 = Points.CartesianPoints(points; iteration_order=order_3)
+points_4 = Points.CartesianPoints(points; iteration_order=order_4)
+points_5 = Points.CartesianPoints(points; iteration_order=order_5)
+points_6 = Points.CartesianPoints(points; iteration_order=order_6)
 num_points = Points.get_num_points(points_0)
 
 for p in 1:num_points
@@ -108,5 +108,45 @@ end
 @test points_6[6] == (2, 1, 2)
 @test points_6[7] == (2, 2, 1)
 @test points_6[8] == (2, 2, 2)
+
+# Test different number of points
+
+points = Mantis.Points.CartesianPoints(1:2, 1:3, 1:4; iteration_order=(3, 1, 2))
+@test points[1] == (1, 1, 1)
+@test points[2] == (1, 2, 1)
+@test points[3] == (1, 3, 1)
+@test points[4] == (1, 1, 2)
+@test points[5] == (1, 2, 2)
+@test points[6] == (1, 3, 2)
+@test points[7] == (1, 1, 3)
+@test points[8] == (1, 2, 3)
+@test points[9] == (1, 3, 3)
+@test points[10] == (1, 1, 4)
+@test points[11] == (1, 2, 4)
+@test points[12] == (1, 3, 4)
+@test points[13] == (2, 1, 1)
+@test points[14] == (2, 2, 1)
+@test points[15] == (2, 3, 1)
+@test points[16] == (2, 1, 2)
+@test points[17] == (2, 2, 2)
+@test points[18] == (2, 3, 2)
+@test points[19] == (2, 1, 3)
+@test points[20] == (2, 2, 3)
+@test points[21] == (2, 3, 3)
+@test points[22] == (2, 1, 4)
+@test points[23] == (2, 2, 4)
+@test points[24] == (2, 3, 4)
+
+# Test heterogeneous types
+@inferred Points.CartesianPoints([1, 2], [1.0, 2.0])
+@inferred Points.CartesianPoints(LinRange(0, 1, 2), [1.0, 2.0])
+@inferred Points.CartesianPoints(LinRange(0, 1, 2), [1, 2])
+@inferred Points.CartesianPoints(
+    1:10, [1, 2], LinRange(0, 1, 10), zeros(Float32, 3); iteration_order=(4, 2, 1, 3)
+)
+weird_points = Points.CartesianPoints(
+    1:10, [1, 2], LinRange(0, 1, 10), zeros(Float32, 3); iteration_order=(4, 2, 1, 3)
+)
+@inferred weird_points[3]
 
 end

--- a/test/Points/CartesianPoints.jl
+++ b/test/Points/CartesianPoints.jl
@@ -3,6 +3,11 @@ module CartesianPointsTests
 using Mantis
 using Test
 
+@test_throws ArgumentError Points.CartesianPoints(())
+@test_throws ArgumentError Points.CartesianPoints(([1], Int[]))
+@test_throws ArgumentError Points.CartesianPoints(([1], ["wrong_type"]))
+@test_throws TypeError Points.CartesianPoints(1:2, 1:2; iteration_order=(1, 2, 3))
+
 manifold_dims = [1, 2, 3]
 num_const_points = [(2,), (4, 3), (2, 1, 5)]
 num_points = [prod(num_const_points[dim]) for dim in 1:3]
@@ -24,10 +29,6 @@ for i in 1:3
         @test xi[j] == original_point
     end
 end
-
-# Iteration order
-
-@test_throws TypeError Points.CartesianPoints(1:2, 1:2; iteration_order=(1, 2, 3))
 
 points = (1:2, 1:2, 1:2)
 order_1 = (1, 2, 3)
@@ -138,15 +139,16 @@ points = Mantis.Points.CartesianPoints(1:2, 1:3, 1:4; iteration_order=(3, 1, 2))
 @test points[24] == (2, 3, 4)
 
 # Test heterogeneous types
-@inferred Points.CartesianPoints([1, 2], [1.0, 2.0])
-@inferred Points.CartesianPoints(LinRange(0, 1, 2), [1.0, 2.0])
-@inferred Points.CartesianPoints(LinRange(0, 1, 2), [1, 2])
-@inferred Points.CartesianPoints(
-    1:10, [1, 2], LinRange(0, 1, 10), zeros(Float32, 3); iteration_order=(4, 2, 1, 3)
-)
-weird_points = Points.CartesianPoints(
-    1:10, [1, 2], LinRange(0, 1, 10), zeros(Float32, 3); iteration_order=(4, 2, 1, 3)
-)
-@inferred weird_points[3]
+@test typeof(Points.CartesianPoints([1, 2], [1.0, 2.0]).constituent_points) ==
+    Tuple{Vector{Float64}, Vector{Float64}}
+@test typeof(Points.CartesianPoints(LinRange(0, 1, 2), [1.0, 2.0]).constituent_points) ==
+    Tuple{LinRange{Float64, Int}, Vector{Float64}}
+@test typeof(Points.CartesianPoints(LinRange(0, 1, 2), [1, 2]).constituent_points) ==
+    Tuple{LinRange{Float64, Int}, Vector{Float64}}
+@test typeof(
+    Points.CartesianPoints(
+        1:2, [1, 2], LinRange(0, 1, 2), zeros(Float32, 2)
+    ).constituent_points,
+) == Tuple{Vector{Float64}, Vector{Float64}, LinRange{Float64, Int}, Vector{Float64}}
 
 end

--- a/test/Points/PointSet.jl
+++ b/test/Points/PointSet.jl
@@ -3,6 +3,11 @@ module PointSetTests
 using Mantis
 using Test
 
+@test_throws ArgumentError Points.PointSet(())
+@test_throws ArgumentError Points.PointSet(([1], Int[]))
+@test_throws ArgumentError Points.PointSet([1, 2], [1, 2, 3])
+@test_throws ArgumentError Points.PointSet(([1], ["wrong_type"]))
+
 manifold_dims = [1, 2, 3]
 num_points = [7, 8, 9]
 for i in 1:3
@@ -22,13 +27,15 @@ for i in 1:3
     end
 end
 
-@test_throws ArgumentError Points.PointSet([1, 2], [1, 2, 3])
 # Test heterogeneous types
-@inferred Points.PointSet([1, 2], [1.0, 2.0])
-@inferred Points.PointSet(LinRange(0, 1, 2), [1.0, 2.0])
-@inferred Points.PointSet(LinRange(0, 1, 2), [1, 2])
-@inferred Points.PointSet(1:2, [1, 2], LinRange(0, 1, 2), zeros(Float32, 2))
-weird_points = Points.PointSet(1:2, [1, 2], LinRange(0, 1, 2), zeros(Float32, 2))
-@inferred weird_points[2]
+@test typeof(Points.PointSet([1, 2], [1.0, 2.0]).constituent_points) ==
+    Tuple{Vector{Float64}, Vector{Float64}}
+@test typeof(Points.PointSet(LinRange(0, 1, 2), [1.0, 2.0]).constituent_points) ==
+    Tuple{LinRange{Float64, Int}, Vector{Float64}}
+@test typeof(Points.PointSet(LinRange(0, 1, 2), [1, 2]).constituent_points) ==
+    Tuple{LinRange{Float64, Int}, Vector{Float64}}
+@test typeof(
+    Points.PointSet(1:2, [1, 2], LinRange(0, 1, 2), zeros(Float32, 2)).constituent_points
+) == Tuple{Vector{Float64}, Vector{Float64}, LinRange{Float64, Int}, Vector{Float64}}
 
 end

--- a/test/Points/PointSet.jl
+++ b/test/Points/PointSet.jl
@@ -22,4 +22,13 @@ for i in 1:3
     end
 end
 
+@test_throws ArgumentError Points.PointSet([1, 2], [1, 2, 3])
+# Test heterogeneous types
+@inferred Points.PointSet([1, 2], [1.0, 2.0])
+@inferred Points.PointSet(LinRange(0, 1, 2), [1.0, 2.0])
+@inferred Points.PointSet(LinRange(0, 1, 2), [1, 2])
+@inferred Points.PointSet(1:2, [1, 2], LinRange(0, 1, 2), zeros(Float32, 2))
+weird_points = Points.PointSet(1:2, [1, 2], LinRange(0, 1, 2), zeros(Float32, 2))
+@inferred weird_points[2]
+
 end


### PR DESCRIPTION
- Fixes bug in CartesianPoints when using iteration_order.
- Adds functionality for mixing different types of `constituents_points`. This new functionality has flexibility advantages but is difficult to implement in `SkeletonGeometry` when converting points from the skeleton geometry to points in the parent geometry. It assumes the same type of `constituent_points`. It is possible to change, but it is a more complex construction there. This change therefore should be carefully considered.