### PR TITLE
Feat: add time integration

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -12,12 +12,12 @@ whitespace_typedefs = true
 # Enables formatting for code blocks
 format_docstrings = false
 # Enables formatting for markdown
-format_markdown = false
+# format_markdown = false
 # Stops pipes from being converted to function calls
 pipe_to_function_call = false
 # Since the `formart_markdown` can break markdown blocks in the docs, it is best to ignore
-# the docs folder. 
+# the docs folder.
 ignore = ["docs"]
-# NOTES: It is possible to skip sections of code from being formatted by typing 
-# `#! format: off` and `#! format: on` comments. The same can be done for indentation with 
+# NOTES: It is possible to skip sections of code from being formatted by typing
+# `#! format: off` and `#! format: on` comments. The same can be done for indentation with
 # `#! format: noindent`.

--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -12,7 +12,7 @@ whitespace_typedefs = true
 # Enables formatting for code blocks
 format_docstrings = false
 # Enables formatting for markdown
-# format_markdown = false
+format_markdown = false
 # Stops pipes from being converted to function calls
 pipe_to_function_call = false
 # Since the `formart_markdown` can break markdown blocks in the docs, it is best to ignore

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,12 @@ Manifest.toml
 !docs/src/assets/*.svg
 !docs/src/assets/*.ico
 
+# Ignore videos by default
+*.mkv
+*.mp4
+*.webm
+*.gif
+
 # Ignore all Vim temporary buffer files
 *.swp
 *.swo

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -22,3 +22,13 @@ project reference 2023.00238.BD and DOI identifier https://doi.org/10.54499/2023
 
 The research of Deepesh Toshniwal was partially supported (2021-2025) by project number
 202.150 awarded through the Veni research programme by the Dutch Research Council (NWO).
+
+# Previous Contributors
+The following TU Delft 'Computer Science and Engineering'-minor students created the first
+implementation of the `TimeIntegrators`-module in Q2/3 of AY2024/2025:
+- Daisy de Blom,
+- Wiktor Cupiał,
+- Pelle Mutsaers,
+- Pablo Raichs Fernandez,
+- Teun Schuurs,
+- Aleksandra Taneva.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,9 +4,12 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Mantis = "45fd81cf-4570-4cb4-b51d-06adeaefc15d"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [sources]
 Mantis = {path = ".."}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ for example in readdir(examples_dir)
     if endswith(example, ".jl")
         path_to_example = joinpath(examples_dir, example)
 
-        push!(example_names, example[1:(end-3)])  # Remove the file extension from the name.
+        push!(example_names, example[1:(end - 3)])  # Remove the file extension from the name.
 
         # Literate.notebook(path_to_example, joinpath(mantis_dir, "examples", "notebooks"))
 
@@ -52,6 +52,7 @@ Design = [
                 "Plot.md",
                 "Points.md",
                 "Quadrature.md",
+                "TimeIntegrators.md",
             ],
         ),
 ]
@@ -64,29 +65,27 @@ Support = [
 ]
 
 ReleaseHistory = [
-    "v0.6 Acanthops onorei" => joinpath(
-		"ReleaseHistory", "v0-Acanthops", "v0.6-onorei.md"),
-    "v0.5 Acanthops godmani" => joinpath(
-		"ReleaseHistory", "v0-Acanthops", "v0.5-godmani.md"),
-    "v0.4 Acanthops falcata" => joinpath(
-		"ReleaseHistory", "v0-Acanthops", "v0.4-falcata.md"),
-    "v0.3 Acanthops erosa" => joinpath(
-		"ReleaseHistory", "v0-Acanthops", "v0.3-erosa.md"),
-    "v0.2 Acanthops centralis" => joinpath(
-		"ReleaseHistory", "v0-Acanthops", "v0.2-centralis.md"),
-    "v0.1 Acanthops brunneri" => joinpath(
-		"ReleaseHistory", "v0-Acanthops", "v0.1-brunneri.md"),
+    "v0.6 Acanthops onorei" => joinpath("ReleaseHistory", "v0-Acanthops", "v0.6-onorei.md"),
+    "v0.5 Acanthops godmani" =>
+        joinpath("ReleaseHistory", "v0-Acanthops", "v0.5-godmani.md"),
+    "v0.4 Acanthops falcata" =>
+        joinpath("ReleaseHistory", "v0-Acanthops", "v0.4-falcata.md"),
+    "v0.3 Acanthops erosa" => joinpath("ReleaseHistory", "v0-Acanthops", "v0.3-erosa.md"),
+    "v0.2 Acanthops centralis" =>
+        joinpath("ReleaseHistory", "v0-Acanthops", "v0.2-centralis.md"),
+    "v0.1 Acanthops brunneri" =>
+        joinpath("ReleaseHistory", "v0-Acanthops", "v0.1-brunneri.md"),
 ]
 
 Pages = [
-	"Getting Started" => "GettingStarted.md",
-	"Examples" => Examples,
+    "Getting Started" => "GettingStarted.md",
+    "Examples" => Examples,
     "Design" => Design,
     "Support(ing)" => Support,
     "Releases" => ReleaseHistory,
     "Bibliography" => [
         joinpath("BibliographicInformation", "references.md"),
-        joinpath("BibliographicInformation", "HowToCite.md")
+        joinpath("BibliographicInformation", "HowToCite.md"),
     ],
 ]
 
@@ -112,6 +111,7 @@ makedocs(;
         Mantis.Plot,
         Mantis.Points,
         Mantis.Quadrature,
+        Mantis.TimeIntegrators,
     ],
     repo=Remotes.GitHub("MantisFEM", "Mantis.jl"),
     sitename="Mantis.jl",

--- a/docs/src/Design/Modules/TimeIntegrators.md
+++ b/docs/src/Design/Modules/TimeIntegrators.md
@@ -91,8 +91,8 @@ methods.
 
 ### [GLMs: Characterising a GLM](@id TIGLMCharacter)
 Any time integrator that fits in the above framework can thus be characterised by the four matrices ``A``, ``B``, ``U``, ``V``, and the layout of the in- and output vectors ``\mathbf{y}``. 
-In addition, evey time integrator will also need a vector ``C``, which keeps track of the time at which the stages are evaluated.
-In `Mantis`, the ``A``, ``B``, ``U``, ``V`` are stored in the time integrator structs (see [this section below](@ref TIwhatareTIs)).
+In addition, every time integrator will also need a vector ``C``, which keeps track of the time at which the stages are evaluated.
+In `Mantis`, ``A``, ``B``, ``U``, ``V``, and ``C`` are stored in the time integrator structs (see [this section below](@ref TIwhatareTIs)).
 The matrices have the following sizes:
 
 | Matrix        | Size          |
@@ -101,7 +101,7 @@ The matrices have the following sizes:
 | ``B``         | `num_steps` x `num_stages`  |
 | ``U``         | `num_stages` x `num_steps`  |
 | ``V``         | `num_steps` x `num_steps`   |
-| ``C``         | `num_stages` |
+| ``C``         | `num_stages` x `1` |
 
 
 ### GLMs: Extension to IMEX Schemes
@@ -183,14 +183,15 @@ get_remaining_startup_steps
 ::: details Internals: solution objects
 
 We explain some internals related to the solution objects. 
-However, this is considered an implementational detail.
+However, this is considered an implementation detail.
 
-Next to the information just mentioned, a `TimeIntegrationSolution` also stored the pre-allocated arrays, which can be obtained with the following getters.
+Next to the information just mentioned, a `TimeIntegrationSolution` also stores the pre-allocated arrays and the solution object for the startup scheme (if present), which can be obtained with the following getters.
 
 ```@docs
 get_solution_allocated
 get_F_allocated
 get_G_allocated
+get_startup_solution
 get_stage_allocated
 get_temp_var
 ```
@@ -241,7 +242,7 @@ time_integrate!
 ::: details Internals: time integration
 
 We explain how the time integration is performed. 
-However, this is considered an implementational detail.
+However, this is considered an implementation detail.
 
 The integration functions from [Time Integrate](@ref TIintegrate) end up calling the following internal integrator.
 This integrator function is specialised for different integrators and encodes how the time stepping is actually performed.
@@ -261,22 +262,30 @@ Every time integrator has a `TimeLevels` struct to define what information is ne
 TimeLevels
 ```
 
+In general, the length of the arrays in the `TimeLevels` object is required.
+These lengths can be easily obtained using the following getters.
+```@docs
+get_num_step_values
+get_num_implicit_derivatives
+get_num_explicit_derivatives
+```
+
 The actual initialisation step(s) can be performed by calling the following function.
 ```@docs
-initialize_scheme
+initialise_scheme
 ```
 
 ::: tip Other initialisation procedures
 
 `Mantis` does not provide an exhaustive set of initialisation procedures. 
-Some GLM schemes may require a different quantity to be initialised than what the `initialize_scheme`-method provides.
+Some GLM schemes may require a different quantity to be initialised than what the `initialise_scheme`-method provides.
 If this is the case, you can always perform the initialisation manually.
 See [Adding your own scheme](@ref TimeIntegratorsAddYourOwn) for the details.
 
 :::
 
 ## [Pre-implemented schemes](@id TIschemes)
-`Mantis` provides a few pre-implemented schemes for convience. 
+`Mantis` provides a few pre-implemented schemes for convenience. 
 
 ::: details Pre-implemented explicit integrators in the Runge-Kutta family.
 ```@docs
@@ -300,8 +309,10 @@ RALSTON4
 BACKWARD_EULER
 RADAU_IA_1
 IMPLICIT_MIDPOINT
+CRANK_NICOLSON
 DIRK2
 DIRK3
+ESDIRK32
 RADAU_IA_3
 DIRK4
 GAUSS_LEGENDRE_4
@@ -337,6 +348,7 @@ BDF4
 BACKWARD_FORWARD_EULER
 MIDPOINT_IMEX
 RK3_IMEX
+IMEX331
 CNAB2
 SSSS2
 ```
@@ -350,7 +362,7 @@ butcher_tableau_to_glm
 ```
 
 ## [Adding your own scheme](@id TimeIntegratorsAddYourOwn)
-As an example of how to add your own time integrator, we look at how to implement an Almost Runge Kutta (ARK) scheme.
+As an example of how to add your own time integrator, we look at how to implement an Almost Runge-Kutta (ARK) scheme.
 We use a specific scheme introduced in [Rattenbury2005](@cite).
 
 This scheme requires a specialised initialisation, since it needs an estimate of the second derivative which is not accounted for in the available initialisations. 

--- a/docs/src/Design/Modules/TimeIntegrators.md
+++ b/docs/src/Design/Modules/TimeIntegrators.md
@@ -1,0 +1,422 @@
+```@meta
+CurrentModule = Mantis.TimeIntegrators
+```
+# TimeIntegrators
+
+The time integration module implemented in `Mantis` is based on the framework developed by [Vos2011](@cite).
+This framework allows for an easy implementation of a variety of explicit, implicit, and implicit-explicit (IMEX) time stepping schemes, and is based on the concept of general linear methods (GLMs). 
+See, for example, [Butcher2006](@cite), for more details.
+These methods are applicable to both ODEs and PDEs, so that both are available in `Mantis`. 
+
+## GLMs: Notation and Theory
+General linear methods can be characterised as follows (see [Butcher2006](@cite), [Vos2011](@cite)). 
+Consider the initial value problem defined as the ODE
+```math
+\frac{d\mathbf{y}}{dt} = \mathbf{f}(\mathbf{y}), \quad \mathbf{y}(t_0) = \mathbf{y}_0\;,
+```
+where ``\mathbf{f}: \mathbb{R}^N \to \mathbb{R}^N``. 
+The ``n``-th (time) step of the GLM comprised of ``r`` (integrator) steps and ``s`` stages is then formulated as
+```math
+\begin{align}
+    \mathbf{Y}_i &= \Delta t \sum_{j=1}^{s} a_{ij} \mathbf{F}_j + \sum_{j=1}^{r} u_{ij} \mathbf{y}_j^{n-1}, \quad i = 1, \dots, s\;, \\
+    \mathbf{y}_i^n &= \Delta t \sum_{j=1}^{s} b_{ij} \mathbf{F}_j + \sum_{j=1}^{r} v_{ij} \mathbf{y}_j^{n-1}, \quad i = 1, \dots, r\;,
+\end{align}
+```
+where ``\mathbf{Y}_i`` are called the stage values and ``\mathbf{F}_i`` are called the stage derivatives.
+These two quantities are related by the differential equation
+```math
+\mathbf{F}_i = \mathbf{f}(\mathbf{Y}_i)\;.
+```
+The above formulation can be cast into the following matrix form
+```math
+\begin{bmatrix}
+\mathbf{Y} \\
+\mathbf{y}^n
+\end{bmatrix} = 
+\begin{bmatrix}
+A \otimes I & U \otimes I \\
+B \otimes I & V \otimes I
+\end{bmatrix}
+\begin{bmatrix}
+\Delta t \mathbf{Y} \\
+\mathbf{y}^{n-1}
+\end{bmatrix} \;,
+```
+which is often simplified (with some abuse of notation) to
+```math
+\begin{bmatrix}
+\mathbf{Y} \\
+\mathbf{y}^n
+\end{bmatrix} = 
+\begin{bmatrix}
+A & U \\
+B & V 
+\end{bmatrix}
+\begin{bmatrix}
+\Delta t \mathbf{Y} \\
+\mathbf{y}^{n-1}
+\end{bmatrix} \;.
+```
+Either way, the vectors ``\mathbf{y}`` (in/output approximations), ``\mathbf{Y}`` (stage values), and ``\mathbf{F}`` (stage derivatives) are defined as
+```math
+\mathbf{y}^{n-1} = \begin{bmatrix}
+y_1^{n-1} \\
+y_2^{n-1} \\
+\vdots \\
+y_r^{n-1}
+\end{bmatrix}\;, \quad 
+\mathbf{y}^n = \begin{bmatrix}
+y_1^{n} \\
+y_2^{n} \\
+\vdots \\
+y_r^{n}
+\end{bmatrix}\;, \quad
+\mathbf{Y} = \begin{bmatrix}
+Y_1 \\
+Y_2 \\
+\vdots \\
+Y_s
+\end{bmatrix}\;, \quad
+\mathbf{F} = \begin{bmatrix}
+F_1 \\
+F_2 \\
+\vdots \\
+F_s
+\end{bmatrix}\;.
+```
+It is important to note that the in/output vectors can contain more than just the solution. 
+The exact content depends on the specific method, but often includes previously computed 
+stage derivatives. This is particularly important when creating and/or initialising new 
+methods.
+
+### [GLMs: Characterising a GLM](@id TIGLMCharacter)
+Any time integrator that fits in the above framework can thus be characterised by the four matrices ``A``, ``B``, ``U``, ``V``, and the layout of the in- and output vectors ``\mathbf{y}``. 
+In addition, evey time integrator will also need a vector ``C``, which keeps track of the time at which the stages are evaluated.
+In `Mantis`, the ``A``, ``B``, ``U``, ``V`` are stored in the time integrator structs (see [this section below](@ref TIwhatareTIs)).
+The matrices have the following sizes:
+
+| Matrix        | Size          |
+| :-----------: | :-----------: |
+| ``A``         | `num_stages` x `num_stages` |
+| ``B``         | `num_steps` x `num_stages`  |
+| ``U``         | `num_stages` x `num_steps`  |
+| ``V``         | `num_steps` x `num_steps`   |
+| ``C``         | `num_stages` |
+
+
+### GLMs: Extension to IMEX Schemes
+The framework introduced by [Vos2011](@cite) extends the GLM idea to IMEX integrators.
+The ODE from the previous section is now split into
+```math
+\frac{d\mathbf{y}}{dt} = \mathbf{f}(\mathbf{y}) + \mathbf{g}(\mathbf{y}), \quad \mathbf{y}(t_0) = \mathbf{y}_0\;,
+```
+where ``\mathbf{f}: \mathbb{R}^N \to \mathbb{R}^N`` and ``\mathbf{g}: \mathbb{R}^N \to \mathbb{R}^N``. 
+The ``\mathbf{f}``-part represent the part of the ODE that is treated explicitly, while the ``\mathbf{g}``-part is treated implicitly.
+The ``n``-th (time) step of the IMEX-GLM comprised of ``r`` (integrator) steps and ``s`` stages is then formulated as
+```math
+\begin{align}
+    \mathbf{Y}_i &= \Delta t \sum_{j=1}^{s} a^{IM}_{ij} \mathbf{G}_j + \Delta t \sum_{j=1}^{s} a^{EX}_{ij} \mathbf{F}_j + \sum_{j=1}^{r} u_{ij} \mathbf{y}_j^{n-1}, \quad i = 1, \dots, s\;, \\
+    \mathbf{y}_i^n &= \Delta t \sum_{j=1}^{s} b^{IM}_{ij} \mathbf{G}_j + \Delta t \sum_{j=1}^{s} b^{EX}_{ij} \mathbf{F}_j + \sum_{j=1}^{r} v_{ij} \mathbf{y}_j^{n-1}, \quad i = 1, \dots, r\;,
+\end{align}
+```
+where ``\mathbf{Y}_i`` are called the stage values and ``\mathbf{F}_i`` and ``\mathbf{G}_i`` are called the (explicit and implicit) stage derivatives.
+These quantities are related by the differential equation
+```math
+\mathbf{F}_i = \mathbf{f}(\mathbf{Y}_i), \quad \mathbf{G}_i = \mathbf{g}(\mathbf{Y}_i)\;.
+```
+The matrix form is obtained in the same way as in the previous section.
+
+IMEX GLMs are characterised in the same way as described in [GLMs: Characterising a GLM](@ref TIGLMCharacter). 
+The only difference is that an IMEX GLM will have two ``A`` and ``B`` matrices, and two ``C`` vectors : one for the explicit part and one for the implicit part.
+
+
+## [What are time integrators in `Mantis`?](@id TIwhatareTIs)
+The top-level type within the `TimeIntegrators` module is the `AbstractTimeIntegrator{num_stages, num_steps}` type. 
+```@docs
+AbstractTimeIntegrator
+```
+
+Note that you can always obtain the number of stages and steps using the following functions.
+```@docs
+get_num_stages
+get_num_steps
+```
+
+The `AbstractTimeIntegrator{num_stages, num_steps}` type has four concrete subtypes, each 
+representing a specific class of time integrators.
+```@docs
+Explicit
+DiagonallyImplicit
+Implicit
+IMEX
+```
+
+The ``A``-matrix (see above) in the GLM framework dictates whether a scheme is implicit or not.
+When initialising one of the above structs, this is checked using the following function.
+You can also use this to check what to expect.
+```@docs
+check_implicit
+```
+
+Since all schemes store the order of the scheme, you can always retrieve that information using the following getter.
+```@docs
+get_order
+```
+
+### [The solution objects](@id TIsolutions)
+The time integrators themselves do not store the solution. 
+This is instead handled by the `TimeIntegrationSolution`-object. 
+```@docs
+TimeIntegrationSolution
+```
+
+The `TimeIntegrationSolution` stores the information about the state of the time integration problem.
+You can inspect such objects through the following getters.
+```@docs
+get_num_variables
+get_solution
+get_scheme
+get_startup_scheme
+get_remaining_startup_steps
+```
+
+::: details Internals: solution objects
+
+We explain some internals related to the solution objects. 
+However, this is considered an implementational detail.
+
+Next to the information just mentioned, a `TimeIntegrationSolution` also stored the pre-allocated arrays, which can be obtained with the following getters.
+
+```@docs
+get_solution_allocated
+get_F_allocated
+get_G_allocated
+get_stage_allocated
+get_temp_var
+```
+
+> [!CAUTION]
+> Do not manually modify the pre-allocated arrays.
+> 
+> Modifying the pre-allocated arrays may lead to incorrect results or unexpected behaviour.
+
+The above getters are internally used to access the pre-allocated arrays and to overwrite their values.
+You should not need these functions unless you are extending the integrate functionality to new types.
+
+:::
+
+## [Adding problem-specific information](@id TIprobleminfo)
+To use the `TimeIntegrators`-module, you have to specify which problem you want to solve. 
+Information about the problem is collected in `TimeIntegrationOperators`. 
+See [GLMs: Notation and Theory](@ref) and [GLMs: Extension to IMEX Schemes](@ref) for the notation.
+```@docs
+TimeIntegrationOperators
+```
+
+There are various ways in which you can construct the above object, using the following functions.
+
+::: tip The input functions are generic
+
+This means that within these functions, you can choose how to treat your problem. For example, you can solve a non-linear system via the Newton-Rhapson method, as done in the [Lorenz Attractor](@ref)
+
+:::
+
+```@docs
+define_explicit_ode
+define_diagonally_implicit_ode
+define_implicit_ode
+define_imex_ode
+```
+
+## [Time Integration](@id TIintegration)
+Now that the scheme, solution object, and the problem are all defined, we can perform the actual time integration.
+
+### [Time Integrate](@id TIintegrate)
+The integration happens by calling one of the following two methods.
+```@docs
+time_integrate
+time_integrate!
+```
+
+::: details Internals: time integration
+
+We explain how the time integration is performed. 
+However, this is considered an implementational detail.
+
+The integration functions from [Time Integrate](@ref TIintegrate) end up calling the following internal integrator.
+This integrator function is specialised for different integrators and encodes how the time stepping is actually performed.
+```@docs
+_time_integrate!
+```
+
+:::
+
+### [Initialisation](@id TIsolutions)
+All integrators must be initialised. 
+For multi-stage schemes, this is often just a matter of adding the initial condition. 
+For multi-step schemes, this requires a startup scheme and more computation.
+To handle these different initialisation requirements, `Mantis` has a `TimeLevels` struct, as introduced in [Vos2011](@cite), to keep track of what needs to be initialised. 
+Every time integrator has a `TimeLevels` struct to define what information is needed from previous steps.
+```@docs
+TimeLevels
+```
+
+The actual initialisation step(s) can be performed by calling the following function.
+```@docs
+initialize_scheme
+```
+
+::: tip Other initialisation procedures
+
+`Mantis` does not provide an exhaustive set of initialisation procedures. 
+Some GLM schemes may require a different quantity to be initialised than what the `initialize_scheme`-method provides.
+If this is the case, you can always perform the initialisation manually.
+See [Adding your own scheme](@ref TimeIntegratorsAddYourOwn) for the details.
+
+:::
+
+## [Pre-implemented schemes](@id TIschemes)
+`Mantis` provides a few pre-implemented schemes for convience. 
+
+::: details Pre-implemented explicit integrators in the Runge-Kutta family.
+```@docs
+FORWARD_EULER
+EXPLICIT_MIDPOINT
+HEUN2
+RALSTON2
+HEUN3
+RK3
+RALSTON3
+VDHW3
+SSPRK3
+RK4
+RK4_3_8
+RALSTON4
+```
+:::
+
+::: details Pre-implemented (diagonally) implicit integrators in the Runge-Kutta family.
+```@docs
+BACKWARD_EULER
+RADAU_IA_1
+IMPLICIT_MIDPOINT
+DIRK2
+DIRK3
+RADAU_IA_3
+DIRK4
+GAUSS_LEGENDRE_4
+GAUSS_LEGENDRE_6
+```
+:::
+
+::: details Pre-implemented explicit multi-step integrators.
+```@docs
+AB1
+AB2
+AB3
+AB4
+```
+:::
+
+::: details Pre-implemented (diagonally) implicit multi-step integrators.
+```@docs
+AM0
+AM1
+AM2
+AM3
+AM4
+BDF1
+BDF2
+BDF3
+BDF4
+```
+:::
+
+::: details Pre-implemented IMEX integrators.
+```@docs
+BACKWARD_FORWARD_EULER
+MIDPOINT_IMEX
+RK3_IMEX
+CNAB2
+SSSS2
+```
+:::
+
+You can, of course, always initialise a new scheme yourself (see the concrete types in [this section](@ref TIwhatareTIs) or [Adding your own scheme](@ref TimeIntegratorsAddYourOwn)).
+
+Next to the pre-implemented schemes, `Mantis` also provides the following convenience function to take a Butcher-Tableau and turn it into a GLM-based time integrator.
+```@docs
+butcher_tableau_to_glm
+```
+
+## [Adding your own scheme](@id TimeIntegratorsAddYourOwn)
+As an example of how to add your own time integrator, we look at how to implement an Almost Runge Kutta (ARK) scheme.
+We use a specific scheme introduced in [Rattenbury2005](@cite).
+
+This scheme requires a specialised initialisation, since it needs an estimate of the second derivative which is not accounted for in the available initialisations. 
+As a result, this scheme is not part of Mantis.
+
+::: details Example: solving a simple ODE with an ARK scheme.
+
+Consider the ODE:
+```math
+\frac{dy}{dt} = \lambda y,\quad  y(t=0) = 1.0
+```
+which has exact solution 
+```math
+y(t) = \exp(\lambda t)\;.
+```
+We can encode this in code as
+```@example arkexample
+using Mantis
+import StaticArrays
+
+const lambda = -4
+const t_final = 1
+
+y_0 = 1.0
+function exact_sol(t)
+    return exp(lambda * t)
+end
+
+function test_ode_explicit_func!(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n]
+    end
+    return nothing
+end
+test_ode_explicit = TimeIntegrators.define_explicit_ode(test_ode_explicit_func!)
+```
+:::
+
+The ARK3 scheme that we use here has a known GLM-representation (see [Rattenbury2005](@cite), page 50). 
+This method, however, requires its own initialisation, see [Rattenbury2005](@cite), pages 37-38. 
+This initialisation, can be easily implemented as shown below. 
+Note that the `TimeLevels` struct has more entries for the explicit forcing step. 
+No other changes are required. 
+```@example arkexample
+const ARK3 = TimeIntegrators.Explicit(
+    StaticArrays.SMatrix{3, 3}(0.0, 1/2, 0.0, 0.0, 0.0, 3/4, 0.0, 0.0, 0.0), # A
+    StaticArrays.SMatrix{3, 3}(0.0, 0.0, 3.0, 3/4, 0.0, -3.0, 0.0, 1.0, 2.0), # B
+    StaticArrays.SMatrix{3, 3}(1.0, 1.0, 1.0, 1/3, 1/6, 1/4, 1/18, 1/18, 0.0), # U
+    StaticArrays.SMatrix{3, 3}(1.0, 0.0, 0.0, 1/4, 0, -2.0, 0.0, 0.0, 0.0), # V
+    StaticArrays.SVector(1 / 3, 2 / 3, 1.0),
+    TimeIntegrators.TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        [0, 1],  # Δt F and Δt^2 F'
+    ),
+    3,
+)
+
+dt = 0.1 
+yn = zeros(Float64, 1, 3)
+yn[:, 1] .= [y_0]
+yn[:, 2] .= lambda .* [y_0] .* dt
+yn[:, 3] .= lambda^2 .* [y_0] .* dt^2
+y_n = TimeIntegrators.TimeIntegrationSolution(yn, ARK3, nothing, 0)
+
+for t in 0.0:dt:(t_final - dt)
+    TimeIntegrators.time_integrate!(y_n, test_ode_explicit, t, dt)
+end
+```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -110,6 +110,18 @@
   notes = {Available online: \url{https://fncbook.com/}, last accessed: 04 April 2026.}
 }
 
+@article{Ern2023,
+  title = {Invariant-{{Domain Preserving High-Order Time Stepping}}: {{II}}. {{IMEX Schemes}}},
+  shorttitle = {Invariant-{{Domain Preserving High-Order Time Stepping}}},
+  author = {Ern, Alexandre and Guermond, Jean-Luc},
+  year = 2023,
+  journal = {SIAM Journal on Scientific Computing},
+  volume = {45},
+  number = {5},
+  pages = {A2511-A2538},
+  doi = {10.1137/22M1505025}
+}
+
 @article{Evans2020,
   title={Hierarchical B-spline complexes of discrete differential forms},
   author={Evans, John A. and Scott, Michael A. and Shepherd, Kendrick M. and Thomas, Derek C. and V{\'a}zquez Hern{\'a}ndez, Rafael},
@@ -168,6 +180,17 @@
   number = {2},
   pages = {414--443},
   doi = {10.1016/0021-9991(91)90007-8},
+}
+
+@article{Kvaerno2004,
+  title = {Singly {{Diagonally Implicit Runge}}--{{Kutta Methods}} with an {{Explicit First Stage}}},
+  author = {Kv{\ae}rn{\o}, A.},
+  year = 2004,
+  journal = {BIT Numerical Mathematics},
+  volume = {44},
+  number = {3},
+  pages = {489--502},
+  doi = {10.1023/B:BITN.0000046811.70614.38},
 }
 
 @article{Palha2014,

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,3 +1,14 @@
+@article{Alexander1977,
+  title = {Diagonally {{Implicit Runge}}--{{Kutta Methods}} for {{Stiff O}}.{{D}}.{{E}}.'s},
+  author = {Alexander, Roger},
+  year = 1977,
+  journal = {SIAM Journal on Numerical Analysis},
+  volume = {14},
+  number = {6},
+  pages = {1006--1021},
+  doi = {10.1137/0714068},
+}
+
 @article{Arnold2006,
   title={Finite element exterior calculus, homological techniques, and applications},
   author={Arnold, Douglas N and Falk, Richard S and Winther, Ragnar},
@@ -20,6 +31,16 @@
   doi = {10.1002/nme.2968},
 }
 
+@article{Butcher2006,
+  title = {General Linear Methods},
+  author = {Butcher, J. C.},
+  year = 2006,
+  journal = {Acta Numerica},
+  volume = {15},
+  pages = {157--256},
+  doi = {10.1017/S0962492906220014},
+}
+
 @article{Cabanas2025,
   title={Construction of exact refinements for the two-dimensional HB/THB-spline de Rham complex},
   author={Cabanas, Diogo C. and Shepherd, Kendrick M. and Toshniwal, Deepesh and V{\'a}zquez, Rafael},
@@ -35,6 +56,17 @@
   doi = {10.5281/zenodo.17495870},
   copyright = {EUPL License},
   howpublished = {Zenodo},
+}
+
+@article{Chenciner2000,
+  title = {A {{Remarkable Periodic Solution}} of the {{Three-Body Problem}} in the {{Case}} of {{Equal Masses}}},
+  author = {Chenciner, Alain and Montgomery, Richard},
+  year = 2000,
+  journal = {The Annals of Mathematics},
+  volume = {152},
+  number = {3},
+  pages = {881},
+  doi = {10.2307/2661357},
 }
 
 @article{Costa2000,
@@ -127,6 +159,17 @@
   doi={10.1137/19M1263583},
 }
 
+@article{Karniadakis1991,
+  title = {High-Order Splitting Methods for the Incompressible {{Navier-Stokes}} Equations},
+  author = {Karniadakis, George Em and Israeli, Moshe and Orszag, Steven A},
+  year = {1991},
+  journal = {Journal of Computational Physics},
+  volume = {97},
+  number = {2},
+  pages = {414--443},
+  doi = {10.1016/0021-9991(91)90007-8},
+}
+
 @article{Palha2014,
   title={Physics-compatible discretization techniques on single and dual grids, with application to the Poisson equation of volume forms},
   author={Palha, Artur and Rebelo, Pedro Pinto and Hiemstra, Ren{\'e} and Kreeft, Jasper and Gerritsma, Marc},
@@ -136,6 +179,14 @@
   year={2014},
   publisher={Elsevier},
   doi={10.1016/j.jcp.2013.08.005},
+}
+
+@phdthesis{Rattenbury2005,
+  title = {Almost {{Runge-Kutta Methods}} for {{Stiff}} and {{Non-Stiff Problems}}},
+  author = {Rattenbury, Nicolette},
+  year = 2005,
+  address = {Auckland, New Zealand},
+  school = {The University of Auckland}
 }
 
 @book{Schumaker2007,
@@ -219,6 +270,17 @@
   number = {1},
   pages = {132--150},
   doi = {10.1137/20M1389522},
+}
+
+@article{Vos2011,
+  title = {A Generic Framework for Time-Stepping Partial Differential Equations ({{PDEs}}): General Linear Methods, Object-Oriented Implementation and Application to Fluid Problems},
+  author = {Vos, Peter E.J. and Eskilsson, Claes and Bolis, Alessandro and Chun, Sehun and Kirby, Robert M. and Sherwin, Spencer J.},
+  year = 2011,
+  journal = {International Journal of Computational Fluid Dynamics},
+  volume = {25},
+  number = {3},
+  pages = {107--125},
+  doi = {10.1080/10618562.2011.575368},
 }
 
 @article{Waldvogel2006,

--- a/examples/src/GetStartTimeIntegration.jl
+++ b/examples/src/GetStartTimeIntegration.jl
@@ -1,0 +1,308 @@
+# # Getting Started with Time Integrators
+# In this example, we go through the basic setup needed when using the `TimeIntegrators`
+# module in `Mantis`. We will use a very simple ODE and show how to setup different time
+# integrators for this problem.
+
+# ## [Background knowledge](@id GSTIBackground)
+# We will consider the following ODE:
+# ```math
+#   \frac{dy}{dt} = \lambda y, \quad y(t=0) = 1.0\;,
+# ```
+# which has exact solution ``y(t) = \exp{\lambda t}``.
+# We will set ``\lambda`` as
+
+const lambda = -4
+
+# ## [Packages](@id GSTIPackages)
+# As the goal of this example is to setup basic time integration problems in `Mantis`, we
+# will only use `Mantis` for now.
+
+using Mantis
+
+# ## [Explicit Integrators](@id GSTIExplicit)
+# In this section, we will treat the [previously introduced ODE](@ref GSTIBackground) with
+# an [`TimeIntegrators.Explicit`](@ref) integrator. We will go through the setup
+# step-by-step.
+
+
+# ### [Step 1: Defining an explicit ODE](@id GSTIExplicit_1)
+# For an explicit integrator, we need to provide a function that provides the explicit part
+# of the ODE. In the terminology of the [TimeIntegrators](@ref)-module, this is the
+# function ``F``. In our case, we simply have ``F(y, t) = \lambda y``.
+#
+# This is implemented as follows.
+#
+# !!! note "Make sure to overwrite the first argument (here called `output`)."
+#     As explained in the [TimeIntegrators.`TimeIntegrationOperators`](@ref) docstring,
+#     the evaluate function for an explicit ODE should have three input arguments, and the
+#     first one must be overwritten. Not overwriting the first argument will lead to
+#     incorrect results.
+
+function ode_explicit_function(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n]
+    end
+    return nothing
+end
+
+# We can use this newly defined function and pass it to the
+# [`TimeIntegrators.define_explicit_ode`](@ref)-function, which will create the required
+# [`TimeIntegrators.TimeIntegrationOperators`](@ref) object.
+
+ode_explicit = TimeIntegrators.define_explicit_ode(ode_explicit_function)
+
+# ### [Step 2: Picking and initialising a scheme](@id GSTIExplicit_2)
+# Now we can pick an [`TimeIntegrators.Explicit`](@ref) integrator and initialise it. We
+# will pick the provided [`TimeIntegrators.RK4`](@ref) method. Since this is a multi-stage
+# but single-step method, the initialisation procedure for this integrator is simple.
+
+const method_ex = TimeIntegrators.RK4
+
+const y₀_ex = [1.0]
+const y_n_ex = TimeIntegrators.initialize_scheme(y₀_ex, method_ex)
+
+# ### [Step 3: Integrating the ODE](@id GSTIExplicit_3)
+# Now we can integrate our ODE. Say we want to integrate for 100 time steps with a time
+# step size of 0.1, then our code would look like this.
+
+const n_steps_ex = 100
+const dt_ex = 0.1
+t_ex = 0.0
+for step in 1:100
+    global t_ex
+    ## Call this function to advance the solution. Note that the input time is the current
+    ## time.
+    TimeIntegrators.time_integrate!(y_n_ex, ode_explicit, t_ex, dt_ex)
+    t_ex += dt_ex
+end
+
+
+# ### [Step 2 take 2: Picking and initialising a scheme](@id GSTIExplicit_2v2)
+# If we instead want to use a multi-step method, we will need to be a little more careful
+# when initialising the scheme. Say we pick the provided [`TimeIntegrators.AB2`](@ref)
+# method. We will also have to pick a startup scheme. In this case, we pick
+# [`TimeIntegrators.HEUN2`](@ref). Note that a startup scheme cannot be a multi-step scheme
+# itself. Also, make sure that the startup scheme is accurate enough to initialise your
+# multi-step scheme, or you may lose accuracy.
+
+const method_ex2 = TimeIntegrators.AB2
+const startup_method_ex2 = TimeIntegrators.HEUN2
+
+const y₀_ex2 = [1.0]
+const y_n_ex2 = TimeIntegrators.initialize_scheme(y₀_ex2, method_ex2, startup_method_ex2)
+
+
+
+
+# ## [Diagonally Implicit Integrators](@id GSTIDiagImplicit)
+# In this section, we will treat the [previously introduced ODE](@ref GSTIBackground) with
+# an [`TimeIntegrators.DiagonallyImplicit`](@ref) integrator. We will go through the setup
+# step-by-step.
+
+# ### [Step 1: Defining an diagonally Implicit ODE](@id GSTIDiagImplicit_1)
+# For a diagonally implicit integrator, we need to provide a solver that solves the
+# implicit part of the ODE. That is, in the terminology of the
+# [TimeIntegrators](@ref)-module, we need to solve
+# ``\mathbf{Y} - h \mathbf{g}(\mathbf{Y}) = \mathbf{x}``. If
+# ``\mathbf{g}(\mathbf{Y})`` is linear, as it is in this example, we can use a direct
+# solver. This is implemented as follows. Note that, for efficiency reasons, you may want
+# to use solver that directly overwrite the output argument. For simplicity, that is not
+# done here.
+#
+# !!! note "Make sure to overwrite the first argument (here called `output`)."
+#     As explained in the [`TimeIntegrators.TimeIntegrationOperators`](@ref) docstring, the
+#     solver function for a diagonally implicit ODE should have four input arguments, and
+#     the first one must be overwritten. Not overwriting the first argument will lead to
+#     incorrect results.
+#
+# !!! note "An implicit evaluate function may be needed."
+#     As explained in the [`TimeIntegrators.define_diagonally_implicit_ode`](@ref)
+#     docstring, if you use a multi-step scheme, you will also have to provide an implicit
+#     evaluate function.
+
+import LinearAlgebra
+function implicit_solve(output, x, h, t)
+    output .= (LinearAlgebra.I - h * lambda) \ x
+    return nothing
+end
+
+# We can use this newly defined function and pass it to the
+# [`TimeIntegrators.define_diagonally_implicit_ode`](@ref)-function, which will create the
+# required [`TimeIntegrators.TimeIntegrationOperators`](@ref) object.
+
+ode_diag_implicit = TimeIntegrators.define_diagonally_implicit_ode(implicit_solve)
+
+# ### [Step 2: Picking and initialising a scheme](@id GSTIDiagImplicit_2)
+# Now we can pick a [`TimeIntegrators.DiagonallyImplicit`](@ref) integrator and initialise
+# it. We will pick the provided [`TimeIntegrators.DIRK3`](@ref) method. Since this is a
+# multi-stage but single-step method, the initialisation procedure for this integrator is
+# simple.
+
+const method_di = TimeIntegrators.DIRK3
+
+const y₀_di = [1.0]
+const y_n_di = TimeIntegrators.initialize_scheme(y₀_di, method_di)
+
+# ### [Step 3: Integrating the ODE](@id GSTIDiagImplicit_3)
+# Now we can integrate our ODE. Say we want to integrate for 100 time steps with a time
+# step size of 0.1, then our code would look like this. Note that this has the same
+# structure as the [explicit case](@ref GSTIExplicit_3).
+
+const n_steps_di = 100
+const dt_di = 0.1
+t_di = 0.0
+for step in 1:100
+    global t_di
+    ## Call this function to advance the solution. Note that the input time is the current
+    ## time.
+    TimeIntegrators.time_integrate!(y_n_di, ode_diag_implicit, t_di, dt_di)
+    t_di += dt_di
+end
+
+
+
+
+# ## [Fully Implicit Integrators](@id GSTIImplicit)
+# In this section, we will treat the [previously introduced ODE](@ref GSTIBackground) with
+# an [`TimeIntegrators.Implicit`](@ref) integrator. We will go through the setup
+# step-by-step.
+
+# ### [Step 1: Defining an Implicit ODE](@id GSTIImplicit_1)
+# For an implicit integrator, we need to provide both a solver that solves the implicit
+# part of the ODE as well as an evaluate function for this implicit part. In the
+# terminology of the  [TimeIntegrators](@ref)-module, we need to solve
+# ``\mathbf{Y} - h \mathbf{g}(\mathbf{Y}) = \mathbf{x}``. If
+# ``\mathbf{g}(\mathbf{Y})`` is linear, as it is in this example, we can use a direct
+# solver. Note that, for efficiency reasons, you may want
+# to use solver that directly overwrite the output argument. For simplicity, that is not
+# done here. Additionally, we need to define the function ``G(y, t) = \lambda y``. This is
+# implemented as follows.
+#
+# !!! note "Make sure to overwrite the first argument (here called `output`)."
+#     As explained in the [`TimeIntegrators.TimeIntegrationOperators`](@ref) docstring, the
+#     solver function for an implicit ODE should have four input arguments, and the first
+#     one must be overwritten. Not overwriting the first argument will not lead to correct
+#     results. The evaluate function should have three argument, and the first one must
+#     also be overwritten.
+
+function implicit_solve(output, x, h, t)
+    output .= (LinearAlgebra.I - h * lambda) \ x
+    return nothing
+end
+
+function implicit_evaluate(output, y, t)
+    for n in eachindex(output, y)
+        output[n] = lambda * y[n]
+    end
+    return nothing
+end
+
+# We can use this newly defined function and pass it to the
+# [`TimeIntegrators.define_implicit_ode`](@ref)-function, which will create the required
+# [`TimeIntegrators.TimeIntegrationOperators`](@ref) object.
+
+ode_implicit = TimeIntegrators.define_implicit_ode(implicit_solve, implicit_evaluate)
+
+# ### [Step 2: Picking and initialising a scheme](@id GSTIImplicit_2)
+# Now we can pick an [`TimeIntegrators.Implicit`](@ref) integrator and initialise it. We
+# will pick the provided [`TimeIntegrators.GAUSS_LEGENDRE_4`](@ref) method. Since this is a
+# multi-stage but single-step method, the initialisation procedure for this integrator is
+# simple.
+
+const method_impl = TimeIntegrators.GAUSS_LEGENDRE_4
+
+const y₀_impl = [1.0]
+const y_n_impl = TimeIntegrators.initialize_scheme(y₀_impl, method_impl)
+
+# ### [Step 3: Integrating the ODE](@id GSTIImplicit_3)
+# Now we can integrate our ODE. Say we want to integrate for 100 time steps with a time
+# step size of 0.1, then our code would look like this. Note that this again has the same
+# structure as in the previous cases.
+
+const n_steps_impl = 100
+const dt_impl = 0.1
+t_impl = 0.0
+for step in 1:100
+    global t_impl
+    ## Call this function to advance the solution. Note that the input time is the current
+    ## time.
+    TimeIntegrators.time_integrate!(y_n_impl, ode_implicit, t_impl, dt_impl)
+    t_impl += dt_impl
+end
+
+
+
+
+# ## [IMEX Integrators](@id GSTIIMEX)
+# In this section, we will treat the [previously introduced ODE](@ref GSTIBackground) with
+# an [`TimeIntegrators.IMEX`](@ref) integrator. We will go through the setup step-by-step.
+
+# ### [Step 1: Defining an IMEX ODE](@id GSTIIMEX_1)
+# IMEX integrators can treat one part of the ODE with an implicit step, while it treat the
+# other part with an explicit step. The stiffness of the terms in your ODE often influence
+# this split. In this simple example, we introduce the following split:
+# ```math
+#     \frac{dy}{dt} = 0.5 \lambda y + 0.5 \lambda y\;.
+# ```
+# That is, the implicit and explicit parts are the same.
+#
+# For an IMEX integrator, we need to provide a function for evaluating the explicit part,
+# here ``F(y, t) = 0.5 \lambda y``, and a solver for the implicit part, just like in the
+# [diagonally implicit case](@ref GSTIDiagImplicit_1). This is implemented as follows.
+#
+# !!! note "Make sure to overwrite the first argument (here called `output`)."
+#     As explained in the [`TimeIntegrators.TimeIntegrationOperators`](@ref) docstring,
+#     the evaluate function for an explicit ODE should have three input arguments, and the
+#     first one must be overwritten. Not overwriting the first argument will not lead to
+#     correct results.
+#
+# !!! note "An implicit evaluate function may be needed."
+#     As explained in the [`TimeIntegrators.define_diagonally_implicit_ode`](@ref)
+#     docstring, if you use a multi-step scheme, you will also have to provide an implicit
+#     evaluate function.
+
+function explicit_imex_function(output, yn, t)
+    for n in axes(output, 1)
+        output[n] = 0.5 * lambda * yn[n]
+    end
+    return nothing
+end
+
+function implicit_imex_solver(output, x, h, t)
+    LinearAlgebra.ldiv!(output, LinearAlgebra.lu(LinearAlgebra.I - 0.5 * h * lambda), x)
+    return nothing
+end
+
+# We can use this newly defined function and pass it to the
+# [`TimeIntegrators.define_imex_ode`](@ref)-function, which will create the required
+# [`TimeIntegrators.TimeIntegrationOperators`](@ref) object.
+
+ode_imex = TimeIntegrators.define_imex_ode(
+    explicit_imex_function, implicit_imex_solver
+)
+
+# ### [Step 2: Picking and initialising a scheme](@id GSTIIMEX_2)
+# Now we can pick an [`TimeIntegrators.IMEX`](@ref) integrator and initialise it. We will
+# pick the provided [`TimeIntegrators.RK3_IMEX`](@ref) method. Since this is a multi-stage
+# but single-step method, the initialisation procedure for this integrator is simple.
+
+const method_imex = TimeIntegrators.RK3_IMEX
+
+const y₀_imex = [1.0]
+const y_n_imex = TimeIntegrators.initialize_scheme(y₀_imex, method_imex)
+
+# ### [Step 3: Integrating the ODE](@id GSTIIMEX_3)
+# Now we can integrate our ODE. Say we want to integrate for 100 time steps with a time
+# step size of 0.1, then our code would look like this. Note that this again has the same
+# structure as in the previous cases.
+
+const n_steps_imex = 100
+const dt_imex = 0.1
+t_imex = 0.0
+for step in 1:100
+    global t_imex
+    ## Call this function to advance the solution. Note that the input time is the current
+    ## time.
+    TimeIntegrators.time_integrate!(y_n_imex, ode_imex, t_imex, dt_imex)
+    t_imex += dt_imex
+end

--- a/examples/src/GetStartTimeIntegration.jl
+++ b/examples/src/GetStartTimeIntegration.jl
@@ -8,7 +8,7 @@
 # ```math
 #   \frac{dy}{dt} = \lambda y, \quad y(t=0) = 1.0\;,
 # ```
-# which has exact solution ``y(t) = \exp{\lambda t}``.
+# which has exact solution ``y(t) = e^{\lambda t}``.
 # We will set ``\lambda`` as
 
 const lambda = -4
@@ -24,7 +24,6 @@ using Mantis
 # an [`TimeIntegrators.Explicit`](@ref) integrator. We will go through the setup
 # step-by-step.
 
-
 # ### [Step 1: Defining an explicit ODE](@id GSTIExplicit_1)
 # For an explicit integrator, we need to provide a function that provides the explicit part
 # of the ODE. In the terminology of the [TimeIntegrators](@ref)-module, this is the
@@ -38,7 +37,7 @@ using Mantis
 #     first one must be overwritten. Not overwriting the first argument will lead to
 #     incorrect results.
 
-function ode_explicit_function(output, yn, t)
+function ode_explicit_function!(output, yn, t)
     for n in eachindex(output)
         output[n] = lambda * yn[n]
     end
@@ -49,7 +48,7 @@ end
 # [`TimeIntegrators.define_explicit_ode`](@ref)-function, which will create the required
 # [`TimeIntegrators.TimeIntegrationOperators`](@ref) object.
 
-ode_explicit = TimeIntegrators.define_explicit_ode(ode_explicit_function)
+ode_explicit = TimeIntegrators.define_explicit_ode(ode_explicit_function!)
 
 # ### [Step 2: Picking and initialising a scheme](@id GSTIExplicit_2)
 # Now we can pick an [`TimeIntegrators.Explicit`](@ref) integrator and initialise it. We
@@ -59,7 +58,7 @@ ode_explicit = TimeIntegrators.define_explicit_ode(ode_explicit_function)
 const method_ex = TimeIntegrators.RK4
 
 const y₀_ex = [1.0]
-const y_n_ex = TimeIntegrators.initialize_scheme(y₀_ex, method_ex)
+const y_n_ex = TimeIntegrators.initialise_scheme(y₀_ex, method_ex)
 
 # ### [Step 3: Integrating the ODE](@id GSTIExplicit_3)
 # Now we can integrate our ODE. Say we want to integrate for 100 time steps with a time
@@ -76,7 +75,6 @@ for step in 1:100
     t_ex += dt_ex
 end
 
-
 # ### [Step 2 take 2: Picking and initialising a scheme](@id GSTIExplicit_2v2)
 # If we instead want to use a multi-step method, we will need to be a little more careful
 # when initialising the scheme. Say we pick the provided [`TimeIntegrators.AB2`](@ref)
@@ -89,10 +87,7 @@ const method_ex2 = TimeIntegrators.AB2
 const startup_method_ex2 = TimeIntegrators.HEUN2
 
 const y₀_ex2 = [1.0]
-const y_n_ex2 = TimeIntegrators.initialize_scheme(y₀_ex2, method_ex2, startup_method_ex2)
-
-
-
+const y_n_ex2 = TimeIntegrators.initialise_scheme(y₀_ex2, method_ex2, startup_method_ex2)
 
 # ## [Diagonally Implicit Integrators](@id GSTIDiagImplicit)
 # In this section, we will treat the [previously introduced ODE](@ref GSTIBackground) with
@@ -117,11 +112,11 @@ const y_n_ex2 = TimeIntegrators.initialize_scheme(y₀_ex2, method_ex2, startup_
 #
 # !!! note "An implicit evaluate function may be needed."
 #     As explained in the [`TimeIntegrators.define_diagonally_implicit_ode`](@ref)
-#     docstring, if you use a multi-step scheme, you will also have to provide an implicit
-#     evaluate function.
+#     docstring, if you use a multi-step scheme or a scheme with zeros on the diagonal, you
+#     will also have to provide an implicit evaluate function.
 
 import LinearAlgebra
-function implicit_solve(output, x, h, t)
+function implicit_solve!(output, x, h, t)
     output .= (LinearAlgebra.I - h * lambda) \ x
     return nothing
 end
@@ -130,7 +125,7 @@ end
 # [`TimeIntegrators.define_diagonally_implicit_ode`](@ref)-function, which will create the
 # required [`TimeIntegrators.TimeIntegrationOperators`](@ref) object.
 
-ode_diag_implicit = TimeIntegrators.define_diagonally_implicit_ode(implicit_solve)
+ode_diag_implicit = TimeIntegrators.define_diagonally_implicit_ode(implicit_solve!)
 
 # ### [Step 2: Picking and initialising a scheme](@id GSTIDiagImplicit_2)
 # Now we can pick a [`TimeIntegrators.DiagonallyImplicit`](@ref) integrator and initialise
@@ -141,7 +136,7 @@ ode_diag_implicit = TimeIntegrators.define_diagonally_implicit_ode(implicit_solv
 const method_di = TimeIntegrators.DIRK3
 
 const y₀_di = [1.0]
-const y_n_di = TimeIntegrators.initialize_scheme(y₀_di, method_di)
+const y_n_di = TimeIntegrators.initialise_scheme(y₀_di, method_di)
 
 # ### [Step 3: Integrating the ODE](@id GSTIDiagImplicit_3)
 # Now we can integrate our ODE. Say we want to integrate for 100 time steps with a time
@@ -159,9 +154,6 @@ for step in 1:100
     t_di += dt_di
 end
 
-
-
-
 # ## [Fully Implicit Integrators](@id GSTIImplicit)
 # In this section, we will treat the [previously introduced ODE](@ref GSTIBackground) with
 # an [`TimeIntegrators.Implicit`](@ref) integrator. We will go through the setup
@@ -174,7 +166,7 @@ end
 # ``\mathbf{Y} - h \mathbf{g}(\mathbf{Y}) = \mathbf{x}``. If
 # ``\mathbf{g}(\mathbf{Y})`` is linear, as it is in this example, we can use a direct
 # solver. Note that, for efficiency reasons, you may want
-# to use solver that directly overwrite the output argument. For simplicity, that is not
+# to use a solver that directly overwrites the output argument. For simplicity, that is not
 # done here. Additionally, we need to define the function ``G(y, t) = \lambda y``. This is
 # implemented as follows.
 #
@@ -185,12 +177,12 @@ end
 #     results. The evaluate function should have three argument, and the first one must
 #     also be overwritten.
 
-function implicit_solve(output, x, h, t)
+function implicit_solve!(output, x, h, t)
     output .= (LinearAlgebra.I - h * lambda) \ x
     return nothing
 end
 
-function implicit_evaluate(output, y, t)
+function implicit_evaluate!(output, y, t)
     for n in eachindex(output, y)
         output[n] = lambda * y[n]
     end
@@ -201,7 +193,7 @@ end
 # [`TimeIntegrators.define_implicit_ode`](@ref)-function, which will create the required
 # [`TimeIntegrators.TimeIntegrationOperators`](@ref) object.
 
-ode_implicit = TimeIntegrators.define_implicit_ode(implicit_solve, implicit_evaluate)
+ode_implicit = TimeIntegrators.define_implicit_ode(implicit_solve!, implicit_evaluate!)
 
 # ### [Step 2: Picking and initialising a scheme](@id GSTIImplicit_2)
 # Now we can pick an [`TimeIntegrators.Implicit`](@ref) integrator and initialise it. We
@@ -212,7 +204,7 @@ ode_implicit = TimeIntegrators.define_implicit_ode(implicit_solve, implicit_eval
 const method_impl = TimeIntegrators.GAUSS_LEGENDRE_4
 
 const y₀_impl = [1.0]
-const y_n_impl = TimeIntegrators.initialize_scheme(y₀_impl, method_impl)
+const y_n_impl = TimeIntegrators.initialise_scheme(y₀_impl, method_impl)
 
 # ### [Step 3: Integrating the ODE](@id GSTIImplicit_3)
 # Now we can integrate our ODE. Say we want to integrate for 100 time steps with a time
@@ -230,17 +222,14 @@ for step in 1:100
     t_impl += dt_impl
 end
 
-
-
-
 # ## [IMEX Integrators](@id GSTIIMEX)
 # In this section, we will treat the [previously introduced ODE](@ref GSTIBackground) with
 # an [`TimeIntegrators.IMEX`](@ref) integrator. We will go through the setup step-by-step.
 
 # ### [Step 1: Defining an IMEX ODE](@id GSTIIMEX_1)
-# IMEX integrators can treat one part of the ODE with an implicit step, while it treat the
-# other part with an explicit step. The stiffness of the terms in your ODE often influence
-# this split. In this simple example, we introduce the following split:
+# IMEX integrators can treat one part of the ODE with an implicit step, while treating the
+# rest with an explicit step. The stiffness of the terms in your ODE often influences this
+# split. In this simple example, we introduce the following split:
 # ```math
 #     \frac{dy}{dt} = 0.5 \lambda y + 0.5 \lambda y\;.
 # ```
@@ -257,19 +246,26 @@ end
 #     correct results.
 #
 # !!! note "An implicit evaluate function may be needed."
-#     As explained in the [`TimeIntegrators.define_diagonally_implicit_ode`](@ref)
-#     docstring, if you use a multi-step scheme, you will also have to provide an implicit
-#     evaluate function.
+#     As explained in the [`TimeIntegrators.define_imex_ode`](@ref) docstring, if you use a
+#     multi-step scheme or a scheme with zeros on the diagonal (as done here), you will
+#     also have to provide an implicit evaluate function.
 
-function explicit_imex_function(output, yn, t)
+function explicit_imex_function!(output, yn, t)
     for n in axes(output, 1)
         output[n] = 0.5 * lambda * yn[n]
     end
     return nothing
 end
 
-function implicit_imex_solver(output, x, h, t)
+function implicit_imex_solver!(output, x, h, t)
     LinearAlgebra.ldiv!(output, LinearAlgebra.lu(LinearAlgebra.I - 0.5 * h * lambda), x)
+    return nothing
+end
+
+function implicit_imex_function!(output, yn, t)
+    for n in axes(output, 1)
+        output[n] = 0.5 * lambda * yn[n]
+    end
     return nothing
 end
 
@@ -278,7 +274,7 @@ end
 # [`TimeIntegrators.TimeIntegrationOperators`](@ref) object.
 
 ode_imex = TimeIntegrators.define_imex_ode(
-    explicit_imex_function, implicit_imex_solver
+    explicit_imex_function!, implicit_imex_solver!, implicit_imex_function!
 )
 
 # ### [Step 2: Picking and initialising a scheme](@id GSTIIMEX_2)
@@ -289,7 +285,7 @@ ode_imex = TimeIntegrators.define_imex_ode(
 const method_imex = TimeIntegrators.RK3_IMEX
 
 const y₀_imex = [1.0]
-const y_n_imex = TimeIntegrators.initialize_scheme(y₀_imex, method_imex)
+const y_n_imex = TimeIntegrators.initialise_scheme(y₀_imex, method_imex)
 
 # ### [Step 3: Integrating the ODE](@id GSTIIMEX_3)
 # Now we can integrate our ODE. Say we want to integrate for 100 time steps with a time

--- a/examples/src/HeatEquation.jl
+++ b/examples/src/HeatEquation.jl
@@ -124,7 +124,6 @@
 #    where the function space ``W_n`` consists of spatially-varying functions in ``V_n``
 #    that satisfy homogeneous (or, equivalently, zero) boundary conditions.
 
-
 # ## The finite element method
 
 # Now we are at a stage where, if we make a choice for ``V_n``, we can convert the discrete
@@ -166,7 +165,8 @@
 # ```
 # for some numbers ``c_i \in \mathbb{R}``.
 #
-# > **EXAMPLE:** ``V_n`` with ``(N,p,k) = (4, 1, 0)``.
+# ::: details EXAMPLE: ``V_n`` with ``(N,p,k) = (4, 1, 0)``.
+#
 # Consider the space of functions that are linear polynomials over each mesh element, and
 # which are ``C^0`` smooth (or, equivalently, continuous) at the interfaces ``x_i``
 # between the elements. This space of functions has dimension:
@@ -184,66 +184,36 @@ using GLMakie
 using DisplayAs #hide
 
 ## The size of the domain where to solve our problem
-L = 1.0
+L1 = 1.0
 
 ## The degree of the piecewise-polynomial basis functions
-p = 1
+p1 = 1
 ## The number of elements in the mesh
-N = 4
+N1 = 4
 ## The smoothness of the basis functions (must be smaller than the polynomial degree, and
 ## larger than -1)
-k = 0
+k1 = 0
 
 ## The number of basis functions in the piecewise-polynomial function space
-n = N * (p + 1) - (k + 1) * (N - 1)
+n1 = N1 * (p1 + 1) - (k1 + 1) * (N1 - 1)
 
 ## Create the mesh and the function space
-breakpoints = LinRange(0.0, L, N+1)
-line_geo = Geometry.CartesianGeometry((breakpoints,))
-B = FunctionSpaces.BSplineSpace(line_geo, p, k)
+breakpoints1 = LinRange(0.0, L1, N1+1)
+line_geo1 = Geometry.CartesianGeometry((breakpoints1,))
+B1 = FunctionSpaces.BSplineSpace(line_geo1, p1, k1)
 
-## Create a Form Space.
-BF = Forms.FormSpace(0, B, "b")
-
-## Plot the basis functions.
-n_plot_points_per_element = 25
-
-fig = Figure()
-ax = Axis(fig[1, 1],
-    title = "Basis functions of V_n",
-    xlabel = "x",
-    ylabel = "b_i(x)",
+fig1 = Mantis.Plot.plot_basis(
+    B1;
+    label_prefix=L"\phi_",
+    title=L"\text{Basis functions of }V_n",
+    xlabel=L"x",
+    ylabel=L"\phi_i(x)",
 )
-
-n_elements = Geometry.get_num_elements(line_geo)
-xi = Points.CartesianPoints((LinRange(0.0, 1.0, n_plot_points_per_element),))
-BFF = Forms.FormField(BF)
-
-dim_V = Forms.get_num_basis(BF)
-colors = [:blue, :green, :red, :purple, :orange]
-for basis_idx in 1:dim_V
-
-    BFF.coefficients[basis_idx] = 1.0
-    if basis_idx > 1
-        BFF.coefficients[basis_idx - 1] = 0.0
-    end
-
-    color_i = colors[basis_idx]
-
-    for element_idx in 1:n_elements
-        form_eval, _ = Forms.evaluate(BFF, element_idx, xi)
-        x = Geometry.evaluate(Forms.get_geometry(BF), element_idx, xi)
-
-        lines!(ax, x[:], form_eval[1], color=color_i, label=L"\phi_{%$basis_idx}")
-
-        scatter!(ax, x[:][[1, end]], [0.0, 0.0], color=:tomato)
-    end
-end
-fig[1, 2] = Legend(fig, ax, marge=true, unique=true)
-
-fig = DisplayAs.Text(DisplayAs.PNG(fig))
-
-# > **EXAMPLE:** ``V_n`` with ``(N,p,k) = (4, 2, 1)``.
+fig1 = DisplayAs.Text(DisplayAs.PNG(fig1)) #hide
+# :::
+#
+# ::: details EXAMPLE: ``V_n`` with ``(N,p,k) = (4, 2, 1)``.
+#
 # Consider now the space of functions that are quadratic polynomials over each mesh
 # element, and which are ``C^1`` smooth (or, equivalently, continuous and continuously
 # differentiable) at the interfaces ``x_i`` between the elements. This space of functions
@@ -255,51 +225,22 @@ fig = DisplayAs.Text(DisplayAs.PNG(fig))
 # space ``V_n``. Run the code below to create such a ``V_n`` and look at one such choice of
 # the basis functions called *B-splines*. (Each function is plotted in a different color.)
 
+p2 = 2
+k2 = 1
+n2 = N1 * (p2 + 1) - (k2 + 1) * (N1 - 1)
 
-p = 2
-k = 1
-n = N * (p + 1) - (k + 1) * (N - 1)
+B2 = FunctionSpaces.BSplineSpace(line_geo1, p2, k2)
 
-B = FunctionSpaces.BSplineSpace(line_geo, p, k)
-
-## Create a Form Space.
-BF = Forms.FormSpace(0, B, "b")
-
-fig = Figure()
-ax = Axis(fig[1, 1],
-    title = "Basis functions of V_n",
-    xlabel = "x",
-    ylabel = "b_i(x)",
+fig2 = Mantis.Plot.plot_basis(
+    B2;
+    label_prefix=L"\phi_",
+    title=L"\text{Basis functions of }V_n",
+    xlabel=L"x",
+    ylabel=L"\phi_i(x)",
 )
-
-n_elements = Geometry.get_num_elements(line_geo)
-xi = Points.CartesianPoints((LinRange(0.0, 1.0, n_plot_points_per_element),))
-BFF = Forms.FormField(BF)
-
-dim_V = Forms.get_num_basis(BF)
-colors = [:blue, :green, :red, :purple, :orange, :black]
-for basis_idx in 1:dim_V
-
-    BFF.coefficients[basis_idx] = 1.0
-    if basis_idx > 1
-        BFF.coefficients[basis_idx - 1] = 0.0
-    end
-
-    color_i = colors[basis_idx]
-
-    for element_idx in 1:n_elements
-        form_eval, _ = Forms.evaluate(BFF, element_idx, xi)
-        x = Geometry.evaluate(Forms.get_geometry(BF), element_idx, xi)
-
-        lines!(ax, x[:], form_eval[1], color=color_i, label=L"\phi_{%$basis_idx}")
-
-        scatter!(ax, x[:][[1, end]], [0.0, 0.0], color=:tomato)
-    end
-end
-fig[1, 2] = Legend(fig, ax, marge=true, unique=true)
-
-fig = DisplayAs.Text(DisplayAs.PNG(fig))
-
+fig2 = DisplayAs.Text(DisplayAs.PNG(fig2)) #hide
+# :::
+#
 # > **Note:** In both of the above examples, the only functions non-zero at ``x=0`` and
 # > ``x=L`` are ``\phi_1`` and ``\phi_n``. This means that, in particular, the functions
 # > ``\phi_2, \dots, \phi_{n-1}`` form a basis for ``W_n``. We will use this fact later on.
@@ -397,5 +338,226 @@ fig = DisplayAs.Text(DisplayAs.PNG(fig))
 # f(x, t) = \frac{2\alpha\pi^{2}}{L^{2}}\cos\left(\frac{2\pi}{L} x\right)\,.
 # ```
 # We choose a finite element space with ``(N,p,k) = (10,2,1)``, i.e., with more elements
-#  compared to the last example. This is to ensure that we have sufficient accuracy for
+# compared to the last example. This is to ensure that we have sufficient accuracy for
 # computing a decent solution.
+
+## The size of the domain where to solve our problem
+L = 1.0
+## The number of elements in the mesh
+num_elements = 10
+line_geometry = Geometry.create_cartesian_box((0.0,), (L,), (num_elements,))
+
+## The degree of the piecewise-polynomial basis functions
+polynomial_degree = 2
+## The smoothness of the basis functions (-1 <= smoothness <= p-1)
+smoothness = 1
+
+## The piecewise-polynomial function space
+V = FunctionSpaces.BSplineSpace(line_geometry, polynomial_degree, smoothness)
+## The number of basis functions in the piecewise-polynomial function space
+num_basis_functions = FunctionSpaces.get_num_basis(V)
+
+## Use this function space as a differential form
+V⁰ = Forms.FormSpace(0, V, L"V^0")
+
+## Thermal diffusivity
+const alpha = 1.0
+
+## Analytical solution
+u_analytical_expression(x) = [1.0 .+ 0.5*cos.((2.0*π/L)*x[:, 1])]
+u_analytical = Mantis.Forms.AnalyticalFormField(
+    0, u_analytical_expression, line_geometry, L"u_{\text{exact}}"
+)
+
+## Right hand side
+f_expression(x) = [@. alpha*0.5*(4.0*(π^2)/(L^2))*cos(2.0*π*x[:, 1]/L)]
+f = Mantis.Forms.AnalyticalFormField(0, f_expression, line_geometry, "f")
+
+function assemble_system_matrices(
+    V::Forms.FormSpace,
+    f::Forms.AnalyticalFormField,
+    alpha::Float64,
+    dΩ::Quadrature.AbstractQuadratureRule,
+)
+    ## assemble L2 inner-product matrix
+    weak_form_inputs = Assemblers.WeakFormInputs(V, f)
+    lhs_expressions, rhs_expressions = Assemblers.L2_projection(weak_form_inputs, dΩ)
+    weak_form = Assemblers.WeakForm(lhs_expressions, rhs_expressions, weak_form_inputs)
+    M, _ = Assemblers.assemble(weak_form)
+
+    ## assemble H1 inner-product matrix
+    weak_form_inputs = Assemblers.WeakFormInputs(V, f)
+    lhs_expressions, rhs_expressions = Assemblers.zero_form_hodge_laplacian(
+        weak_form_inputs, dΩ
+    )
+    weak_form = Assemblers.WeakForm(lhs_expressions, rhs_expressions, weak_form_inputs)
+    ## bc = Forms.set_dirichlet_boundary_conditions(V, 0.0)
+    K, f = Assemblers.assemble(weak_form)
+
+    return M, alpha .* K, f
+end
+
+## Define the quadrature
+quadrature_degree = polynomial_degree + 2
+∫ = Quadrature.gauss_legendre(quadrature_degree)
+dΩ = Quadrature.StandardQuadrature(∫, num_elements)
+
+## Assemble the matrices
+M, K, F = assemble_system_matrices(V⁰, f, alpha, dΩ)
+
+## Remove the unecessary parts of the matrices
+F = Vector(F[2:(end - 1)])
+
+K_0 = Vector(K[2:(end - 1), 1])
+K_L = Vector(K[2:(end - 1), end])
+
+M = M[2:(end - 1), 2:(end - 1)]
+K = K[2:(end - 1), 2:(end - 1)]
+
+## Boundary conditions
+u_0 = 1.5
+u_L = 1.5
+
+## Solution field
+u_h = Mantis.Forms.FormField(V⁰, zeros(Forms.get_num_basis(V⁰)), "u_h")
+
+## With boundary values set
+u_h.coefficients[1] = u_0
+u_h.coefficients[end] = u_L
+
+## Solve for the unknown coefficients
+u_h.coefficients[2:(end - 1)] = K \ (F - u_0*K_0 - u_L*K_L)
+
+## Plot the error with respect to the analytical solution
+error = u_analytical - u_h
+
+## Compute the error norm
+error_nom = Analysis.L2_norm(error, dΩ)
+
+# ## Time Integration
+
+# We will now consider a specific time integrator to evolve our solution in time: the
+# midpoint rule.
+#
+# The midpoint rule is the lowest order Gauss integrator and, for linear systems (as is our
+# case), is an explicit integrator. Additionally, it can be interpreted as a Runge-Kutta
+# method (i.e., it has an associated Butcher tableau). Given a first order ODE in the time
+# interval ``(0, T)``
+# ```math
+#     \frac{\mathrm{d}g}{\mathrm{d}t} = f(t, g(t))
+# ```
+# with initial condition ``g(0) = g_{0}``, the midpoint rule to evolve the solution from
+# the time instant ``t_{k}`` to the time instant ``t_{k+1} = t_{k} + \Delta t`` is
+# ```math
+#     g_{k+1} = g_{k} + \Delta t\, f\left(t + \frac{\Delta t}{2}, \frac{g_{k+1} + g_{k}}{2}\right)\,.
+# ```
+# where ``g_{k} = g(k\Delta t)``.
+#
+# The spatial discretisation process has left us with the following system of ODEs:
+# ```math
+# \mathbf{M}\frac{d\mathbf{C}}{dt} = - \mathbf{K} \mathbf{C} + \mathbf{F} - u_{0}\mathbf{F}^{b,0} - u_{L}\mathbf{F}^{b,L}\;.
+# ```
+# We can integrate this in time using the pre-implemented midpoint rule.
+#
+# !!! note "Explicit ODE with a matrix solve"
+#     While the integrator is considered explicit, this only holds for simple ODEs. In our
+#     case, we have a coupled system of ODEs, so that we do have to use a matrix solver.
+
+## Time step size and final time.
+const dt = 0.001
+const num_time_steps = 501
+
+## Here, we encode the ODE information for the time integrator. We are using LinearSolve's
+## ability to cachee the factorised M matrix. Since this matrix does not change per
+## timestep, we can reuse the factorisation. This is more efficient than refactorising every
+## step.
+import LinearSolve as LS
+const prob = LS.LinearProblem(M, zeros(Forms.get_num_basis(V⁰)-2))
+const linsolve = LS.init(prob)
+function heat_equation_solver(output, C::Vector{Float64}, t::Float64)
+    linsolve.b = (-K * C + F - u_0 * K_0 - u_L * K_L)
+    output .= LS.solve!(linsolve)
+    return output
+end
+const heat_equation = TimeIntegrators.define_explicit_ode(heat_equation_solver)
+
+scheme = TimeIntegrators.EXPLICIT_MIDPOINT
+
+## We also create a helper function to easily evaluate our solution.
+function evaluate_solution(u_h)
+    geometry = Forms.get_geometry(u_h)
+    num_elements = Geometry.get_num_elements(geometry)
+    xi = Points.CartesianPoints((LinRange(0.0, 1.0, 25),))
+    all_x = Vector{Float64}(undef, 25 * num_elements)
+    all_values = Vector{Float64}(undef, 25 * num_elements)
+    for element_id in 1:num_elements
+        form_eval, _ = Forms.evaluate(u_h, element_id, xi)
+        x = Geometry.evaluate(geometry, element_id, xi)
+
+        all_x[((element_id - 1) * 25 + 1):((element_id) * 25)] = x[:]
+        all_values[((element_id - 1) * 25 + 1):((element_id) * 25)] = form_eval[1]
+    end
+
+    return all_x, all_values
+end
+
+## We project the initial condition onto our form space
+u_initial_expression(x) = [@. 1.5 + sin((2.0*π/L)*x[:, 1])]
+u_initial = Forms.AnalyticalFormField(0, u_initial_expression, line_geometry, "u")
+u_hi = Assemblers.solve_L2_projection(V⁰, u_initial, dΩ)
+
+## Enforce the boundary condition on the initial condition, just in case the initial
+## condition does not satisfy the boundary conditions already
+u_hi.coefficients[1] = u_0
+u_hi.coefficients[end] = u_L
+
+## Initialise the time scheme
+const u_h_n = TimeIntegrators.initialize_scheme(u_hi.coefficients[2:(end - 1)], scheme)
+
+# Now we are set to march our equation in time. We will also create a video, which is why
+# we set up the time `Observable`. The `all_y` variable is a lift, which is `Makie`'s way
+# of expressing a depency. That is, as soon as we update `time`, `Makie` will automatically
+# update all other variables in the plot that depend on `time`. In our case, this is the
+# `all_y` variable, which calls `TimeIntegrators.time_integrate!` to advance our solution.
+
+## We use Printf to print the time in our animation.
+using Printf
+
+time = Observable(dt)
+
+all_y = lift(time) do t
+    TimeIntegrators.time_integrate!(u_h_n, heat_equation, t, dt)
+
+    u_hi.coefficients[2:(end - 1)] = TimeIntegrators.get_solution(u_h_n)
+
+    all_x, all_values = evaluate_solution(u_hi)
+
+    return all_values
+end
+
+all_x, all_values = evaluate_solution(u_hi)
+fig = lines(
+    all_x,
+    all_y;
+    color=:blue,
+    axis=(
+        title=@lift("t = $(@sprintf("%0.2f", round($time, digits = 2)))"),
+        limits=(0.0, 1.0, 0.0, 3.0),
+    ),
+)
+
+xe, ye = evaluate_solution(u_analytical)
+lines!(xe, ye; color=:black, label="exact")
+
+record(
+    fig,
+    "heat_equation_1d.mp4",
+    LinRange(dt, dt*num_time_steps, num_time_steps);
+    framerate=30,
+) do t
+    time[] = t
+end
+
+# ```@raw html
+# <video autoplay loop muted playsinline controls src="./heat_equation_1d.mp4" />
+# ```

--- a/examples/src/HeatEquation.jl
+++ b/examples/src/HeatEquation.jl
@@ -148,7 +148,7 @@
 # ##### Defining ``V_n``
 
 # The space ``V_n`` is defined as the space of functions ``v_n`` such that:
-# * on any element (i.e., on the interval ``(x_{i}, x_{i+1})`` ``with i = 1, \dots, N``) it
+# * on any element (i.e., on the interval ``(x_{i}, x_{i+1})`` with ``i = 1, \dots, N``) it
 #   is a polynomial of degree ``p``,
 # * at each ``x_i``, ``i = 2, \dots, N``, the function ``v_n`` is ``C^k`` smooth for some
 #   ``k \geq 0``.
@@ -468,7 +468,7 @@ const dt = 0.001
 const num_time_steps = 501
 
 ## Here, we encode the ODE information for the time integrator. We are using LinearSolve's
-## ability to cachee the factorised M matrix. Since this matrix does not change per
+## ability to cache the factorised M matrix. Since this matrix does not change per
 ## timestep, we can reuse the factorisation. This is more efficient than refactorising every
 ## step.
 import LinearSolve as LS
@@ -512,13 +512,14 @@ u_hi.coefficients[1] = u_0
 u_hi.coefficients[end] = u_L
 
 ## Initialise the time scheme
-const u_h_n = TimeIntegrators.initialize_scheme(u_hi.coefficients[2:(end - 1)], scheme)
+const u_h_n = TimeIntegrators.initialise_scheme(u_hi.coefficients[2:(end - 1)], scheme)
 
 # Now we are set to march our equation in time. We will also create a video, which is why
 # we set up the time `Observable`. The `all_y` variable is a lift, which is `Makie`'s way
-# of expressing a depency. That is, as soon as we update `time`, `Makie` will automatically
-# update all other variables in the plot that depend on `time`. In our case, this is the
-# `all_y` variable, which calls `TimeIntegrators.time_integrate!` to advance our solution.
+# of expressing a dependency. That is, as soon as we update `time`, `Makie` will
+# automatically update all other variables in the plot that depend on `time`. In our case,
+# this is the `all_y` variable, which calls `TimeIntegrators.time_integrate!` to advance
+# our solution.
 
 ## We use Printf to print the time in our animation.
 using Printf
@@ -555,7 +556,7 @@ record(
     LinRange(dt, dt*num_time_steps, num_time_steps);
     framerate=30,
 ) do t
-    time[] = t
+    return time[] = t
 end
 
 # ```@raw html

--- a/examples/src/LorenzAttractor.jl
+++ b/examples/src/LorenzAttractor.jl
@@ -1,0 +1,144 @@
+# # Lorenz Attractor
+
+# ## [Background knowledge](@id LorenzBackground)
+# The [Lorenz system](https://en.wikipedia.org/wiki/Lorenz_system) is well-known system of
+# three non-linear ODEs. It is defined by the following system of equations
+# ```math
+# \begin{cases}
+#   \frac{\partial x}{\partial t} = \sigma (y - x) \;, \\
+#   \frac{\partial y}{\partial t} = x (\rho - z) \;, \\
+#   \frac{\partial z}{\partial t} = x y - \beta z\;,
+# \end{cases}
+# ```
+# where ``x``, ``y``, and ``z`` are the coordinates in 3D space, ``t`` is the time, and
+# ``\sigma``, ``\rho``, and ``\beta`` are constants.
+#
+# In this example, we will solve the above system using an implicit time integrator and the
+# Newton-Rhapson method for the non-linearities.
+
+# ## [Implementation](@id ThreeBodyImplementation)
+# In this section, we will implement the above Lorenz system using the `TimeIntegrators`
+# module within `Mantis`.
+#
+# ### [Packages](@id ThreeBodyPackages)
+# In this example, we will use `Mantis` for the integration, `GLMakie` to create an
+# animation, `Printf` to easily create a nicely formatted title for the animation,
+# `StaticArrays` for efficiently storing small arrays, and LinearAlgebra to make use of the
+# identity matrix. So, we are `using` these five packages.
+
+using Mantis
+using GLMakie
+using Printf
+using StaticArrays
+using LinearAlgebra
+
+# ### [Test case](@id LorenzTestCase)
+# In this example, we will consider the 'butterfly'-shaped solutions with the parameters as
+# shown in the code.
+
+const σ = 10
+const ρ = 28
+const β = 8/3
+
+# ### [Setting up the ODE](@id LorenzODESetup)
+# The ODEs as described in the [background section](@ref LorenzBackground) need to be
+# implemented. In this case, the ODEs themselves are relatively simple to implement. Next
+# to the ODEs, we also create the Jacobian of the system, which will be used in the
+# Newton-Rhapson method.
+
+function g(sol)
+    x = sol[1]
+    y = sol[2]
+    z = sol[3]
+    return [σ * (y - x), x * (ρ - z) - y, x * y - β * z]
+end
+
+function J(sol)
+    x, y, z = sol
+
+    ## Note that SMatrix creates a matrix per column.
+    return SMatrix{3,3}(-σ, ρ-z, y, σ, -1.0, x, 0.0, -x, -β)
+end
+
+function newton_rhapson(
+    output, x, h, g, jacobian, t; eps=1e-14, iter=10,
+)
+    for i in eachindex(output, x)
+        output[i] = x[i]
+    end
+
+    for i in 1:iter
+        residual = output - x - h * g(output)
+        if all(r -> abs(r) < eps, residual)
+            return output
+        end
+        diff = -(I - h * jacobian(output)) \ residual
+        output .+= diff
+    end
+
+    return output
+end
+
+# With these functions, we can now define the implicit ode in `Mantis`.
+
+const ode = TimeIntegrators.define_implicit_ode(
+    (output, x, h, t) -> newton_rhapson(output, x, h, g, J, t), g
+)
+
+# ### [Time integration](@id LorenzTimeIntegration)
+# We can now setup the time integrator of our choosing. We are solving an implicit system,
+# so we should choose a diagonally (or fully) implicit integrator.
+
+const method = TimeIntegrators.DIRK3
+
+y₀ = [0.1, 0.0, 0.0]
+const y_n = TimeIntegrators.initialize_scheme(y₀, method)
+const dt = 1e-2
+const n_steps = 10000
+
+# The remaining code is almost all for the visualisation.
+
+steps = Observable(1)
+position_vec = Point3f[]
+colour_vec = Int[]
+colours = lift(steps) do step
+    push!(colour_vec, step)
+
+    return colour_vec
+end
+integrator = lift(steps) do step
+    ## Here we advance our solution.
+    TimeIntegrators.time_integrate!(
+        y_n, ode, (step-1)*dt, dt
+    )
+    push!(position_vec, Point3f(vec(TimeIntegrators.get_solution(y_n))))
+
+    return position_vec[1:step]
+end
+
+
+fig, ax, line = lines(
+    integrator,
+    color = colours,
+    colormap = Reverse(:copper),
+    transparency = true,
+    axis = (;
+        type = Axis3,
+        protrusions = (0, 0, 0, 0),
+        title=@lift("t = $(@sprintf("%0.2f", round(($steps-1)*dt, digits = 2)))"),
+        viewmode = :fit,
+        limits = (-30, 30, -30, 30, 0, 50),
+        azimuth = 1.7pi,
+    ),
+)
+line.colorrange = (0, n_steps)
+
+record(
+    fig, "lorenz_attractor.mp4", 1:n_steps; framerate=144
+) do step
+    steps[] = step
+end
+
+# ```@raw html
+# <video autoplay loop muted playsinline controls src="./lorenz_attractor.mp4" />
+# ```

--- a/examples/src/LorenzAttractor.jl
+++ b/examples/src/LorenzAttractor.jl
@@ -5,9 +5,9 @@
 # three non-linear ODEs. It is defined by the following system of equations
 # ```math
 # \begin{cases}
-#   \frac{\partial x}{\partial t} = \sigma (y - x) \;, \\
-#   \frac{\partial y}{\partial t} = x (\rho - z) \;, \\
-#   \frac{\partial z}{\partial t} = x y - \beta z\;,
+#   \frac{\mathrm{d} x}{\mathrm{d} t} = \sigma (y - x) \;, \\
+#   \frac{\mathrm{d} y}{\mathrm{d} t} = x (\rho - z) - y \;, \\
+#   \frac{\mathrm{d} z}{\mathrm{d} t} = x y - \beta z\;,
 # \end{cases}
 # ```
 # where ``x``, ``y``, and ``z`` are the coordinates in 3D space, ``t`` is the time, and
@@ -23,8 +23,8 @@
 # ### [Packages](@id ThreeBodyPackages)
 # In this example, we will use `Mantis` for the integration, `GLMakie` to create an
 # animation, `Printf` to easily create a nicely formatted title for the animation,
-# `StaticArrays` for efficiently storing small arrays, and LinearAlgebra to make use of the
-# identity matrix. So, we are `using` these five packages.
+# `StaticArrays` for efficiently storing small arrays, and `LinearAlgebra` to make use of
+# the identity matrix. So, we are `using` these five packages.
 
 using Mantis
 using GLMakie
@@ -57,12 +57,10 @@ function J(sol)
     x, y, z = sol
 
     ## Note that SMatrix creates a matrix per column.
-    return SMatrix{3,3}(-σ, ρ-z, y, σ, -1.0, x, 0.0, -x, -β)
+    return SMatrix{3, 3}(-σ, ρ-z, y, σ, -1.0, x, 0.0, -x, -β)
 end
 
-function newton_rhapson(
-    output, x, h, g, jacobian, t; eps=1e-14, iter=10,
-)
+function newton_rhapson(output, x, h, g, jacobian, t; eps=1e-14, iter=10)
     for i in eachindex(output, x)
         output[i] = x[i]
     end
@@ -92,7 +90,7 @@ const ode = TimeIntegrators.define_implicit_ode(
 const method = TimeIntegrators.DIRK3
 
 y₀ = [0.1, 0.0, 0.0]
-const y_n = TimeIntegrators.initialize_scheme(y₀, method)
+const y_n = TimeIntegrators.initialise_scheme(y₀, method)
 const dt = 1e-2
 const n_steps = 10000
 
@@ -108,35 +106,30 @@ colours = lift(steps) do step
 end
 integrator = lift(steps) do step
     ## Here we advance our solution.
-    TimeIntegrators.time_integrate!(
-        y_n, ode, (step-1)*dt, dt
-    )
+    TimeIntegrators.time_integrate!(y_n, ode, (step-1)*dt, dt)
     push!(position_vec, Point3f(vec(TimeIntegrators.get_solution(y_n))))
 
     return position_vec[1:step]
 end
 
-
 fig, ax, line = lines(
-    integrator,
-    color = colours,
-    colormap = Reverse(:copper),
-    transparency = true,
-    axis = (;
-        type = Axis3,
-        protrusions = (0, 0, 0, 0),
+    integrator;
+    color=colours,
+    colormap=Reverse(:copper),
+    transparency=true,
+    axis=(;
+        type=Axis3,
+        protrusions=(0, 0, 0, 0),
         title=@lift("t = $(@sprintf("%0.2f", round(($steps-1)*dt, digits = 2)))"),
-        viewmode = :fit,
-        limits = (-30, 30, -30, 30, 0, 50),
-        azimuth = 1.7pi,
+        viewmode=:fit,
+        limits=(-30, 30, -30, 30, 0, 50),
+        azimuth=1.7pi,
     ),
 )
 line.colorrange = (0, n_steps)
 
-record(
-    fig, "lorenz_attractor.mp4", 1:n_steps; framerate=144
-) do step
-    steps[] = step
+record(fig, "lorenz_attractor.mp4", 1:n_steps; framerate=144) do step
+    return steps[] = step
 end
 
 # ```@raw html

--- a/examples/src/ThreeBodyProblem.jl
+++ b/examples/src/ThreeBodyProblem.jl
@@ -4,16 +4,16 @@
 # The [three-body problem](https://en.wikipedia.org/wiki/Three-body_problem) is a classical
 # physics problem where three bodies are orbiting each other and are thus interacting based
 # on Newton's law of universal gravitation. From a computational point of view, the goal is
-# to compute the trajecteries of all three bodies given the initial position and velocity
+# to compute the trajectories of all three bodies given the initial position and velocity
 # of each body.
 #
 # The problem is an application of the Newton's second law and Newton's law of universal
 # gravitation, that is, we can define the following system of equations:
 # ```math
 # \begin{cases}
-#   \frac{\partial^2 x_1}{\partial t^2} = -Gm_2 \frac{\mathbf{x}_1 - \mathbf{x}_2}{||\mathbf{x}_1 - \mathbf{x}_2||^3} -Gm_3 \frac{\mathbf{x}_1 - \mathbf{x}_3}{||\mathbf{x}_1 - \mathbf{x}_3||^3}\;, \\
-#   \frac{\partial^2 x_2}{\partial t^2} = -Gm_3 \frac{\mathbf{x}_2 - \mathbf{x}_3}{||\mathbf{x}_1 - \mathbf{x}_3||^3} -Gm_1 \frac{\mathbf{x}_2 - \mathbf{x}_1}{||\mathbf{x}_2 - \mathbf{x}_1||^3}\;, \\
-#   \frac{\partial^2 x_3}{\partial t^2} = -Gm_1 \frac{\mathbf{x}_3 - \mathbf{x}_1}{||\mathbf{x}_1 - \mathbf{x}_1||^3} -Gm_2 \frac{\mathbf{x}_3 - \mathbf{x}_2}{||\mathbf{x}_3 - \mathbf{x}_2||^3}\;,
+#   \frac{\mathrm{d}^2 x_1}{\mathrm{d} t^2} = -Gm_2 \frac{\mathbf{x}_1 - \mathbf{x}_2}{||\mathbf{x}_1 - \mathbf{x}_2||^3} -Gm_3 \frac{\mathbf{x}_1 - \mathbf{x}_3}{||\mathbf{x}_1 - \mathbf{x}_3||^3}\;, \\
+#   \frac{\mathrm{d}^2 x_2}{\mathrm{d} t^2} = -Gm_3 \frac{\mathbf{x}_2 - \mathbf{x}_3}{||\mathbf{x}_1 - \mathbf{x}_3||^3} -Gm_1 \frac{\mathbf{x}_2 - \mathbf{x}_1}{||\mathbf{x}_2 - \mathbf{x}_1||^3}\;, \\
+#   \frac{\mathrm{d}^2 x_3}{\mathrm{d} t^2} = -Gm_1 \frac{\mathbf{x}_3 - \mathbf{x}_1}{||\mathbf{x}_1 - \mathbf{x}_1||^3} -Gm_2 \frac{\mathbf{x}_3 - \mathbf{x}_2}{||\mathbf{x}_3 - \mathbf{x}_2||^3}\;,
 # \end{cases}
 # ```
 # where ``\mathbf{x}_i`` is the position of the ``i``-th body, and G is the gravitational
@@ -23,8 +23,8 @@
 # terms of two ODEs for each body as
 # ```math
 # \begin{cases}
-#   \frac{\partial v_i}{\partial t} = -G \sum_{j=1, j \neq i}^3 \frac{\mathbf{x}_i - \mathbf{x}_j}{||\mathbf{x}_i - \mathbf{x}_j||^3}\; \\
-#   \frac{\partial x_i}{\partial t} = v_i\;.
+#   \frac{\mathrm{d} v_i}{\mathrm{d} t} = -G \sum_{j=1, j \neq i}^3 m_j \frac{\mathbf{x}_i - \mathbf{x}_j}{||\mathbf{x}_i - \mathbf{x}_j||^3}\; \\
+#   \frac{\mathrm{d} x_i}{\mathrm{d} t} = v_i\;.
 # \end{cases}
 # ```
 # This system of two ODEs will be used in the implementation below. In this example, we
@@ -103,8 +103,8 @@ ode_position = TimeIntegrators.define_explicit_ode(f_position)
 #
 # To make this work in `Mantis`, we setup the two solutions `x_n` and `v_n` using the
 # previously defined initial conditions and using the forward Euler method in each.
-const x_n_E = TimeIntegrators.initialize_scheme(x₀, TimeIntegrators.FORWARD_EULER)
-const v_n_E = TimeIntegrators.initialize_scheme(v₀, TimeIntegrators.FORWARD_EULER)
+const x_n_E = TimeIntegrators.initialise_scheme(x₀, TimeIntegrators.FORWARD_EULER)
+const v_n_E = TimeIntegrators.initialise_scheme(v₀, TimeIntegrators.FORWARD_EULER)
 
 function integrate_sym_Euler!(x_n, v_n, t)
     ## Advance both ODEs. Note that the velocity must be updated first, to ensure that the
@@ -122,8 +122,8 @@ end
 
 # Alternatively, we can also use a Störmer-Verlet type scheme, by combining the same
 # integrators in a different way.
-const x_n_S = TimeIntegrators.initialize_scheme(x₀, TimeIntegrators.FORWARD_EULER)
-const v_n_S = TimeIntegrators.initialize_scheme(v₀, TimeIntegrators.FORWARD_EULER)
+const x_n_S = TimeIntegrators.initialise_scheme(x₀, TimeIntegrators.FORWARD_EULER)
+const v_n_S = TimeIntegrators.initialise_scheme(v₀, TimeIntegrators.FORWARD_EULER)
 
 function integrate_Stormer_Verlet!(x_n, v_n, t)
     ## Advance both ODEs. By first updating the velocity with a half time-step, followed by
@@ -146,8 +146,8 @@ end
 # conserve the Hamiltonian. Note that the scheme used for both ODEs is a higher-order
 # integrator. However, since the coupling between the ODEs is poor, this still does not
 # provide accurate results.
-const x_n_R = TimeIntegrators.initialize_scheme(x₀, TimeIntegrators.RK4)
-const v_n_R = TimeIntegrators.initialize_scheme(v₀, TimeIntegrators.RK4)
+const x_n_R = TimeIntegrators.initialise_scheme(x₀, TimeIntegrators.RK4)
+const v_n_R = TimeIntegrators.initialise_scheme(v₀, TimeIntegrators.RK4)
 
 function integrate_RK4!(x_n, v_n, t)
     ## Advance both ODEs. Here, we use the current velocity and position in both cases.

--- a/examples/src/ThreeBodyProblem.jl
+++ b/examples/src/ThreeBodyProblem.jl
@@ -1,0 +1,340 @@
+# # Three-body problem
+
+# ## [Background knowledge](@id ThreeBodyBackground)
+# The [three-body problem](https://en.wikipedia.org/wiki/Three-body_problem) is a classical
+# physics problem where three bodies are orbiting each other and are thus interacting based
+# on Newton's law of universal gravitation. From a computational point of view, the goal is
+# to compute the trajecteries of all three bodies given the initial position and velocity
+# of each body.
+#
+# The problem is an application of the Newton's second law and Newton's law of universal
+# gravitation, that is, we can define the following system of equations:
+# ```math
+# \begin{cases}
+#   \frac{\partial^2 x_1}{\partial t^2} = -Gm_2 \frac{\mathbf{x}_1 - \mathbf{x}_2}{||\mathbf{x}_1 - \mathbf{x}_2||^3} -Gm_3 \frac{\mathbf{x}_1 - \mathbf{x}_3}{||\mathbf{x}_1 - \mathbf{x}_3||^3}\;, \\
+#   \frac{\partial^2 x_2}{\partial t^2} = -Gm_3 \frac{\mathbf{x}_2 - \mathbf{x}_3}{||\mathbf{x}_1 - \mathbf{x}_3||^3} -Gm_1 \frac{\mathbf{x}_2 - \mathbf{x}_1}{||\mathbf{x}_2 - \mathbf{x}_1||^3}\;, \\
+#   \frac{\partial^2 x_3}{\partial t^2} = -Gm_1 \frac{\mathbf{x}_3 - \mathbf{x}_1}{||\mathbf{x}_1 - \mathbf{x}_1||^3} -Gm_2 \frac{\mathbf{x}_3 - \mathbf{x}_2}{||\mathbf{x}_3 - \mathbf{x}_2||^3}\;,
+# \end{cases}
+# ```
+# where ``\mathbf{x}_i`` is the position of the ``i``-th body, and G is the gravitational
+# constant (which will be set to ``1`` below).
+#
+# Instead of using one second order ODE for each body, we can reformulate the problem in
+# terms of two ODEs for each body as
+# ```math
+# \begin{cases}
+#   \frac{\partial v_i}{\partial t} = -G \sum_{j=1, j \neq i}^3 \frac{\mathbf{x}_i - \mathbf{x}_j}{||\mathbf{x}_i - \mathbf{x}_j||^3}\; \\
+#   \frac{\partial x_i}{\partial t} = v_i\;.
+# \end{cases}
+# ```
+# This system of two ODEs will be used in the implementation below. In this example, we
+# will consider a 2D version of this problem.
+
+# ## [Implementation](@id ThreeBodyImplementation)
+# In this section, we will implement the above three-body problem using the
+# `TimeIntegrators` module within `Mantis`.
+#
+# ### [Packages](@id ThreeBodyPackages)
+# In this example, we will use `Mantis` for the integration, `GLMakie` to create an
+# animation, and `Printf` to easily create a nicely formatted title for the animation. So,
+# we are `using` these three packages.
+
+using Mantis
+using GLMakie
+using Printf
+
+# ### [Test case](@id ThreeBodyTestCase)
+# In this example, we will consider the 'figure 8' periodic solution as described in
+# [Chenciner2000](@cite). This means that the three bodies each have the same mass (we use
+# the case where the mass is 1), and we define the initial positions and velocities as
+# shown in the code. This solution is part of the Broucke–Hénon–Hadjidemetriou family.
+m1 = 1.0
+m2 = 1.0
+m3 = 1.0
+
+## x₀ = [x₁, y₁, x₂, y₂, x₃, y₃] and similarly for v₀.
+x₀ = [0.97000436, -0.24308753, -0.97000436, 0.24308753, 0.0, 0.0]
+v₀ = [-0.4662036850, -0.4323657300, -0.4662036850, -0.4323657300, 0.93240737, 0.86473146]
+
+# ### [Setting up the ODE](@id ThreeBodyODESetup)
+# The ODEs as described in the [background section](@ref ThreeBodyBackground) need to be
+# implemented. We can do this by creating the `get_forces` function, which will compute the
+# gravitation force. We can then define the forcing functions for the position and velocity
+# as `f_position` and `f_velocity`. The latter computes and returns the force, while the
+# former returns the velocity. Note that both forcing functions take in a keyword argument,
+# as the forces do not depend on ``t`` nor on the variable in the ODE itself.
+function get_forces!(force, x)
+    ## x = [x1, y1, x2, y2, x3, y3]
+    force .= zero(eltype(force))
+    for i in 1:2:5
+        for j in 1:2:5
+            if i != j
+                r = sqrt((x[i] - x[j])^2 + (x[i + 1] - x[j + 1])^2)
+                force[i] += (x[j] - x[i]) / r^3 ## x component
+                force[i + 1] += (x[j + 1] - x[i + 1]) / r^3 ## y component
+            end
+        end
+    end
+    return force
+end
+
+function f_velocity(output, vel, t; pos)
+    return get_forces!(output, pos)
+end
+function f_position(output, pos, t; vel)
+    for i in eachindex(output, vel)
+        output[i] = vel[i]
+    end
+    return output
+end
+
+# With these forcing functions, we can define the ODEs by simply calling the
+# [`Mantis.TimeIntegrators.define_explicit_ode`](@ref) function.
+ode_velocity = TimeIntegrators.define_explicit_ode(f_velocity)
+ode_position = TimeIntegrators.define_explicit_ode(f_position)
+
+# ### [Time integration](@id ThreeBodyTimeIntegration)
+# We can now setup the time integrator of our choosing. Since we are evolving two ODEs at
+# the same time, and we would like to ensure that we preserve the Hamiltonian of the
+# system (see [the Wikipedia page](https://en.wikipedia.org/wiki/Three-body_problem) for
+# the Hamiltonian), we will solve the two ODEs in sequence. Using the forward Euler method
+# for each ODE while using the result from the first ODE, we will end up with the so-called
+# symplectic Euler method.
+#
+# To make this work in `Mantis`, we setup the two solutions `x_n` and `v_n` using the
+# previously defined initial conditions and using the forward Euler method in each.
+const x_n_E = TimeIntegrators.initialize_scheme(x₀, TimeIntegrators.FORWARD_EULER)
+const v_n_E = TimeIntegrators.initialize_scheme(v₀, TimeIntegrators.FORWARD_EULER)
+
+function integrate_sym_Euler!(x_n, v_n, t)
+    ## Advance both ODEs. Note that the velocity must be updated first, to ensure that the
+    ## position update can use the new velocity. This is what makes this the symplectic
+    ## Euler scheme.
+    TimeIntegrators.time_integrate!(
+        v_n, ode_velocity, t, dt; pos=TimeIntegrators.get_solution(x_n)
+    )
+    TimeIntegrators.time_integrate!(
+        x_n, ode_position, t, dt; vel=TimeIntegrators.get_solution(v_n)
+    )
+
+    return nothing
+end
+
+# Alternatively, we can also use a Störmer-Verlet type scheme, by combining the same
+# integrators in a different way.
+const x_n_S = TimeIntegrators.initialize_scheme(x₀, TimeIntegrators.FORWARD_EULER)
+const v_n_S = TimeIntegrators.initialize_scheme(v₀, TimeIntegrators.FORWARD_EULER)
+
+function integrate_Stormer_Verlet!(x_n, v_n, t)
+    ## Advance both ODEs. By first updating the velocity with a half time-step, followed by
+    ## a full position updated, followed by another half time-step velocity update, we
+    ## obtain the Störmer-Verlet (or kick-drift-kick) algorithm.
+    TimeIntegrators.time_integrate!(
+        v_n, ode_velocity, t, 0.5*dt; pos=TimeIntegrators.get_solution(x_n)
+    )
+    TimeIntegrators.time_integrate!(
+        x_n, ode_position, t, dt; vel=TimeIntegrators.get_solution(v_n)
+    )
+    TimeIntegrators.time_integrate!(
+        v_n, ode_velocity, t+0.5*dt, 0.5*dt; pos=TimeIntegrators.get_solution(x_n)
+    )
+
+    return nothing
+end
+
+# For comparison, we also show what happens when choosing an integrator that does not
+# conserve the Hamiltonian. Note that the scheme used for both ODEs is a higher-order
+# integrator. However, since the coupling between the ODEs is poor, this still does not
+# provide accurate results.
+const x_n_R = TimeIntegrators.initialize_scheme(x₀, TimeIntegrators.RK4)
+const v_n_R = TimeIntegrators.initialize_scheme(v₀, TimeIntegrators.RK4)
+
+function integrate_RK4!(x_n, v_n, t)
+    ## Advance both ODEs. Here, we use the current velocity and position in both cases.
+    v_current = TimeIntegrators.get_solution(v_n)
+    TimeIntegrators.time_integrate!(
+        v_n, ode_velocity, t, dt; pos=TimeIntegrators.get_solution(x_n)
+    )
+    TimeIntegrators.time_integrate!(x_n, ode_position, t, dt; vel=v_current)
+
+    return nothing
+end
+
+# Then we can set the desired start time t0, the time step size dt and the final time T.
+const dt = 0.05
+const T = 10.0
+const t0 = 0.0
+
+# The remaining code is just for the visualisation. We want to create an animation where we
+# see the masses move in their orbit with a tail. We set the tail length to be ``30``,
+# meaning that we see at most ``30`` points. We will also make them increasingly less
+# visible, which is why we define the alphas. The animation is then created using the
+# `record` function (from `GLMakie`) and `Makie`'s `Observables`. See the `Makie`
+# documentation for more details on creating animations.
+const tail_length = 30
+alphas = LinRange(0.0, 1.0, tail_length)
+time = Observable(t0)
+
+## Histories for the symplectic Euler integrator.
+tail_x_E = [copy(TimeIntegrators.get_solution(x_n_E)[1:2:end]) for _ in 1:tail_length]
+tail_y_E = [copy(TimeIntegrators.get_solution(x_n_E)[2:2:end]) for _ in 1:tail_length]
+hamiltonian_history_vec_E = Tuple{Float64, Float64}[]
+colors_E = [(:black, i) for i in alphas]
+
+## Histories for the Stormer-Verlet integrator.
+tail_x_S = [copy(TimeIntegrators.get_solution(x_n_S)[1:2:end]) for _ in 1:tail_length]
+tail_y_S = [copy(TimeIntegrators.get_solution(x_n_S)[2:2:end]) for _ in 1:tail_length]
+hamiltonian_history_vec_S = Tuple{Float64, Float64}[]
+colors_S = [(:red, i) for i in alphas]
+
+## Histories for the RK4 integrator.
+tail_x_R = [copy(TimeIntegrators.get_solution(x_n_R)[1:2:end]) for _ in 1:tail_length]
+tail_y_R = [copy(TimeIntegrators.get_solution(x_n_R)[2:2:end]) for _ in 1:tail_length]
+hamiltonian_history_vec_R = Tuple{Float64, Float64}[]
+colors_R = [(:green, i) for i in alphas]
+
+## This part is doing the actual computation at each timestep, everything else is just for
+## the animation.
+integrator = lift(time) do t
+    integrate_sym_Euler!(x_n_E, v_n_E, t)
+    integrate_Stormer_Verlet!(x_n_S, v_n_S, t)
+    integrate_RK4!(x_n_R, v_n_R, t)
+    return t
+end
+
+function update_tails!(x_n, tail_x, tail_y)
+    x = TimeIntegrators.get_solution(x_n)
+
+    push!(tail_x, x[1:2:end])
+    push!(tail_y, x[2:2:end])
+    if length(tail_x) > tail_length
+        popfirst!(tail_x)
+        popfirst!(tail_y)
+    end
+
+    return nothing
+end
+
+update_all_tails = lift(integrator) do update
+    ## Now we update the trails for the visualisation. If there are more entries than the
+    ## desired `trail_length`, we remove the oldest position.
+    update_tails!(x_n_E, tail_x_E, tail_y_E)
+    update_tails!(x_n_S, tail_x_S, tail_y_S)
+    update_tails!(x_n_R, tail_x_R, tail_y_R)
+
+    return nothing
+end
+
+tail1_E = lift(update_all_tails) do update
+    return Point2f.(getindex.(tail_x_E, 1), getindex.(tail_y_E, 1))
+end
+tail2_E = lift(update_all_tails) do update
+    return Point2f.(getindex.(tail_x_E, 2), getindex.(tail_y_E, 2))
+end
+tail3_E = lift(update_all_tails) do update
+    return Point2f.(getindex.(tail_x_E, 3), getindex.(tail_y_E, 3))
+end
+
+tail1_S = lift(update_all_tails) do update
+    return Point2f.(getindex.(tail_x_S, 1), getindex.(tail_y_S, 1))
+end
+tail2_S = lift(update_all_tails) do update
+    return Point2f.(getindex.(tail_x_S, 2), getindex.(tail_y_S, 2))
+end
+tail3_S = lift(update_all_tails) do update
+    return Point2f.(getindex.(tail_x_S, 3), getindex.(tail_y_S, 3))
+end
+
+tail1_R = lift(update_all_tails) do update
+    return Point2f.(getindex.(tail_x_R, 1), getindex.(tail_y_R, 1))
+end
+tail2_R = lift(update_all_tails) do update
+    return Point2f.(getindex.(tail_x_R, 2), getindex.(tail_y_R, 2))
+end
+tail3_R = lift(update_all_tails) do update
+    return Point2f.(getindex.(tail_x_R, 3), getindex.(tail_y_R, 3))
+end
+
+function compute_hamiltonian(x_n, v_n)
+    x = TimeIntegrators.get_solution(x_n)
+    v = TimeIntegrators.get_solution(v_n)
+    K = 0.0
+    U = 0.0
+    for i in 1:2:5
+        for j in 1:2:5
+            if i < j
+                r = sqrt((x[i] - x[j])^2 + (x[i + 1] - x[j + 1])^2)
+                U += 1.0 / r
+            end
+        end
+        K += 0.5 * (v[i]^2 + v[i+1]^2)
+    end
+    return K - U
+end
+
+hamiltonian_E = lift(integrator) do t
+    return t, compute_hamiltonian(x_n_E, v_n_E)
+end
+hamiltonian_history_E = lift(hamiltonian_E) do (t, H)
+    H = push!(hamiltonian_history_vec_E, (t, H))
+    return Point2f.(hamiltonian_history_vec_E)
+end
+
+hamiltonian_S = lift(integrator) do t
+    return t, compute_hamiltonian(x_n_S, v_n_S)
+end
+hamiltonian_history_S = lift(hamiltonian_S) do (t, H)
+    H = push!(hamiltonian_history_vec_S, (t, H))
+    return Point2f.(hamiltonian_history_vec_S)
+end
+
+hamiltonian_R = lift(integrator) do t
+    return t, compute_hamiltonian(x_n_R, v_n_R)
+end
+hamiltonian_history_R = lift(hamiltonian_R) do (t, H)
+    H = push!(hamiltonian_history_vec_R, (t, H))
+    return Point2f.(hamiltonian_history_vec_R)
+end
+
+fig = Figure()
+ax_sol = Axis(
+    fig[1, 1];
+    title=@lift("t = $(@sprintf("%0.2f", round($time, digits = 2)))"),
+    limits=(-1.2, 1.2, -1.2, 1.2),
+)
+scatter!(ax_sol, tail1_E; color=colors_E)
+scatter!(ax_sol, tail2_E; color=colors_E)
+scatter!(ax_sol, tail3_E; color=colors_E)
+
+scatter!(ax_sol, tail1_S; color=colors_S)
+scatter!(ax_sol, tail2_S; color=colors_S)
+scatter!(ax_sol, tail3_S; color=colors_S)
+
+scatter!(ax_sol, tail1_R; color=colors_R)
+scatter!(ax_sol, tail2_R; color=colors_R)
+scatter!(ax_sol, tail3_R; color=colors_R)
+
+ax_ham = Axis(
+    fig[1, 2];
+    title=@lift("t = $(@sprintf("%0.2f", round($time, digits = 2)))"),
+    limits=(t0, T, -2, -0.5),
+)
+
+scatter!(ax_ham, hamiltonian_E; color=:black)
+lines!(ax_ham, hamiltonian_history_E; color=:black)
+
+scatter!(ax_ham, hamiltonian_S; color=:red)
+lines!(ax_ham, hamiltonian_history_S; color=:red)
+
+scatter!(ax_ham, hamiltonian_R; color=:green)
+lines!(ax_ham, hamiltonian_history_R; color=:green)
+
+record(
+    fig, "three_body_problem.mp4", LinRange(t0, T, round(Int, T / dt)); framerate=30
+) do t
+    time[] = t
+end
+
+# ```@raw html
+# <video autoplay loop muted playsinline controls src="./three_body_problem.mp4" />
+# ```

--- a/exports/Exports.jl
+++ b/exports/Exports.jl
@@ -1,3 +1,0 @@
-# This file is auto-generated. To edit, run 'tool/populate_exports.sh'
-
-include("Forms.jl")

--- a/exports/Forms.jl
+++ b/exports/Forms.jl
@@ -1,5 +1,0 @@
-# This file is auto-generated. To edit, run 'tool/populate_exports.sh'
-
-using .Forms
-
-export d, ★, ♯, ∧, ∫, codifferential, dstar, δ

--- a/ext/MakieExt.jl
+++ b/ext/MakieExt.jl
@@ -2,6 +2,7 @@ module MakieExt
 
 using Mantis
 using Makie
+import LaTeXStrings
 
 function Mantis.Plot.plot_solution(
     fields::T,
@@ -32,6 +33,236 @@ function Mantis.Plot.plot_solution(
     fig[1, 2] = Legend(fig, ax; marge=true, unique=true)
 
     return fig
+end
+
+function Mantis.Plot.plot_basis(
+    space::FunctionSpaces.AbstractFESpace{1, 1};
+    ids=1:FunctionSpaces.get_num_basis(space),
+    draw_elements=true,
+    plot_points_per_element=75,
+    color_per_basis=true,
+    colorrange=(0.0, 1.0),
+    colormap=Makie.wong_colors(),
+    show_legend=true,
+    show_colormap=true,
+    label_prefix="",
+    axis_kwargs...,
+)
+    fig = Figure()
+    ax = Axis(fig[1, 1]; axis_kwargs...)
+
+    fig = _plot_basis!(
+        fig,
+        ax,
+        space;
+        ids=ids,
+        draw_elements=draw_elements,
+        plot_points_per_element=plot_points_per_element,
+        color_per_basis=color_per_basis,
+        colorrange=colorrange,
+        colormap=colormap,
+        show_legend=show_legend,
+        show_colormap=show_colormap,
+        label_prefix=label_prefix,
+    )
+
+    return fig
+end
+
+function Mantis.Plot.plot_basis(
+    space::FunctionSpaces.AbstractFESpace{2, 1};
+    ids=1:FunctionSpaces.get_num_basis(space),
+    draw_elements=false,
+    plot_points_per_element=25,
+    color_per_basis=false,
+    colorrange=(0.0, 1.0),
+    colormap=:viridis,
+    show_legend=true,
+    show_colormap=true,
+    label_prefix="",
+    axis_kwargs...,
+)
+    fig = Figure()
+    ax = Axis3(fig[1, 1]; viewmode=:fit, axis_kwargs...)
+
+    fig = _plot_basis!(
+        fig,
+        ax,
+        space;
+        ids=ids,
+        draw_elements=draw_elements,
+        plot_points_per_element=plot_points_per_element,
+        color_per_basis=color_per_basis,
+        colorrange=colorrange,
+        colormap=colormap,
+        show_legend=show_legend,
+        show_colormap=show_colormap,
+        label_prefix=label_prefix,
+    )
+
+    return fig
+end
+
+function sanitise_label(label_prefix::AbstractString, main_label::AbstractString)
+    label = label_prefix * main_label
+
+    return label
+end
+function sanitise_label(label_prefix::LaTeXStrings.LaTeXString, main_label::AbstractString)
+    # Remove trailing $ and add it back at the end.
+    label = LaTeXStrings.LaTeXString(label_prefix.s[1:(end - 1)] * main_label * "\$")
+
+    return label
+end
+
+function _plot_basis!(
+    fig,
+    ax,
+    space;
+    ids,
+    draw_elements,
+    plot_points_per_element,
+    color_per_basis,
+    colorrange,
+    colormap,
+    show_legend,
+    show_colormap,
+    label_prefix,
+)
+    if typeof(ids) <: Integer
+        basis_ids = ids:ids
+    else
+        basis_ids = ids
+    end
+
+    manifold_dim = FunctionSpaces.get_manifold_dim(space)
+    geometry = FunctionSpaces.get_geometry(space)
+    image_dim = Geometry.get_image_dim(geometry)
+
+    TPoint = Point{image_dim, Float32}
+    xi = Points.CartesianPoints(
+        ntuple(manifold_dim) do i
+            return LinRange(
+                zero(eltype(TPoint)), one(eltype(TPoint)), plot_points_per_element
+            )
+        end,
+    )
+    point_shape = ntuple(image_dim) do i
+        return plot_points_per_element
+    end
+
+    # First plot the geometry wireframe and/or the elements, if desired.
+    if draw_elements
+        _draw_elements!(ax, geometry, TPoint)
+    end
+
+    # Then plot the basis functions on top.
+    for basis_id in basis_ids
+
+        # Get the elements on which the current basis function is supported.
+        element_ids = FunctionSpaces.get_support(space, basis_id)
+
+        for element_id in element_ids
+            position_coordinates = Geometry.evaluate(geometry, element_id, xi)
+
+            x = reshape(position_coordinates[:, 1], point_shape)
+            if manifold_dim == 2
+                y = reshape(
+                    position_coordinates[:, 2],
+                    (plot_points_per_element, plot_points_per_element),
+                )
+            end
+
+            function_values, bases = FunctionSpaces.evaluate(space, element_id, xi)
+            basis_index = findfirst(isequal(basis_id), bases)
+            z = reshape(function_values[1][1][1][:, basis_index], point_shape)
+            if manifold_dim == 1
+                if color_per_basis
+                    color = colormap[basis_id % length(colormap) + 1]
+                    label = sanitise_label(label_prefix, string(basis_id))
+                    lines!(ax, x, z; color=color, label=label)
+                else
+                    lines!(ax, x, z; color=z, colorrange=colorrange, colormap=colormap)
+                end
+
+            else
+                if color_per_basis
+                    color = colormap[basis_id % length(colormap) + 1]
+                    surface!(
+                        ax,
+                        x,
+                        y,
+                        z;
+                        shading=true,
+                        transparency=false,
+                        color=fill(color, plot_points_per_element, plot_points_per_element),
+                        label=label_prefix*string(basis_id),
+                    )
+                else
+                    surface!(
+                        ax,
+                        x,
+                        y,
+                        z;
+                        shading=true,
+                        transparency=false,
+                        colorrange=colorrange,
+                        colormap=colormap,
+                    )
+                end
+            end
+        end
+    end
+
+    if show_legend && color_per_basis
+        Legend(fig[1, 2], ax; unique=true)
+    end
+    if show_colormap && !color_per_basis
+        Colorbar(fig[1, 2]; limits=colorrange, colormap=colormap)
+    end
+
+    return fig
+end
+
+function _draw_elements!(ax, geometry, TPoint)
+    manifold_dim = Geometry.get_manifold_dim(geometry)
+    image_dim = Geometry.get_image_dim(geometry)
+
+    xi_element = Points.CartesianPoints(
+        ntuple(manifold_dim) do i
+            return LinRange(0.0, 1.0, 2)
+        end,
+    )
+    if image_dim == manifold_dim
+        permutations = ([1, 3, 2, 4], [1, 5, 2, 6, 3, 7, 4, 8])
+    elseif image_dim == manifold_dim + 1
+        permutations = ([1, 3, 2, 4], [1, 3, 2, 4])
+    end
+    for element_id in 1:Geometry.get_num_elements(geometry)
+        element_vertices = Geometry.evaluate(geometry, element_id, xi_element)
+        element_vertices_points = [
+            Mantis.Plot._pad_point(TPoint(element_vertices[i, :]...)) for
+            i in axes(element_vertices, 1)
+        ]
+        # Element lines in the x direction.
+        linesegments!(element_vertices_points; color=:black)
+        if image_dim == 1
+            # Also add a vertical bar for the edges, otherwise they are invisble.
+            scatter!(
+                ax, element_vertices_points; marker=:vline, markersize=15, color=:black
+            )
+        end
+
+        # Element lines in the other directions.
+        for dim in 1:(manifold_dim - 1)
+            linesegments!(ax, element_vertices_points[permutations[dim]]; color=:black)
+        end
+    end
+end
+
+# Pad for 1D
+function Mantis.Plot._pad_point(point::Point{1, T}, pad_value=zero(T)) where {T}
+    return Point{2, T}(point[1], pad_value)
 end
 
 end

--- a/src/Mantis.jl
+++ b/src/Mantis.jl
@@ -3,18 +3,18 @@ module Mantis
 ############################################################################################
 #                                         Includes                                         #
 ############################################################################################
-include("GeneralHelpers/GeneralHelpers.jl")  # Creates Module GeneralHelpers
-include("Mesh/Mesh.jl")  # Creates Module Mesh
-include("Points/Points.jl")  # Creates Module Mesh
-include("Hierarchy/Hierarchy.jl") # Creates Module Hierarchy
-include("Geometry/Geometry.jl")  # Creates Module Geometry
-include("FunctionSpaces/FunctionSpaces.jl")  # Creates Module FunctionSpaces
-include("Quadrature/Quadrature.jl")  # Creates Module Quadrature
-include("Forms/Forms.jl")  # Creates Module Forms
-include("Analysis/Analysis.jl")  # Creates Module Analysis
-include("Assemblers/Assemblers.jl")  # Creates Module Assemblers
-include("TimeIntegrators/TimeIntegrators.jl")  # Creates Module TimeIntegrators
-include("Plot/Plot.jl")  # Creates Module Plot
+include("GeneralHelpers/GeneralHelpers.jl")
+include("Mesh/Mesh.jl")
+include("Points/Points.jl")
+include("Hierarchy/Hierarchy.jl")
+include("Geometry/Geometry.jl")
+include("FunctionSpaces/FunctionSpaces.jl")
+include("Quadrature/Quadrature.jl")
+include("Forms/Forms.jl")
+include("Analysis/Analysis.jl")
+include("Assemblers/Assemblers.jl")
+include("TimeIntegrators/TimeIntegrators.jl")
+include("Plot/Plot.jl")
 
 ############################################################################################
 #                                         Exports                                          #
@@ -38,5 +38,11 @@ export d, ★, ♯, ∧, ∫, dstar, δ
 export ConstantFormSpace, FormField, AnalyticalFormField, FormSpace
 export evaluate
 export get_label, get_num_basis, get_coefficients
+
+# Exports from TimeIntegrators
+using .TimeIntegrators
+export define_explicit_ode, define_diagonally_implicit_ode, define_implicit_ode,
+    define_imex_ode
+export get_solution, initialise_scheme, time_integrate, time_integrate!
 
 end

--- a/src/Mantis.jl
+++ b/src/Mantis.jl
@@ -13,6 +13,7 @@ include("Quadrature/Quadrature.jl")  # Creates Module Quadrature
 include("Forms/Forms.jl")  # Creates Module Forms
 include("Analysis/Analysis.jl")  # Creates Module Analysis
 include("Assemblers/Assemblers.jl")  # Creates Module Assemblers
+include("TimeIntegrators/TimeIntegrators.jl")  # Creates Module TimeIntegrators
 include("Plot/Plot.jl")  # Creates Module Plot
 
 ############################################################################################
@@ -28,6 +29,7 @@ export Mesh,
     Forms,
     Analysis,
     Assemblers,
+    TimeIntegrators,
     Plot
 
 # Exports from Forms.

--- a/src/Plot/Plot.jl
+++ b/src/Plot/Plot.jl
@@ -7,10 +7,12 @@ The exported names are:
 module Plot
 
 import WriteVTK
+import LaTeXStrings
 
 using ..GeneralHelpers
 using ..Points
 using ..Geometry
+using ..FunctionSpaces
 using ..Forms
 
 # core functionality

--- a/src/Plot/PlotHelpers.jl
+++ b/src/Plot/PlotHelpers.jl
@@ -118,5 +118,15 @@ function export_form_fields_to_vtk(
     return nothing
 end
 
-# Only usable if GLMakie is also loaded.
+# Only usable if Makie is also loaded.
 function plot_solution end
+function plot_basis end
+
+# Pad for 1D.
+function _pad_point(point::NTuple{1, T}, pad_value=zero(T)) where {T}
+    return (point[1], pad_value)
+end
+# Otherwise, no padding needed.
+function _pad_point(point, pad_value=0.0)
+    return point
+end

--- a/src/TimeIntegrators/Definitions.jl
+++ b/src/TimeIntegrators/Definitions.jl
@@ -1,0 +1,642 @@
+"""
+    AbstractTimeIntegrator{num_stages, num_steps}
+
+Supertype for all time integrators.
+
+# Type parameters
+- `num_stages`: The number of stages for a multi-step scheme (such as the Runge-Kutta
+    family). Since every scheme is at least a single-stage scheme, `num_stages` >= 1.
+- `num_steps`: The number of steps for a multi-step scheme (such as the Adams-Bashforth
+    family). Since every scheme is at least a single-step scheme, `num_steps` >= 1.
+"""
+abstract type AbstractTimeIntegrator{num_stages, num_steps} end
+
+"""
+    get_num_stages(
+        ::AbstractTimeIntegrator{num_stages, num_steps}
+    ) where {num_stages, num_steps}
+
+Return the number of stages of the given [`AbstractTimeIntegrator`](@ref).
+"""
+function get_num_stages(
+    ::AbstractTimeIntegrator{num_stages, num_steps}
+) where {num_stages, num_steps}
+    return num_stages
+end
+
+"""
+    get_num_steps(
+        ::AbstractTimeIntegrator{num_stages, num_steps}
+    ) where {num_stages, num_steps}
+
+Return the number of steps of the given [`AbstractTimeIntegrator`](@ref).
+"""
+function get_num_steps(
+    ::AbstractTimeIntegrator{num_stages, num_steps}
+) where {num_stages, num_steps}
+    return num_steps
+end
+
+############################################################################################
+##                              Problem-Specific Information                              ##
+############################################################################################
+
+"""
+    TimeIntegrationOperators{EF, IF, IE}
+
+Defines the ODE-specific operators used in the time integration.
+
+Makes a distiction between the explicit and implicit operators. `EF`, `IF`, and `IE` are
+the types the explicit and implicit functions, which are `Nothing` if not defined. Note
+that at least `EF` or `IF` and `IE` must be a function.
+
+# Constructors
+- `define_explicit_ode(explicit_evaluate::Function)`: For fully explicit ODEs.
+- `define_diagonally_implicit_ode(implicit_solve::Function)`: For diagonally implicit ODEs.
+- `define_implicit_ode(implicit_solve::Function, implicit_evaluate::Function)`: For fully
+    implicit ODEs.
+- `define_imex_ode(explicit_evaluate::Function, implicit_solve::Function)`: For IMEX ODEs.
+- `TimeIntegrationOperators(
+        explicit_evaluate::Union{Nothing, Function},
+        implicit_solve::Union{Nothing, Function},
+        implicit_evaluate::Union{Nothing, Function},
+    )`: Generic constructor.
+
+# Fields
+- `explicitEvaluate!::EF`: A function that evaluates the explicit part of the ODE, that is,
+    the function that evaluates ``F = f(y, t)``. See the manual section on
+    [TimeIntegrators](@ref) for the terminology. **This function must have the following
+    inputs: (output, yn, t). It must also overwrite the output argument.** The output
+    argument will be a vector-like object of length N (the number of variables), as will
+    yn. The argument t will be a number indicating the current time.
+- `implicitSolve!::IF`: A function that solves the implicit part of the ODE, that is, the
+    function that solves the equation
+    ``\\mathbf{Y} - h \\mathbf{g}(\\mathbf{Y}) = \\mathbf{x}``, with
+    ``h = a^{IM}_{ii} \\Delta t``. See the manual section on [TimeIntegrators](@ref) for
+    the terminology. In case g is a linear operator, a direct solution method can be
+    through the inverse operator ``(I - h \\mathbf{g})\\mathbf{Y} = \\mathbf{x}``, where
+    ``I`` is the identity function. **This function must have the following inputs:
+    (output, x, h, t). It must also overwrite the output argument.** The output argument
+    will be a matrix-like object of size (N, num_stages), as will yn. The arguments h will
+    be either a number (for DiagonallyImplicit integrators) or a SMatrix (for Implicit
+    integrators) and t will be a number (for DiagonallyImplicit integrators) or an SVector
+    (for Implicit integrators) indicating the current time(s).
+- `implicitEvaluate!::IE`: A function that evaluates the implicit part of the ODE, that is,
+    the function that evaluates ``G = g(y, t)``. See the manual section on
+    [TimeIntegrators](@ref) for the terminology. **This function must have the following
+    inputs: (output, yn, t). It must also overwrite the output argument.** The output
+    argument will be a vector-like object of length N (the number of variables), as will
+    yn, and t will be a number indicating the current time.
+
+# Type parameters
+- `EF`: `typeof(explicitEvaluate!)` if initialised, `Nothing` otherwise.
+- `IF`: `typeof(implicitSolve!)` if initialised, `Nothing` otherwise.
+- `IE`: `typeof(implicitEvaluate!)` if initialised, `Nothing` otherwise.
+"""
+struct TimeIntegrationOperators{EF, IF, IE}
+    explicitEvaluate!::EF
+    implicitSolve!::IF
+    implicitEvaluate!::IE
+
+    function TimeIntegrationOperators(
+        explicit_evaluate::Union{Nothing, Function},
+        implicit_solve::Union{Nothing, Function},
+        implicit_evaluate::Union{Nothing, Function},
+    )
+        if !(explicit_evaluate isa Function || implicit_solve isa Function || implicit_evaluate isa Function)
+            throw(ArgumentError("At least one of the inputs must be a Function."))
+        end
+
+        new{typeof(explicit_evaluate), typeof(implicit_solve), typeof(implicit_evaluate)}(
+            explicit_evaluate, implicit_solve, implicit_evaluate
+        )
+    end
+end
+
+"""
+    define_explicit_ode(explicit_evaluate::Function)
+
+Creates a [`TimeIntegrationOperators`](@ref) object for an explicit ODE.
+"""
+function define_explicit_ode(explicit_evaluate::Function)
+    return TimeIntegrationOperators(explicit_evaluate, nothing, nothing)
+end
+"""
+    define_diagonally_implicit_ode(
+        implicit_solve::Function, implicit_evaluate::Union{Nothing, Function}=nothing
+    )
+
+Creates a [`TimeIntegrationOperators`](@ref) object for a diagonally implicit ODE. The
+`implicit_evaluate` argument is only needed when using a multi-step scheme.
+"""
+function define_diagonally_implicit_ode(
+    implicit_solve::Function, implicit_evaluate::Union{Nothing, Function}=nothing
+)
+    return TimeIntegrationOperators(nothing, implicit_solve, implicit_evaluate)
+end
+"""
+    define_implicit_ode(implicit_solve::Function, implicit_evaluate::Function)
+
+Creates a [`TimeIntegrationOperators`](@ref) object for an implicit ODE.
+"""
+function define_implicit_ode(implicit_solve::Function, implicit_evaluate::Function)
+    return TimeIntegrationOperators(nothing, implicit_solve, implicit_evaluate)
+end
+"""
+    define_imex_ode(
+        explicit_evaluate::Function,
+        implicit_solve::Function,
+        implicit_evaluate::Union{Nothing, Function}=nothing
+    )
+
+Creates a [`TimeIntegrationOperators`](@ref) object for an IMEX ODE. The
+`implicit_evaluate` argument is only needed when using a multi-step scheme.
+"""
+function define_imex_ode(
+    explicit_evaluate::Function,
+    implicit_solve::Function,
+    implicit_evaluate::Union{Nothing, Function}=nothing
+)
+    return TimeIntegrationOperators(explicit_evaluate, implicit_solve, implicit_evaluate)
+end
+
+############################################################################################
+##                                       TimeLevels                                       ##
+############################################################################################
+
+"""
+    TimeLevels
+
+The length of the fields of the `TimeLevels` object descibe the structure of the input and
+output vectors for an integrator. The initialisation procedure uses this information to
+determine what needs to be initialised. Note that the vectors may be empty.
+
+# Fields
+- `step_values::Vector{Int}`: The length of this vector determines how many previous
+    solutions. For multi-stage methods, this is often just `[0]`. For multi-step methods,
+    this may include a longer history.
+- `step_derivatives_implicit::Vector{Int}`: Required implicit step derivatives from
+    previous steps. Note that this is ``\\Delta t G``. This is, for example, used in the
+    Adams-Moulton schemes.
+- `step_derivatives_explicit::Vector{Int}`: Required explicit step derivatives from
+    previous steps. Note that this is ``\\Delta t F``. This is, for example, used in the
+    Adams-Bashford schemes.
+"""
+struct TimeLevels
+    step_values::Vector{Int}
+    step_derivatives_implicit::Vector{Int}
+    step_derivatives_explicit::Vector{Int}
+end
+
+############################################################################################
+##                                      Integrators                                       ##
+############################################################################################
+
+"""
+    check_implicit(A::AbstractMatrix)
+
+Check if the GLM matrix `A` belongs to an implicit or diagonally implicit scheme. Returns
+two booleans; the first indicates if the scheme is fully implicit, the second if the scheme
+is diagonally implicit.
+"""
+function check_implicit(A::AbstractMatrix)
+    is_implicit = false
+    is_diagonally_implicit = false
+    for j in axes(A, 2)
+        for i in axes(A, 1)
+            if i == j && A[i, j] != zero(eltype(A))
+                is_diagonally_implicit = true
+            elseif j > i && A[i, j] != zero(eltype(A))
+                is_implicit = true
+            end
+        end
+    end
+
+    return is_implicit, is_diagonally_implicit
+end
+
+"""
+    Explicit{num_stages, num_steps, NT, AA, AE, EE} <:
+        AbstractTimeIntegrator{num_stages, num_steps}
+
+Explicit time integration scheme.
+
+!!! note "Explicit time integrators are explicit in the ODE sense"
+    Following [Vos2011](@cite), the explicit time integrators in this framework are
+    considered explicit integrators when applied to ODEs. When applied to PDEs using a
+    Galerkin method, one still has to solve a linear system. This can be referred to as an
+    indirect explicit method in this case.
+
+# Fields
+- `A`, `B`, `U`, `V`: See the [GLM characterisation](@ref TIGLMCharacter) for more details,
+    including the matrix sizes. All matrices are of type `SMatrix` with the appropriate
+    size and `NT` as eltype.
+- `C::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at what
+    time each stage is evaluated.
+- `time_levels::TimeLevels`: Required information from previous steps. See
+    [`TimeLevels`](@ref) for the details.
+- `order::Int`: Order of the scheme.
+
+# Type parameters
+- `num_stages`, `num_steps`: See [AbstractTimeIntegrator](@ref) for the details.
+- `NT`: Element type of the `A`, `B`, `U`, `V` matrices.
+- `AA`, `AE`, `EE`: Number of entries in `A`, (`B` and `U`), and `V`, respectively.
+"""
+struct Explicit{num_stages, num_steps, NT, AA, AE, EE} <:
+       AbstractTimeIntegrator{num_stages, num_steps}
+    A::SMatrix{num_stages, num_stages, NT, AA}
+    B::SMatrix{num_steps, num_stages, NT, AE}
+    U::SMatrix{num_stages, num_steps, NT, AE}
+    V::SMatrix{num_steps, num_steps, NT, EE}
+    C::SVector{num_stages, NT}
+    time_levels::TimeLevels
+    order::Int
+
+    function Explicit(
+        A::SMatrix{num_stages, num_stages, NT, AA},
+        B::SMatrix{num_steps, num_stages, NT, AE},
+        U::SMatrix{num_stages, num_steps, NT, AE},
+        V::SMatrix{num_steps, num_steps, NT, EE},
+        C::SVector{num_stages, NT},
+        time_levels::TimeLevels,
+        order::Int,
+    ) where {num_stages, num_steps, NT, AA, AE, EE}
+        is_implicit, is_diagonally_implicit = check_implicit(A)
+        if is_implicit || is_diagonally_implicit
+            throw(
+                ArgumentError(
+                    LazyString(
+                        "Tried to build an Explicit integrator with an A matrix that ",
+                        "belongs to an Implicit or DiagonallyImplicit scheme",
+                    ),
+                ),
+            )
+        end
+
+        return new{num_stages, num_steps, NT, AA, AE, EE}(A, B, U, V, C, time_levels, order)
+    end
+end
+
+"""
+    DiagonallyImplicit{num_stages, num_steps, NT, AA, AE, EE} <:
+        AbstractTimeIntegrator{num_stages, num_steps}
+
+DiagonallyImplicit time integration scheme.
+
+# Fields
+- `A`, `B`, `U`, `V`: See the [GLM characterisation](@ref TIGLMCharacter) for more details,
+    including the matrix sizes. All matrices are of type `SMatrix` with the appropriate
+    size and `NT` as eltype.
+- `C::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at what
+    time each stage is evaluated.
+- `time_levels::TimeLevels`: Required information from previous steps. See
+    [`TimeLevels`](@ref) for the details.
+- `order::Int`: Order of the scheme.
+
+# Type parameters
+- `num_stages`, `num_steps`: See [AbstractTimeIntegrator](@ref) for the details.
+- `NT`: Element type of the `A`, `B`, `U`, `V` matrices.
+- `AA`, `AE`, `EE`: Number of entries in `A`, (`B` and `U`), and `V`, respectively.
+"""
+struct DiagonallyImplicit{num_stages, num_steps, NT, AA, AE, EE} <:
+       AbstractTimeIntegrator{num_stages, num_steps}
+    A::SMatrix{num_stages, num_stages, NT, AA}
+    B::SMatrix{num_steps, num_stages, NT, AE}
+    U::SMatrix{num_stages, num_steps, NT, AE}
+    V::SMatrix{num_steps, num_steps, NT, EE}
+    C::SVector{num_stages, NT}
+    time_levels::TimeLevels
+    order::Int
+
+    function DiagonallyImplicit(
+        A::SMatrix{num_stages, num_stages, NT, AA},
+        B::SMatrix{num_steps, num_stages, NT, AE},
+        U::SMatrix{num_stages, num_steps, NT, AE},
+        V::SMatrix{num_steps, num_steps, NT, EE},
+        C::SVector{num_stages, NT},
+        time_levels::TimeLevels,
+        order::Int,
+    ) where {num_stages, num_steps, NT, AA, AE, EE}
+        is_implicit, is_diagonally_implicit = check_implicit(A)
+        if is_implicit
+            throw(
+                ArgumentError(
+                    LazyString(
+                        "Tried to build a DiagonallyImplicit integrator with an A matrix ",
+                        "that belongs to an Implicit scheme",
+                    ),
+                ),
+            )
+        end
+
+        return new{num_stages, num_steps, NT, AA, AE, EE}(A, B, U, V, C, time_levels, order)
+    end
+end
+
+"""
+    Implicit{num_stages, num_steps, NT, AA, AE, EE} <:
+        AbstractTimeIntegrator{num_stages, num_steps}
+
+Implicit time integration scheme
+
+# Fields
+- `A`, `B`, `U`, `V`: See the [GLM characterisation](@ref TIGLMCharacter) for more details,
+    including the matrix sizes. All matrices are of type `SMatrix` with the appropriate
+    size and `NT` as eltype.
+- `C::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at what
+    time each stage is evaluated.
+- `time_levels::TimeLevels`: Required information from previous steps. See
+    [`TimeLevels`](@ref) for the details.
+- `order::Int`: Order of the scheme.
+
+# Type parameters
+- `num_stages`, `num_steps`: See [AbstractTimeIntegrator](@ref) for the details.
+- `NT`: Element type of the `A`, `B`, `U`, `V` matrices.
+- `AA`, `AE`, `EE`: Number of entries in `A`, (`B` and `U`), and `V`, respectively.
+"""
+struct Implicit{num_stages, num_steps, NT, AA, AE, EE} <:
+       AbstractTimeIntegrator{num_stages, num_steps}
+    A::SMatrix{num_stages, num_stages, NT, AA}
+    B::SMatrix{num_steps, num_stages, NT, AE}
+    U::SMatrix{num_stages, num_steps, NT, AE}
+    V::SMatrix{num_steps, num_steps, NT, EE}
+    C::SVector{num_stages, NT}
+    time_levels::TimeLevels
+    order::Int
+
+    function Implicit(
+        A::SMatrix{num_stages, num_stages, NT, AA},
+        B::SMatrix{num_steps, num_stages, NT, AE},
+        U::SMatrix{num_stages, num_steps, NT, AE},
+        V::SMatrix{num_steps, num_steps, NT, EE},
+        C::SVector{num_stages, NT},
+        time_levels::TimeLevels,
+        order::Int,
+    ) where {num_stages, num_steps, NT, AA, AE, EE}
+        return new{num_stages, num_steps, NT, AA, AE, EE}(A, B, U, V, C, time_levels, order)
+    end
+end
+
+"""
+    IMEX{num_stages, num_steps, NT, AA, AE, EE} <:
+        AbstractTimeIntegrator{num_stages, num_steps}
+
+Implicit-Explicit (IMEX) time integration scheme. Currently only supportes implicit parts
+which are diagonally implicit.
+
+# Fields
+- `A_IM`, `A_EX`, `B_IM`, `B_EX`, `U`, `V`: See the
+    [GLM characterisation](@ref TIGLMCharacter) for more details, including the matrix
+    sizes. All matrices are of type `SMatrix` with the appropriate size and `NT` as eltype.
+- `C_IM::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at
+    what time each implicit stage is evaluated.
+- `C_EX::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at
+    what time each explicit stage is evaluated.
+- `time_levels::TimeLevels`: Required information from previous steps. See
+    [`TimeLevels`](@ref) for the details.
+- `order::Int`: order of the scheme
+
+# Type parameters
+- `num_stages`, `num_steps`: See [AbstractTimeIntegrator](@ref) for the details.
+- `NT`: Element type of the `A`, `B`, `U`, `V` matrices.
+- `AA`, `AE`, `EE`: Number of entries in (`A_IM` and `A_EX`), (`B_IM`, `B_EX` and `U`),
+    and `V`, respectively.
+"""
+struct IMEX{num_stages, num_steps, NT, AA, AE, EE} <:
+       AbstractTimeIntegrator{num_stages, num_steps}
+    A_IM::SMatrix{num_stages, num_stages, NT, AA}
+    A_EX::SMatrix{num_stages, num_stages, NT, AA}
+    B_IM::SMatrix{num_steps, num_stages, NT, AE}
+    B_EX::SMatrix{num_steps, num_stages, NT, AE}
+    U::SMatrix{num_stages, num_steps, NT, AE}
+    V::SMatrix{num_steps, num_steps, NT, EE}
+    C_IM::SVector{num_stages, NT}
+    C_EX::SVector{num_stages, NT}
+    time_levels::TimeLevels
+    order::Int
+
+    function IMEX(
+        A_IM::SMatrix{num_stages, num_stages, NT, AA},
+        A_EX::SMatrix{num_stages, num_stages, NT, AA},
+        B_IM::SMatrix{num_steps, num_stages, NT, AE},
+        B_EX::SMatrix{num_steps, num_stages, NT, AE},
+        U::SMatrix{num_stages, num_steps, NT, AE},
+        V::SMatrix{num_steps, num_steps, NT, EE},
+        C_IM::SVector{num_stages, NT},
+        C_EX::SVector{num_stages, NT},
+        time_levels::TimeLevels,
+        order::Int,
+    ) where {num_stages, num_steps, NT, AA, AE, EE}
+        is_implicit, is_diagonally_implicit = check_implicit(A_IM)
+        if is_implicit
+            throw(
+                ArgumentError(
+                    LazyString(
+                        "Tried to build an IMEX integrator with an A matrix ",
+                        "that is fully implicit. This is currenlty not supported.",
+                    ),
+                ),
+            )
+        end
+
+        return new{num_stages, num_steps, NT, AA, AE, EE}(
+            A_IM, A_EX, B_IM, B_EX, U, V, C_IM, C_EX, time_levels, order
+        )
+    end
+end
+
+"""
+    get_order(scheme::AbstractTimeIntegrator)
+
+Return the order of the time integration scheme
+"""
+function get_order(scheme::AbstractTimeIntegrator)
+    return scheme.order
+end
+
+############################################################################################
+##                                       Solutions                                        ##
+############################################################################################
+
+"""
+    TimeIntegrationSolution{T, S, NT, ST}
+
+Solution and current state of the time integration problem.
+
+!!! note "`TimeIntegrationSolution` does not store problem-specific information."
+    While a `TimeIntegrationSolution` stores most information, it does not store problem-
+    specific information. See [`TimeIntegrationOperators`](@ref) for the problem-specific
+    information.
+
+
+# Constructors
+- `TimeIntegrationSolution(
+        solution::Matrix{NT},
+        scheme::AbstractTimeIntegrator{num_stages, num_steps},
+        startup_scheme::Union{Nothing, AbstractTimeIntegrator},
+        remaining_startup_steps::Int,
+        startup_solution::ST=nothing,
+    ) where {NT, num_stages, num_steps, ST}`: General constructor. Note that the eltype of
+        the solution matrix will dictate the number type used in the
+        `TimeIntegrationSolution`.
+
+# Fields
+- `N::Int`: Number varables in the system.
+- `solution::Matrix{NT}`: Of size (`N`, num_steps).
+- `scheme::T`: The time integration scheme.
+- `startup_scheme::S`: The startup scheme, if desired. Will be `nothing` if there is no
+    startup scheme.
+- `remaining_startup_steps::Int`: remaining startup steps
+- `solution_alocated::Matrix{NT}`: Pre-allocated memory for calculations.
+- `F_alocated::Matrix{NT}`: Pre-allocated memory for calculations.
+- `G_alocated::Matrix{NT}`: Pre-allocated memory for calculations.
+- `startup_solution::ST`: The `TimeIntegrationSolution` object used for the startup
+    procedure. This will contain information specific to the startup scheme and its current
+    state. Will be `nothing` if there is no startup scheme.
+- `stage_values::Vector{NT}`: Pre-allocated memory for calculations.
+- `temp_var::Vector{NT}`: Pre-allocated memory for calculations.
+
+# Type parameters
+- `T`: Type of the scheme.
+- `S`: Type of the startup scheme. `Nothing` if no startup scheme is provided.
+- `NT`: eltype of the solution and pre-allocated arrays.
+- `ST`: Type of the startup solution object, `Nothing` if no startup solution is provided.
+"""
+mutable struct TimeIntegrationSolution{T, S, NT, ST}
+    N::Int
+    solution::Matrix{NT}
+    scheme::T
+    startup_scheme::S
+    remaining_startup_steps::Int
+    solution_allocated::Matrix{NT}
+    F_allocated::Matrix{NT}
+    G_allocated::Matrix{NT}
+    startup_solution::ST
+    stage_values::Vector{NT}
+    temp_var::Vector{NT}
+
+    function TimeIntegrationSolution(
+        solution::Matrix{NT},
+        scheme::AbstractTimeIntegrator{num_stages, num_steps},
+        startup_scheme::Union{Nothing, AbstractTimeIntegrator},
+        remaining_startup_steps::Int,
+        startup_solution::ST=nothing,
+    ) where {NT, num_stages, num_steps, ST}
+        return new{typeof(scheme), typeof(startup_scheme), NT, ST}(
+            size(solution, 1),
+            solution,
+            scheme,
+            startup_scheme,
+            remaining_startup_steps,
+            similar(solution),
+            zeros(NT, size(solution, 1), num_stages),
+            zeros(NT, size(solution, 1), num_stages),
+            startup_solution,
+            zeros(NT, size(solution, 1)),
+            zeros(NT, size(solution, 1)),
+        )
+    end
+end
+
+Base.eltype(::Type{TimeIntegrationSolution{T, S, NT, ST}}) where {T, S, NT, ST} = NT
+
+"""
+    get_num_variables(sol::TimeIntegrationSolution)
+
+Return the number of variables in the system.
+"""
+function get_num_variables(sol::TimeIntegrationSolution)
+    return sol.N
+end
+
+"""
+    get_solution(sol::TimeIntegrationSolution{T, S, NT}) where {T, S, NT}
+
+Return the current solution values. This is a Matrix{NT} of size (`N`, num_steps), where
+`N` is the number of variables in the system.
+"""
+function get_solution(sol::TimeIntegrationSolution{T, S, NT}) where {T, S, NT}
+    return sol.solution
+end
+
+"""
+    get_scheme(sol::TimeIntegrationSolution)
+
+Return the time integration scheme used to obtain the solution.
+"""
+function get_scheme(sol::TimeIntegrationSolution)
+    return sol.scheme
+end
+
+"""
+    get_startup_scheme(sol::TimeIntegrationSolution)
+
+Return the startup scheme used to initialise the solution. Will be nothing if no startup
+scheme is present.
+"""
+function get_startup_scheme(sol::TimeIntegrationSolution)
+    return sol.startup_scheme
+end
+
+"""
+    get_remaining_startup_steps(sol::TimeIntegrationSolution)
+
+Return the number of startup steps that still have to be performed. These are the steps
+that will be computed using the startup scheme instead of the main scheme.
+"""
+function get_remaining_startup_steps(sol::TimeIntegrationSolution)
+    return sol.remaining_startup_steps
+end
+
+"""
+    get_solution_allocated(sol::TimeIntegrationSolution)
+
+Return the pre-allocated matrix for the solution. To obtain the solution itself, use
+[`get_solution`](@ref).
+"""
+function get_solution_allocated(sol::TimeIntegrationSolution)
+    return sol.solution_allocated
+end
+
+"""
+    get_F_allocated(sol::TimeIntegrationSolution)
+
+Return the pre-allocated matrix for the explicit stage derivatives.
+"""
+function get_F_allocated(sol::TimeIntegrationSolution)
+    return sol.F_allocated
+end
+
+"""
+    get_G_allocated(sol::TimeIntegrationSolution)
+
+Return the pre-allocated matrix for the implicit stage derivatives
+"""
+function get_G_allocated(sol::TimeIntegrationSolution)
+    return sol.G_allocated
+end
+
+"""
+    get_stage_allocated(sol::TimeIntegrationSolution)
+
+Return the pre-allocated vector for the stage values.
+"""
+function get_stage_allocated(sol::TimeIntegrationSolution)
+    return sol.stage_values
+end
+
+"""
+    get_temp_var(sol::TimeIntegrationSolution)
+
+Return the pre-allocated vector for the temporary variable for the implicit schemes.
+"""
+function get_temp_var(sol::TimeIntegrationSolution)
+    return sol.temp_var
+end
+
+# return a scalar max of all elements in the TimeLevels struct
+Base.maximum(tl::TimeLevels) = maximum([
+    maximum(tl.step_values; init=0),
+    maximum(tl.step_derivatives_implicit; init=0),
+    maximum(tl.step_derivatives_explicit; init=0),
+])

--- a/src/TimeIntegrators/Definitions.jl
+++ b/src/TimeIntegrators/Definitions.jl
@@ -42,13 +42,13 @@ end
 ############################################################################################
 
 """
-    TimeIntegrationOperators{EF, IF, IE}
+    TimeIntegrationOperators{EE, IS, IE}
 
 Defines the ODE-specific operators used in the time integration.
 
-Makes a distiction between the explicit and implicit operators. `EF`, `IF`, and `IE` are
-the types the explicit and implicit functions, which are `Nothing` if not defined. Note
-that at least `EF` or `IF` and `IE` must be a function.
+Makes a distiction between the explicit and implicit operators. `EE`, `IS`, and `IE` are
+the types of the explicit and implicit functions, which are `Nothing` if not defined. Note
+that at least `EE` or `IS` must be a function.
 
 # Constructors
 - `define_explicit_ode(explicit_evaluate::Function)`: For fully explicit ODEs.
@@ -63,13 +63,13 @@ that at least `EF` or `IF` and `IE` must be a function.
     )`: Generic constructor.
 
 # Fields
-- `explicitEvaluate!::EF`: A function that evaluates the explicit part of the ODE, that is,
+- `explicitEvaluate!::EE`: A function that evaluates the explicit part of the ODE, that is,
     the function that evaluates ``F = f(y, t)``. See the manual section on
     [TimeIntegrators](@ref) for the terminology. **This function must have the following
     inputs: (output, yn, t). It must also overwrite the output argument.** The output
     argument will be a vector-like object of length N (the number of variables), as will
     yn. The argument t will be a number indicating the current time.
-- `implicitSolve!::IF`: A function that solves the implicit part of the ODE, that is, the
+- `implicitSolve!::IS`: A function that solves the implicit part of the ODE, that is, the
     function that solves the equation
     ``\\mathbf{Y} - h \\mathbf{g}(\\mathbf{Y}) = \\mathbf{x}``, with
     ``h = a^{IM}_{ii} \\Delta t``. See the manual section on [TimeIntegrators](@ref) for
@@ -78,9 +78,10 @@ that at least `EF` or `IF` and `IE` must be a function.
     ``I`` is the identity function. **This function must have the following inputs:
     (output, x, h, t). It must also overwrite the output argument.** The output argument
     will be a matrix-like object of size (N, num_stages), as will yn. The arguments h will
-    be either a number (for DiagonallyImplicit integrators) or a SMatrix (for Implicit
-    integrators) and t will be a number (for DiagonallyImplicit integrators) or an SVector
-    (for Implicit integrators) indicating the current time(s).
+    be either a number (for DiagonallyImplicit integrators) or a SMatrix of size
+    (num_stages, num_stages) (for Implicit integrators) and t will be a number (for
+    DiagonallyImplicit integrators) or an SVector of length num_stages (for Implicit
+    integrators) indicating the current time(s).
 - `implicitEvaluate!::IE`: A function that evaluates the implicit part of the ODE, that is,
     the function that evaluates ``G = g(y, t)``. See the manual section on
     [TimeIntegrators](@ref) for the terminology. **This function must have the following
@@ -89,13 +90,13 @@ that at least `EF` or `IF` and `IE` must be a function.
     yn, and t will be a number indicating the current time.
 
 # Type parameters
-- `EF`: `typeof(explicitEvaluate!)` if initialised, `Nothing` otherwise.
-- `IF`: `typeof(implicitSolve!)` if initialised, `Nothing` otherwise.
+- `EE`: `typeof(explicitEvaluate!)` if initialised, `Nothing` otherwise.
+- `IS`: `typeof(implicitSolve!)` if initialised, `Nothing` otherwise.
 - `IE`: `typeof(implicitEvaluate!)` if initialised, `Nothing` otherwise.
 """
-struct TimeIntegrationOperators{EF, IF, IE}
-    explicitEvaluate!::EF
-    implicitSolve!::IF
+struct TimeIntegrationOperators{EE, IS, IE}
+    explicitEvaluate!::EE
+    implicitSolve!::IS
     implicitEvaluate!::IE
 
     function TimeIntegrationOperators(
@@ -103,11 +104,25 @@ struct TimeIntegrationOperators{EF, IF, IE}
         implicit_solve::Union{Nothing, Function},
         implicit_evaluate::Union{Nothing, Function},
     )
-        if !(explicit_evaluate isa Function || implicit_solve isa Function || implicit_evaluate isa Function)
+        if !(
+            explicit_evaluate isa Function ||
+            implicit_solve isa Function ||
+            implicit_evaluate isa Function
+        )
             throw(ArgumentError("At least one of the inputs must be a Function."))
         end
 
-        new{typeof(explicit_evaluate), typeof(implicit_solve), typeof(implicit_evaluate)}(
+        if isnothing(explicit_evaluate) && isnothing(implicit_solve)
+            throw(
+                ArgumentError(
+                    "Only implicit_evaluate is given, but implicit_solve is also required."
+                ),
+            )
+        end
+
+        return new{
+            typeof(explicit_evaluate), typeof(implicit_solve), typeof(implicit_evaluate)
+        }(
             explicit_evaluate, implicit_solve, implicit_evaluate
         )
     end
@@ -127,7 +142,9 @@ end
     )
 
 Creates a [`TimeIntegrationOperators`](@ref) object for a diagonally implicit ODE. The
-`implicit_evaluate` argument is only needed when using a multi-step scheme.
+`implicit_evaluate` argument is needed when:
+- using a multi-step scheme (for the initialisation process).
+- using a diagonally implicit scheme that has at least one zero on the diagonal.
 """
 function define_diagonally_implicit_ode(
     implicit_solve::Function, implicit_evaluate::Union{Nothing, Function}=nothing
@@ -150,12 +167,14 @@ end
     )
 
 Creates a [`TimeIntegrationOperators`](@ref) object for an IMEX ODE. The
-`implicit_evaluate` argument is only needed when using a multi-step scheme.
+`implicit_evaluate` argument is needed when:
+- using a multi-step scheme (for the initialisation process).
+- using a diagonally implicit scheme that has at least one zero on the diagonal.
 """
 function define_imex_ode(
     explicit_evaluate::Function,
     implicit_solve::Function,
-    implicit_evaluate::Union{Nothing, Function}=nothing
+    implicit_evaluate::Union{Nothing, Function}=nothing,
 )
     return TimeIntegrationOperators(explicit_evaluate, implicit_solve, implicit_evaluate)
 end
@@ -167,14 +186,43 @@ end
 """
     TimeLevels
 
-The length of the fields of the `TimeLevels` object descibe the structure of the input and
-output vectors for an integrator. The initialisation procedure uses this information to
-determine what needs to be initialised. Note that the vectors may be empty.
+The length of the fields defines the structure of the input and output vectors for an
+integrator. The initialisation procedure uses this information to determine what needs to
+be initialised. Note that the vectors may be empty.
+
+# Constructors
+- `TimeLevels(
+        step_values::Vector{Int}
+        step_derivatives_implicit::Vector{Int}
+        step_derivatives_explicit::Vector{Int}
+    )`: Generic constructor.
+
+# Examples
+Consider the [`CNAB2`](@ref) scheme, which defines the input vector as
+```math
+\\begin{bmatrix}
+\\mathbf{y}^n \\\\
+\\Delta t \\mathbf{G}^n \\\\
+\\Delta t \\mathbf{F}^n \\\\
+\\Delta t \\mathbf{F}^{n-1}
+\\end{bmatrix} \\;,
+```
+so, the `TimeLevels` input for this scheme is `TimeLevels([0], [0], [0, 1])`.
+
+Consider the [`BDF3`](@ref) scheme, which defines the input vector as
+```math
+\\begin{bmatrix}
+\\mathbf{y}^{n} \\\\
+\\mathbf{y}^{n-1} \\\\
+\\mathbf{y}^{n-2} \\\\
+\\end{bmatrix} \\;,
+```
+so, the `TimeLevels` input for this scheme is `TimeLevels([0, 1, 2], Int[], Int[])`.
 
 # Fields
 - `step_values::Vector{Int}`: The length of this vector determines how many previous
-    solutions. For multi-stage methods, this is often just `[0]`. For multi-step methods,
-    this may include a longer history.
+    solutions are needed. For multi-stage methods, this is often just `[0]`. For multi-step
+    methods, this may include a longer history.
 - `step_derivatives_implicit::Vector{Int}`: Required implicit step derivatives from
     previous steps. Note that this is ``\\Delta t G``. This is, for example, used in the
     Adams-Moulton schemes.
@@ -188,6 +236,40 @@ struct TimeLevels
     step_derivatives_explicit::Vector{Int}
 end
 
+"""
+    get_num_step_values(tl::TimeLevels)
+
+Return the number of step values that `tl` encodes.
+"""
+function get_num_step_values(tl::TimeLevels)
+    return length(tl.step_values)
+end
+
+"""
+    get_num_implicit_derivatives(tl::TimeLevels)
+
+Return the number of implicit derivatives that `tl` encodes.
+"""
+function get_num_implicit_derivatives(tl::TimeLevels)
+    return length(tl.step_derivatives_implicit)
+end
+
+"""
+    get_num_explicit_derivatives(tl::TimeLevels)
+
+Return the number of explicit derivatives that `tl` encodes.
+"""
+function get_num_explicit_derivatives(tl::TimeLevels)
+    return length(tl.step_derivatives_explicit)
+end
+
+# return a scalar max of all elements in the TimeLevels struct
+Base.maximum(tl::TimeLevels) = max(
+    maximum(tl.step_values; init=0),
+    maximum(tl.step_derivatives_implicit; init=0),
+    maximum(tl.step_derivatives_explicit; init=0),
+)
+
 ############################################################################################
 ##                                      Integrators                                       ##
 ############################################################################################
@@ -195,18 +277,22 @@ end
 """
     check_implicit(A::AbstractMatrix)
 
-Check if the GLM matrix `A` belongs to an implicit or diagonally implicit scheme. Returns
-two booleans; the first indicates if the scheme is fully implicit, the second if the scheme
-is diagonally implicit.
+Check if the GLM matrix `A` belongs to an implicit or diagonally implicit scheme.
+
+# Returns
+- `is_implicit::Bool`: whether the scheme is fully implicit or not
+- `is_diagonally_implicit::Bool`: whether the scheme is diagonally implicit. Note that both
+    outputs are true for a fully implicit scheme, and that only this argument is true for a
+    diagonally implicit scheme.
 """
 function check_implicit(A::AbstractMatrix)
     is_implicit = false
     is_diagonally_implicit = false
     for j in axes(A, 2)
-        for i in axes(A, 1)
-            if i == j && A[i, j] != zero(eltype(A))
+        for i in firstindex(axes(A, 1)):j
+            if i == j && !iszero(A[i, j])
                 is_diagonally_implicit = true
-            elseif j > i && A[i, j] != zero(eltype(A))
+            elseif j > i && !iszero(A[i, j])
                 is_implicit = true
             end
         end
@@ -228,18 +314,16 @@ Explicit time integration scheme.
     indirect explicit method in this case.
 
 # Fields
-- `A`, `B`, `U`, `V`: See the [GLM characterisation](@ref TIGLMCharacter) for more details,
-    including the matrix sizes. All matrices are of type `SMatrix` with the appropriate
-    size and `NT` as eltype.
-- `C::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at what
-    time each stage is evaluated.
+- `A`, `B`, `U`, `V`, `C`: See the [GLM characterisation](@ref TIGLMCharacter) for more
+    details, including the matrix sizes. All matrices (and vector) are of type `SMatrix`
+    (or `SVector`, respectively) with the appropriate size and `NT` as eltype.
 - `time_levels::TimeLevels`: Required information from previous steps. See
     [`TimeLevels`](@ref) for the details.
 - `order::Int`: Order of the scheme.
 
 # Type parameters
 - `num_stages`, `num_steps`: See [AbstractTimeIntegrator](@ref) for the details.
-- `NT`: Element type of the `A`, `B`, `U`, `V` matrices.
+- `NT`: Element type of the `A`, `B`, `U`, `V` matrices, and `C` vector.
 - `AA`, `AE`, `EE`: Number of entries in `A`, (`B` and `U`), and `V`, respectively.
 """
 struct Explicit{num_stages, num_steps, NT, AA, AE, EE} <:
@@ -281,21 +365,19 @@ end
     DiagonallyImplicit{num_stages, num_steps, NT, AA, AE, EE} <:
         AbstractTimeIntegrator{num_stages, num_steps}
 
-DiagonallyImplicit time integration scheme.
+Diagonally implicit time integration scheme.
 
 # Fields
-- `A`, `B`, `U`, `V`: See the [GLM characterisation](@ref TIGLMCharacter) for more details,
-    including the matrix sizes. All matrices are of type `SMatrix` with the appropriate
-    size and `NT` as eltype.
-- `C::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at what
-    time each stage is evaluated.
+- `A`, `B`, `U`, `V`, `C`: See the [GLM characterisation](@ref TIGLMCharacter) for more
+    details, including the matrix sizes. All matrices (and vector) are of type `SMatrix`
+    (or `SVector`, respectively) with the appropriate size and `NT` as eltype.
 - `time_levels::TimeLevels`: Required information from previous steps. See
     [`TimeLevels`](@ref) for the details.
 - `order::Int`: Order of the scheme.
 
 # Type parameters
 - `num_stages`, `num_steps`: See [AbstractTimeIntegrator](@ref) for the details.
-- `NT`: Element type of the `A`, `B`, `U`, `V` matrices.
+- `NT`: Element type of the `A`, `B`, `U`, `V` matrices, and `C` vector.
 - `AA`, `AE`, `EE`: Number of entries in `A`, (`B` and `U`), and `V`, respectively.
 """
 struct DiagonallyImplicit{num_stages, num_steps, NT, AA, AE, EE} <:
@@ -317,7 +399,7 @@ struct DiagonallyImplicit{num_stages, num_steps, NT, AA, AE, EE} <:
         time_levels::TimeLevels,
         order::Int,
     ) where {num_stages, num_steps, NT, AA, AE, EE}
-        is_implicit, is_diagonally_implicit = check_implicit(A)
+        is_implicit, _ = check_implicit(A)
         if is_implicit
             throw(
                 ArgumentError(
@@ -340,18 +422,16 @@ end
 Implicit time integration scheme
 
 # Fields
-- `A`, `B`, `U`, `V`: See the [GLM characterisation](@ref TIGLMCharacter) for more details,
-    including the matrix sizes. All matrices are of type `SMatrix` with the appropriate
-    size and `NT` as eltype.
-- `C::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at what
-    time each stage is evaluated.
+- `A`, `B`, `U`, `V`, `C`: See the [GLM characterisation](@ref TIGLMCharacter) for more
+    details, including the matrix sizes. All matrices (and vector) are of type `SMatrix`
+    (or `SVector`, respectively) with the appropriate size and `NT` as eltype.
 - `time_levels::TimeLevels`: Required information from previous steps. See
     [`TimeLevels`](@ref) for the details.
 - `order::Int`: Order of the scheme.
 
 # Type parameters
 - `num_stages`, `num_steps`: See [AbstractTimeIntegrator](@ref) for the details.
-- `NT`: Element type of the `A`, `B`, `U`, `V` matrices.
+- `NT`: Element type of the `A`, `B`, `U`, `V` matrices, and `C` vector.
 - `AA`, `AE`, `EE`: Number of entries in `A`, (`B` and `U`), and `V`, respectively.
 """
 struct Implicit{num_stages, num_steps, NT, AA, AE, EE} <:
@@ -385,20 +465,18 @@ Implicit-Explicit (IMEX) time integration scheme. Currently only supportes impli
 which are diagonally implicit.
 
 # Fields
-- `A_IM`, `A_EX`, `B_IM`, `B_EX`, `U`, `V`: See the
+- `A_IM`, `A_EX`, `B_IM` `B_EX`, `U`, `V`, `C_IM`, `C_EX`: See the
     [GLM characterisation](@ref TIGLMCharacter) for more details, including the matrix
-    sizes. All matrices are of type `SMatrix` with the appropriate size and `NT` as eltype.
-- `C_IM::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at
-    what time each implicit stage is evaluated.
-- `C_EX::SVector{num_stages, NT}`: Time Vector C of length `num_stages`. Indicates at
-    what time each explicit stage is evaluated.
+    sizes. All matrices (and vector) are of type `SMatrix` (or `SVector`, respectively)
+    with the appropriate size and `NT` as eltype.
 - `time_levels::TimeLevels`: Required information from previous steps. See
     [`TimeLevels`](@ref) for the details.
-- `order::Int`: order of the scheme
+- `order::Int`: Order of the scheme.
 
 # Type parameters
 - `num_stages`, `num_steps`: See [AbstractTimeIntegrator](@ref) for the details.
-- `NT`: Element type of the `A`, `B`, `U`, `V` matrices.
+- `NT`: Element type of the `A_IM`, `A_EX`, `B_IM` `B_EX`, `U`, and `V` matrices, and
+    `C_IM`, and `C_EX` vectors.
 - `AA`, `AE`, `EE`: Number of entries in (`A_IM` and `A_EX`), (`B_IM`, `B_EX` and `U`),
     and `V`, respectively.
 """
@@ -427,7 +505,7 @@ struct IMEX{num_stages, num_steps, NT, AA, AE, EE} <:
         time_levels::TimeLevels,
         order::Int,
     ) where {num_stages, num_steps, NT, AA, AE, EE}
-        is_implicit, is_diagonally_implicit = check_implicit(A_IM)
+        is_implicit, _ = check_implicit(A_IM)
         if is_implicit
             throw(
                 ArgumentError(
@@ -452,6 +530,10 @@ Return the order of the time integration scheme
 """
 function get_order(scheme::AbstractTimeIntegrator)
     return scheme.order
+end
+
+function get_time_levels(scheme::AbstractTimeIntegrator)
+    return scheme.time_levels
 end
 
 ############################################################################################
@@ -484,15 +566,15 @@ Solution and current state of the time integration problem.
 - `N::Int`: Number varables in the system.
 - `solution::Matrix{NT}`: Of size (`N`, num_steps).
 - `scheme::T`: The time integration scheme.
-- `startup_scheme::S`: The startup scheme, if desired. Will be `nothing` if there is no
-    startup scheme.
-- `remaining_startup_steps::Int`: remaining startup steps
-- `solution_alocated::Matrix{NT}`: Pre-allocated memory for calculations.
-- `F_alocated::Matrix{NT}`: Pre-allocated memory for calculations.
-- `G_alocated::Matrix{NT}`: Pre-allocated memory for calculations.
+- `startup_scheme::S`: The startup scheme, if provided. Will be `nothing` if not provided.
+    Defaults to `nothing`.
+- `remaining_startup_steps::Int`: Remaining startup steps.
+- `solution_allocated::Matrix{NT}`: Pre-allocated memory for calculations.
+- `F_alLocated::Matrix{NT}`: Pre-allocated memory for calculations.
+- `G_alLocated::Matrix{NT}`: Pre-allocated memory for calculations.
 - `startup_solution::ST`: The `TimeIntegrationSolution` object used for the startup
     procedure. This will contain information specific to the startup scheme and its current
-    state. Will be `nothing` if there is no startup scheme.
+    state. Will be `nothing` if not provided. Defaults to `nothing`.
 - `stage_values::Vector{NT}`: Pre-allocated memory for calculations.
 - `temp_var::Vector{NT}`: Pre-allocated memory for calculations.
 
@@ -555,7 +637,7 @@ end
 Return the current solution values. This is a Matrix{NT} of size (`N`, num_steps), where
 `N` is the number of variables in the system.
 """
-function get_solution(sol::TimeIntegrationSolution{T, S, NT}) where {T, S, NT}
+function get_solution(sol::TimeIntegrationSolution)
     return sol.solution
 end
 
@@ -617,6 +699,15 @@ function get_G_allocated(sol::TimeIntegrationSolution)
 end
 
 """
+    get_startup_solution(sol::TimeIntegrationSolution)
+
+Return the solution object corresponding to the startup scheme.
+"""
+function get_startup_solution(sol::TimeIntegrationSolution)
+    return sol.startup_solution
+end
+
+"""
     get_stage_allocated(sol::TimeIntegrationSolution)
 
 Return the pre-allocated vector for the stage values.
@@ -633,10 +724,3 @@ Return the pre-allocated vector for the temporary variable for the implicit sche
 function get_temp_var(sol::TimeIntegrationSolution)
     return sol.temp_var
 end
-
-# return a scalar max of all elements in the TimeLevels struct
-Base.maximum(tl::TimeLevels) = maximum([
-    maximum(tl.step_values; init=0),
-    maximum(tl.step_derivatives_implicit; init=0),
-    maximum(tl.step_derivatives_explicit; init=0),
-])

--- a/src/TimeIntegrators/Initialisations.jl
+++ b/src/TimeIntegrators/Initialisations.jl
@@ -1,0 +1,96 @@
+"""
+    initialize_scheme(
+        y0::Matrix{T}, scheme::AbstractTimeIntegrator{num_stages, num_steps}
+    ) where {T, num_stages, num_steps}
+
+Creates the TimeIntegrationSolution object with a initialized y0 vector.
+
+# Arguments
+- `y0::Matrix{T}`: The initial value of the solution matrix.
+- `scheme::AbstractTimeIntegrator{num_stages, num_steps}`: The time integration scheme.
+
+# Returns
+- `TimeIntegrationSolution{num_steps}`: The initialized solution vector.
+"""
+function initialize_scheme(
+    y0::Matrix{T}, scheme::AbstractTimeIntegrator{num_stages, num_steps}
+) where {T, num_stages, num_steps}
+    return TimeIntegrationSolution(y0, scheme, nothing, 0)
+end
+
+"""
+    initialize_scheme(
+        y0::Vector{T}, scheme::AbstractTimeIntegrator{num_stages, num_steps}
+    ) where {T, num_stages, num_steps}
+
+Initialise single-step schemes. The given input vector will be turned into a matrix of the
+appropriate size.
+
+# Arguments
+- `y0::Vector{T}`: The initial value of the solution vector.
+- `scheme::AbstractTimeIntegrator{num_stages, num_steps}`: The time integration scheme.
+"""
+function initialize_scheme(
+    y0::Vector{T}, scheme::AbstractTimeIntegrator{num_stages, num_steps}
+) where {T, num_stages, num_steps}
+    if maximum(scheme.time_levels) != 0
+        throw(ArgumentError("The scheme is not a single-step scheme"))
+    end
+
+    # Set the solution vector which has time level 0 to the initial value.
+    yn = zeros(T, length(y0), num_steps)
+    yn[:, 1] .= y0
+
+    return initialize_scheme(yn, scheme)
+end
+
+"""
+    initialize_scheme(
+        y0::Vector{T},
+        scheme::AbstractTimeIntegrator{num_stages_scheme, num_steps},
+        startup_scheme::AbstractTimeIntegrator{num_stages_startup, 1},
+    ) where {T, num_stages_scheme, num_steps, num_stages_startup}
+
+Initialise multi-step schemes.
+
+# Arguments
+- `y0::Vector{T}`: The initial value of the solution vector.
+- `scheme::AbstractTimeIntegrator{num_stages_scheme, num_steps}`: The time integration
+    scheme.
+- `startup_scheme::AbstractTimeIntegrator{num_stages_startup, 1}`: The startup scheme.
+
+# Returns
+- `TimeIntegrationSolution{num_steps}`: The initialized solution vector.
+"""
+function initialize_scheme(
+    y0::Vector{T},
+    scheme::AbstractTimeIntegrator{num_stages_scheme, num_steps},
+    startup_scheme::AbstractTimeIntegrator{num_stages_startup, 1},
+) where {T, num_stages_scheme, num_steps, num_stages_startup}
+    if num_steps == 1
+        throw(
+            ArgumentError(
+                "The scheme is a single-step scheme, so no startup_scheme is needed."
+            ),
+        )
+    end
+
+    total_length =
+        length(scheme.time_levels.step_values) +
+        length(scheme.time_levels.step_derivatives_explicit) +
+        length(scheme.time_levels.step_derivatives_implicit)
+
+    # Set the solution vector which has time level 0 to the initial value.
+    yn = zeros(T, length(y0), total_length)
+    yn[:, length(scheme.time_levels.step_values)] .= y0
+
+    n_startup_steps = max(
+        length(scheme.time_levels.step_values) - 1,
+        length(scheme.time_levels.step_derivatives_explicit),
+        length(scheme.time_levels.step_derivatives_implicit),
+    )
+
+    sol_startup = initialize_scheme(y0, startup_scheme)
+
+    return TimeIntegrationSolution(yn, scheme, startup_scheme, n_startup_steps, sol_startup)
+end

--- a/src/TimeIntegrators/Initialisations.jl
+++ b/src/TimeIntegrators/Initialisations.jl
@@ -1,25 +1,25 @@
 """
-    initialize_scheme(
+    initialise_scheme(
         y0::Matrix{T}, scheme::AbstractTimeIntegrator{num_stages, num_steps}
     ) where {T, num_stages, num_steps}
 
-Creates the TimeIntegrationSolution object with a initialized y0 vector.
+Creates the TimeIntegrationSolution object with an initialised y0 vector.
 
 # Arguments
 - `y0::Matrix{T}`: The initial value of the solution matrix.
 - `scheme::AbstractTimeIntegrator{num_stages, num_steps}`: The time integration scheme.
 
 # Returns
-- `TimeIntegrationSolution{num_steps}`: The initialized solution vector.
+- `TimeIntegrationSolution{num_steps}`: The initialised solution vector.
 """
-function initialize_scheme(
+function initialise_scheme(
     y0::Matrix{T}, scheme::AbstractTimeIntegrator{num_stages, num_steps}
 ) where {T, num_stages, num_steps}
     return TimeIntegrationSolution(y0, scheme, nothing, 0)
 end
 
 """
-    initialize_scheme(
+    initialise_scheme(
         y0::Vector{T}, scheme::AbstractTimeIntegrator{num_stages, num_steps}
     ) where {T, num_stages, num_steps}
 
@@ -30,22 +30,22 @@ appropriate size.
 - `y0::Vector{T}`: The initial value of the solution vector.
 - `scheme::AbstractTimeIntegrator{num_stages, num_steps}`: The time integration scheme.
 """
-function initialize_scheme(
+function initialise_scheme(
     y0::Vector{T}, scheme::AbstractTimeIntegrator{num_stages, num_steps}
 ) where {T, num_stages, num_steps}
     if maximum(scheme.time_levels) != 0
-        throw(ArgumentError("The scheme is not a single-step scheme"))
+        throw(ArgumentError(LazyString("The scheme is not a single-step scheme")))
     end
 
     # Set the solution vector which has time level 0 to the initial value.
     yn = zeros(T, length(y0), num_steps)
     yn[:, 1] .= y0
 
-    return initialize_scheme(yn, scheme)
+    return initialise_scheme(yn, scheme)
 end
 
 """
-    initialize_scheme(
+    initialise_scheme(
         y0::Vector{T},
         scheme::AbstractTimeIntegrator{num_stages_scheme, num_steps},
         startup_scheme::AbstractTimeIntegrator{num_stages_startup, 1},
@@ -60,9 +60,9 @@ Initialise multi-step schemes.
 - `startup_scheme::AbstractTimeIntegrator{num_stages_startup, 1}`: The startup scheme.
 
 # Returns
-- `TimeIntegrationSolution{num_steps}`: The initialized solution vector.
+- `TimeIntegrationSolution{num_steps}`: The initialised solution vector.
 """
-function initialize_scheme(
+function initialise_scheme(
     y0::Vector{T},
     scheme::AbstractTimeIntegrator{num_stages_scheme, num_steps},
     startup_scheme::AbstractTimeIntegrator{num_stages_startup, 1},
@@ -70,27 +70,27 @@ function initialize_scheme(
     if num_steps == 1
         throw(
             ArgumentError(
-                "The scheme is a single-step scheme, so no startup_scheme is needed."
+                LazyString(
+                    "The scheme is a single-step scheme, so no startup_scheme is needed."
+                ),
             ),
         )
     end
 
-    total_length =
-        length(scheme.time_levels.step_values) +
-        length(scheme.time_levels.step_derivatives_explicit) +
-        length(scheme.time_levels.step_derivatives_implicit)
+    tl = get_time_levels(scheme)
+    num_step_values = get_num_step_values(tl)
+    num_impl_ders = get_num_implicit_derivatives(tl)
+    num_expl_ders = get_num_explicit_derivatives(tl)
+
+    total_length = num_step_values + num_impl_ders + num_expl_ders
 
     # Set the solution vector which has time level 0 to the initial value.
     yn = zeros(T, length(y0), total_length)
-    yn[:, length(scheme.time_levels.step_values)] .= y0
+    yn[:, num_step_values] .= y0
 
-    n_startup_steps = max(
-        length(scheme.time_levels.step_values) - 1,
-        length(scheme.time_levels.step_derivatives_explicit),
-        length(scheme.time_levels.step_derivatives_implicit),
-    )
+    n_startup_steps = max(num_step_values - 1, num_impl_ders, num_expl_ders)
 
-    sol_startup = initialize_scheme(y0, startup_scheme)
+    sol_startup = initialise_scheme(y0, startup_scheme)
 
     return TimeIntegrationSolution(yn, scheme, startup_scheme, n_startup_steps, sol_startup)
 end

--- a/src/TimeIntegrators/Integrations.jl
+++ b/src/TimeIntegrators/Integrations.jl
@@ -1,0 +1,671 @@
+"""
+    time_integrate(
+        y_n::TimeIntegrationSolution,
+        ode::TimeIntegrationOperators,
+        t::Float64,
+        dt::Float64;
+        kwargs...,
+    )
+
+Perform a single time integration step using the given time integration scheme and ODE
+system operators. Creates a copy of the solution when called.
+
+# See also
+[`time_integrate!`](@ref)
+
+# Arguments
+- `y_n::TimeIntegrationSolution`: The current solution vector.
+- `ode::TimeIntegrationOperators`: The ODE system operators.
+- `t::Float64`: The current time.
+- `dt::Float64`: The time step.
+- `kwargs...`: Additional arguments passed to the ODE system.
+
+# Returns
+- `TimeIntegrationSolution`: The updated solution vector after one time step.
+"""
+function time_integrate(
+    y_n::TimeIntegrationSolution,
+    ode::TimeIntegrationOperators,
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+)
+    y_n = deepcopy(y_n)
+    time_integrate!(y_n, ode, t, dt; kwargs...)
+    return y_n
+end
+
+"""
+    time_integrate!(
+        y_n::TimeIntegrationSolution,
+        ode::TimeIntegrationOperators,
+        t::Float64,
+        dt::Float64;
+        kwargs...,
+    )
+
+Perform a single, in-place time integration step using the given time integration scheme
+and ODE system operators.
+
+# See also
+[`time_integrate`](@ref)
+
+# Arguments
+- `y_n::TimeIntegrationSolution`: The current solution vector.
+- `ode::TimeIntegrationOperators`: The ODE system operators.
+- `t::Float64`: The current time.
+- `dt::Float64`: The time step.
+- `kwargs...`: Additional arguments passed to the ODE system.
+
+# Returns (in-place)
+- `TimeIntegrationSolution`: The updated solution vector after one time step.
+"""
+function time_integrate!(
+    y_n::TimeIntegrationSolution{T, S},
+    ode::TimeIntegrationOperators,
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {T, S <: AbstractTimeIntegrator}
+    remaining_startup_steps = get_remaining_startup_steps(y_n)
+    if remaining_startup_steps > 0
+        num_steps = length(y_n.scheme.time_levels.step_values)
+        num_G = length(y_n.scheme.time_levels.step_derivatives_implicit)
+        num_F = length(y_n.scheme.time_levels.step_derivatives_explicit)
+
+        y_n_startup = y_n.startup_solution
+
+        # We do have to advance the solution using the startup scheme, to ensure that the
+        # solution remains at the expected time level, even if some of the startup steps
+        # are only needed to initialise the step derivatives.
+        ynm1 = get_solution(y_n_startup)
+        _time_integrate!(y_n_startup, y_n.startup_scheme, ode, t, dt; kwargs...)
+
+        # Then we initialise the required solutions and stage derivatives. Note these are
+        # all if statements, as we may need all of them at the same time. The first
+        # condition in the if statements always check if we ever need the specific type of
+        # initialisation, while the second condition ensures that we are at the correct
+        # time to initialise the solution or stage derivatives.
+        if num_steps > 0 && remaining_startup_steps - num_steps <= 0
+            index_steps = num_steps + (remaining_startup_steps - num_steps)
+            y_n.solution[:, index_steps] = get_solution(y_n_startup)
+        end
+        if num_G > 0 && remaining_startup_steps - num_G <= 0
+            index_implicit = num_steps + num_G + (remaining_startup_steps - num_G)
+            ode.implicitEvaluate!(
+                view(y_n.solution, :, index_implicit),
+                get_solution(y_n_startup),
+                t+dt;
+                kwargs...
+            )
+            y_n.solution[:, index_implicit] .*= dt
+        end
+        if num_F > 0 && remaining_startup_steps - num_F <= 0
+            index_explicit = num_steps + num_G + num_F + (remaining_startup_steps - num_F)
+            ode.explicitEvaluate!(view(y_n.solution, :, index_explicit), ynm1, t; kwargs...)
+            y_n.solution[:, index_explicit] .*= dt
+        end
+
+        t += dt
+        y_n.remaining_startup_steps = y_n.remaining_startup_steps - 1
+
+        return y_n
+    else
+        _time_integrate!(y_n, get_scheme(y_n), ode, t, dt; kwargs...)
+
+        return y_n
+    end
+end
+
+function time_integrate!(
+    y_n::TimeIntegrationSolution{T, Nothing}, # No startup scheme
+    ode::TimeIntegrationOperators,
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {T}
+    return _time_integrate!(y_n, get_scheme(y_n), ode, t, dt; kwargs...)
+end
+
+############################################################################################
+##                              Type-specific implementations                             ##
+############################################################################################
+
+# First, we create the integrate methods that error when the TimeIntegrationOperators do
+# not have the right functions initialised. This allows us to throw more precise errors.
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::Explicit{num_stages, num_steps},
+    ode::TimeIntegrationOperators{Nothing, IF, IE},
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages, IF, IE}
+    throw(
+        ArgumentError(
+            LazyString(
+                "You are trying to use an Explicit scheme but have provided an ",
+                "ode (in a TimeIntegrationOperators struct) which does not have an ",
+                "explicitEvaluate! function."
+            )
+        )
+    )
+end
+
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::DiagonallyImplicit{num_stages, num_steps},
+    ode::TimeIntegrationOperators{EF, Nothing, IE},
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages, EF, IE}
+    throw(
+        ArgumentError(
+            LazyString(
+                "You are trying to use a DiagonallyImplicit scheme but have provided an ",
+                "ode (in a TimeIntegrationOperators struct) which does not have an ",
+                "implicitSolve! function."
+            )
+        )
+    )
+end
+
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::Implicit{num_stages, num_steps},
+    ode::TimeIntegrationOperators{EF, Nothing, IE},
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages, EF, IE}
+    throw(
+        ArgumentError(
+            LazyString(
+                "You are trying to use an Implicit scheme but have provided an ",
+                "ode (in a TimeIntegrationOperators struct) which does not have an ",
+                "implicitSolve! function."
+            )
+        )
+    )
+end
+
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::Implicit{num_stages, num_steps},
+    ode::TimeIntegrationOperators{EF, IF, Nothing},
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages, EF, IF}
+    throw(
+        ArgumentError(
+            LazyString(
+                "You are trying to use an Implicit scheme but have provided an ",
+                "ode (in a TimeIntegrationOperators struct) which does not have an ",
+                "implicitEvaluate! function."
+            )
+        )
+    )
+end
+
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::Implicit{num_stages, num_steps},
+    ode::TimeIntegrationOperators{EF, Nothing, Nothing},
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages, EF}
+    throw(
+        ArgumentError(
+            LazyString(
+                "You are trying to use an Implicit scheme but have provided an ",
+                "ode (in a TimeIntegrationOperators struct) which does not have an ",
+                "implicitSolve! nor an implicitEvaluate! function."
+            )
+        )
+    )
+end
+
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::IMEX{num_stages, num_steps},
+    ode::TimeIntegrationOperators{Nothing, IF, IE},
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages, IF, IE}
+    throw(
+        ArgumentError(
+            LazyString(
+                "You are trying to use an IMEX scheme but have provided an ",
+                "ode (in a TimeIntegrationOperators struct) which does not have an ",
+                "explicitEvaluate! function."
+            )
+        )
+    )
+end
+
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::IMEX{num_stages, num_steps},
+    ode::TimeIntegrationOperators{EF, Nothing, IE},
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages, EF, IE}
+    throw(
+        ArgumentError(
+            LazyString(
+                "You are trying to use an IMEX scheme but have provided an ",
+                "ode (in a TimeIntegrationOperators struct) which does not have an ",
+                "implicitSolve! function."
+            )
+        )
+    )
+end
+
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::IMEX{num_stages, num_steps},
+    ode::TimeIntegrationOperators{Nothing, Nothing, IE},
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages, IE}
+    throw(
+        ArgumentError(
+            LazyString(
+                "You are trying to use an IMEX scheme but have provided an ",
+                "ode (in a TimeIntegrationOperators struct) which does not have an ",
+                "explicitEvaluate! nor an implicitSolve! function."
+            )
+        )
+    )
+end
+
+# Now we can define the integrators themselves, without having to worry about the ode
+# having the required functions.
+
+"""
+    _time_integrate!(
+        y_n::TimeIntegrationSolution,
+        scheme::Explicit{num_stages, num_steps},
+        ode::TimeIntegrationOperators,
+        t::Float64,
+        dt::Float64;
+        kwargs...,
+    ) where {num_steps, num_stages}
+
+Perform a single time integration step using the given Explicit time integration scheme and
+ODE system operators. Implements algorithm 1 of [Vos2011](@cite) specifically for when the
+integrator is explicit.
+
+# Arguments
+- `y_n::TimeIntegrationSolution`: The current solution vector.
+- `scheme::Explicit{num_stages, num_steps}`: The Explicit time integration scheme.
+- `ode::TimeIntegrationOperators`: The ODE system operators.
+- `t::Float64`: The current time.
+- `dt::Float64`: The time step.
+- `kwargs...`: Additional arguments passed to the ODE system.
+
+# Returns (in-place)
+- `TimeIntegrationSolution{num_steps}`: The updated solution vector after one time step.
+"""
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::Explicit{num_stages, num_steps},
+    ode::TimeIntegrationOperators,
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages}
+    T = eltype(y_n)
+    N = get_num_variables(y_n)
+    y_nm1 = get_solution(y_n)
+
+    # Get pre-allocated scratch spaces.
+    solution_allocated = get_solution_allocated(y_n)
+    solution_allocated .= zero(T)
+    stage_values = get_stage_allocated(y_n)
+    F_allocated = get_F_allocated(y_n)
+    F_allocated .= zero(T)
+
+    @inbounds for i in 1:num_stages
+        stage_values .= zero(T)
+        # Calculate the stage value Yi
+        for k in 1:i
+            for n in 1:N
+                stage_values[n] += F_allocated[n, k] * scheme.A[i, k] * dt
+            end
+        end
+        for j in 1:num_steps
+            for n in 1:N
+                stage_values[n] += scheme.U[i, j] * y_nm1[n, j]
+            end
+        end
+
+        # Calculate the stage derivative Fᵢ
+        ode.explicitEvaluate!(
+            view(F_allocated, :, i), stage_values, t + scheme.C[i] * dt; kwargs...
+        )
+    end
+
+    # Optimisation when both the last stages are the same as the first step, so we can skip
+    # the calculation of the final solution
+    start_index = 1
+    if scheme.U[end, :] == scheme.V[1, :] && scheme.A[end, :] == scheme.B[1, :]
+        for n in 1:N
+            solution_allocated[n, 1] = stage_values[n]
+        end
+        start_index = 2
+    end
+
+    @inbounds for i in start_index:num_steps
+        for k in 1:num_stages
+            for n in 1:N
+                solution_allocated[n, i] += F_allocated[n, k] * scheme.B[i, k] * dt
+            end
+        end
+        for k in 1:num_steps
+            for n in 1:N
+                solution_allocated[n, i] += y_nm1[n, k] * scheme.V[i, k]
+            end
+        end
+    end
+
+    # swich the pointers of y_n.solution and y_n.solution_allocated
+    y_n.solution, y_n.solution_allocated = y_n.solution_allocated, y_n.solution
+
+    return y_n
+end
+
+"""
+    _time_integrate!(
+        y_n::TimeIntegrationSolution,
+        scheme::DiagonallyImplicit{num_stages, num_steps},
+        ode::TimeIntegrationOperators,
+        t::Float64,
+        dt::Float64;
+        kwargs...,
+    ) where {num_steps, num_stages}
+
+Perform a single time integration step using the given DiagonallyImplicit time integration
+scheme and ODE system operators. Implements algorithm 1 of [Vos2011](@cite) specifically
+for when the integrator in diagonally implicit.
+
+# Arguments
+- `y_n::TimeIntegrationSolution{num_steps}`: The current solution vector.
+- `scheme::DiagonallyImplicit{num_stages,num_steps}`: The DiagonallyImplicit time integration scheme.
+- `ode::TimeIntegrationOperators`: The ODE system operators.
+- `t::Float64`: The current time.
+- `dt::Float64`: The time step.
+- `kwargs...`: Additional arguments passed to the ODE system.
+
+# Returns (in-place)
+- `TimeIntegrationSolution{num_steps}`: The updated solution vector after one time step.
+"""
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::DiagonallyImplicit{num_stages, num_steps},
+    ode::TimeIntegrationOperators,
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages}
+    T = eltype(y_n)
+    N = get_num_variables(y_n)
+    y_nm1 = get_solution(y_n)
+
+    # Get pre-allocated scratch spaces.
+    solution_allocated = get_solution_allocated(y_n)
+    solution_allocated .= zero(T)
+    temp_var = get_temp_var(y_n)
+    G = get_G_allocated(y_n)
+    G .= zero(T)
+
+    @inbounds for i in 1:num_stages
+        # calculate the temporary value xᵢ
+        temp_var .= zero(T)
+        for k in 1:i
+            for n in 1:N
+                temp_var[n] += G[n, k] * scheme.A[i, k] * dt
+            end
+        end
+        for j in 1:num_steps
+            for n in 1:N
+                temp_var[n] += scheme.U[i, j] * y_nm1[n, j]
+            end
+        end
+
+        # Calculate the stage value Yᵢ
+        # solve (Yᵢ - aᵢᵢᴵᴹ * h * g(Yᵢ,t)) = xᵢ
+        ode.implicitSolve!(
+            y_n.stage_values, temp_var, scheme.A[i, i] * dt, t + scheme.C[i] * dt; kwargs...
+        )
+        # Calculate the stage derivative Gᵢ
+        let a_ii = scheme.A[i, i]
+            if !iszero(a_ii)
+                for n in 1:N
+                    G[n, i] = (y_n.stage_values[n] - temp_var[n]) / (a_ii * dt)
+                end
+            else
+                for n in 1:N
+                    G[n, i] = zero(T)
+                end
+            end
+        end
+    end
+
+    # Optimisation when both the last stages are the same as the first step, so we can skip
+    # the calculation of the final solution
+    start_index = 1
+    if scheme.U[end, :] == scheme.V[1, :] && scheme.A[end, :] == scheme.B[1, :]
+        for n in 1:N
+            solution_allocated[n, 1] = y_n.stage_values[n]
+        end
+        start_index = 2
+    end
+
+    @inbounds for i in start_index:num_steps
+        for k in 1:num_stages
+            for n in 1:N
+                solution_allocated[n, i] += G[n, k] * scheme.B[i, k] * dt
+            end
+        end
+        for k in 1:num_steps
+            for n in 1:N
+                solution_allocated[n, i] += y_nm1[n, k] * scheme.V[i, k]
+            end
+        end
+    end
+
+    y_n.solution, y_n.solution_allocated = y_n.solution_allocated, y_n.solution
+
+    return y_n
+end
+
+"""
+    _time_integrate!(
+        y_n::TimeIntegrationSolution,
+        scheme::Implicit{num_stages, num_steps},
+        ode::TimeIntegrationOperators,
+        t::Float64,
+        dt::Float64;
+        kwargs...,
+    ) where {num_steps, num_stages}
+
+Perform a single time integration step using the given Implicit time integration scheme and
+ODE system operators.
+
+# Arguments
+- `y_n::TimeIntegrationSolution{num_steps}`: The current solution vector.
+- `scheme::Implicit{num_stages,num_steps}`: The Implicit time integration scheme.
+- `ode::TimeIntegrationOperators`: The ODE system operators.
+- `t::Float64`: The current time.
+- `dt::Float64`: The time step.
+- `kwargs...`: Additional arguments passed to the ODE system.
+
+# Returns (in-place)
+- `TimeIntegrationSolution{num_steps}`: The updated solution vector after one time step.
+"""
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::Implicit{num_stages, num_steps},
+    ode::TimeIntegrationOperators,
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages}
+    T = eltype(y_n)
+    N = get_num_variables(y_n)
+    y_nm1 = get_solution(y_n)
+
+    # Get pre-allocated scratch spaces.
+    solution_allocated = get_solution_allocated(y_n)
+    solution_allocated .= zero(T)
+    xi = vec(reduce(vcat, y_nm1 for i in 1:num_stages))
+    Y = reduce(vcat, y_n.stage_values for i in 1:num_stages)
+
+    # Setup a time variable to know at what time instant each stage is computed.
+    tis = SVector((t + scheme.C[i] * dt for i in 1:num_stages)...)
+
+    ode.implicitSolve!(Y, xi, scheme.A * dt, tis; kwargs...)
+
+    allG = Vector{T}(undef, N*num_stages)
+    ode.implicitEvaluate!(allG, Y, tis; kwargs...)
+    @inbounds for i in 1:num_steps
+        for k in 1:num_stages
+            for n in 1:N
+                solution_allocated[n, i] += allG[(k - 1) * N + n] * scheme.B[i, k] * dt
+            end
+        end
+        for k in 1:num_steps
+            for n in 1:N
+                solution_allocated[n, i] += y_nm1[n, k] * scheme.V[i, k]
+            end
+        end
+    end
+
+    y_n.solution, y_n.solution_allocated = y_n.solution_allocated, y_n.solution
+
+    return y_n
+end
+
+"""
+    _time_integrate!(
+        y_n::TimeIntegrationSolution,
+        scheme::IMEX{num_stages, num_steps},
+        ode::TimeIntegrationOperators,
+        t::Float64,
+        dt::Float64;
+        kwargs...,
+    ) where {num_steps, num_stages}
+
+Perform a single time integration step using the given IMEX time integration scheme and ODE
+system operators. Implements algorithm 1 of [Vos2011](@cite) in full.
+
+# Arguments
+- `y_n::TimeIntegrationSolution{num_steps}`: The current solution vector.
+- `scheme::IMEX{num_stages,num_steps}`: The IMEX time integration scheme.
+- `ode::TimeIntegrationOperators`: The ODE system operators.
+- `t::Float64`: The current time.
+- `dt::Float64`: The time step.
+- `kwargs...`: Additional arguments passed to the ODE system.
+
+# Returns (in-place)
+- `TimeIntegrationSolution{num_steps}`: The updated solution vector after one time step.
+"""
+function _time_integrate!(
+    y_n::TimeIntegrationSolution,
+    scheme::IMEX{num_stages, num_steps},
+    ode::TimeIntegrationOperators,
+    t::Float64,
+    dt::Float64;
+    kwargs...,
+) where {num_steps, num_stages}
+    T = eltype(y_n)
+    N = get_num_variables(y_n)
+    y_nm1 = get_solution(y_n)
+
+    # Get pre-allocated scratch spaces.
+    solution_allocated = get_solution_allocated(y_n)
+    solution_allocated .= zero(T)
+    stage_values = get_stage_allocated(y_n)
+    F_allocated = get_F_allocated(y_n)
+    F_allocated .= zero(T)
+    temp_var = get_temp_var(y_n)
+    G = get_G_allocated(y_n)
+    G .= zero(T)
+
+    @inbounds for i in 1:num_stages
+        # calculate the temporary value xᵢ
+        temp_var .= zero(T)
+        for k in 1:i
+            for n in 1:N
+                temp_var[n] += G[n, k] * scheme.A_IM[i, k] * dt
+                temp_var[n] += F_allocated[n, k] * scheme.A_EX[i, k] * dt
+            end
+        end
+        for j in 1:num_steps
+            for n in 1:N
+                temp_var[n] += scheme.U[i, j] * y_nm1[n, j]
+            end
+        end
+
+        # Calculate the stage value Yᵢ
+        # solve (Yᵢ - aᵢᵢᴵᴹ * h * g(Yᵢ,t)) = xᵢ
+        ode.implicitSolve!(
+            stage_values,
+            temp_var,
+            scheme.A_IM[i, i] * dt,
+            t + scheme.C_IM[i] * dt;
+            kwargs...,
+        )
+
+        # Calculate the stage derivative Fᵢ
+        ode.explicitEvaluate!(
+            view(F_allocated, :, i), stage_values, t + scheme.C_EX[i] * dt; kwargs...
+        )
+
+        # Calculate the stage derivative Gᵢ
+        let a_ii = scheme.A_IM[i, i]
+            if !iszero(a_ii)
+                for n in 1:N
+                    G[n, i] = (stage_values[n] - temp_var[n]) / (a_ii * dt)
+                end
+            else
+                for n in 1:N
+                    G[n, i] = zero(T)
+                end
+            end
+        end
+    end
+
+    start_index = 1
+    if scheme.U[end, :] == scheme.V[1, :] &&
+        scheme.A_IM[end, :] == scheme.B_IM[1, :] &&
+        scheme.A_EX[end, :] == scheme.B_EX[1, :]
+        solution_allocated[:, 1] .= stage_values
+        start_index = 2
+    end
+
+    @inbounds for i in start_index:num_steps
+        for k in 1:num_stages
+            for n in 1:N
+                solution_allocated[n, i] += G[n, k] * scheme.B_IM[i, k] * dt
+                solution_allocated[n, i] += F_allocated[n, k] * scheme.B_EX[i, k] * dt
+            end
+        end
+        for k in 1:num_steps
+            for n in 1:N
+                solution_allocated[n, i] += y_nm1[n, k] * scheme.V[i, k]
+            end
+        end
+    end
+
+    y_n.solution, y_n.solution_allocated = y_n.solution_allocated, y_n.solution
+
+    return y_n
+end

--- a/src/TimeIntegrators/Integrations.jl
+++ b/src/TimeIntegrators/Integrations.jl
@@ -69,39 +69,57 @@ function time_integrate!(
 ) where {T, S <: AbstractTimeIntegrator}
     remaining_startup_steps = get_remaining_startup_steps(y_n)
     if remaining_startup_steps > 0
-        num_steps = length(y_n.scheme.time_levels.step_values)
-        num_G = length(y_n.scheme.time_levels.step_derivatives_implicit)
-        num_F = length(y_n.scheme.time_levels.step_derivatives_explicit)
+        scheme = get_scheme(y_n)
+        tl = get_time_levels(scheme)
+        num_steps = get_num_step_values(tl)
+        num_G = get_num_implicit_derivatives(tl)
+        num_F = get_num_explicit_derivatives(tl)
 
-        y_n_startup = y_n.startup_solution
+        startup_scheme = get_startup_scheme(y_n)
+        y_n_startup = get_startup_solution(y_n)
 
         # We do have to advance the solution using the startup scheme, to ensure that the
         # solution remains at the expected time level, even if some of the startup steps
         # are only needed to initialise the step derivatives.
         ynm1 = get_solution(y_n_startup)
-        _time_integrate!(y_n_startup, y_n.startup_scheme, ode, t, dt; kwargs...)
+        _time_integrate!(y_n_startup, startup_scheme, ode, t, dt; kwargs...)
 
-        # Then we initialise the required solutions and stage derivatives. Note these are
-        # all if statements, as we may need all of them at the same time. The first
-        # condition in the if statements always check if we ever need the specific type of
-        # initialisation, while the second condition ensures that we are at the correct
-        # time to initialise the solution or stage derivatives.
-        if num_steps > 0 && remaining_startup_steps - num_steps <= 0
-            index_steps = num_steps + (remaining_startup_steps - num_steps)
+        # Then we initialise the required solutions and stage derivatives.
+        #
+        # Note that the layout of y_n.solution should be
+        # [
+        # y_n,
+        # y_{n-1},
+        # ...,
+        # y_{n-num_steps+1}
+        # \Delta t G_n,
+        # \Delta t G_{n-1},
+        # ...,
+        # \Delta t G_{n-num_G+1},
+        # \Delta t F_n,
+        # \Delta t F_{n-1},
+        # ...,
+        # \Delta t F_{n-num_F+1},
+        # ]
+        #
+        # The solution vector is filled from the back (remaining_startup_steps is
+        # decreasing) to comply with this layout.
+        if num_steps > 0 && num_steps >= remaining_startup_steps
+            index_steps = remaining_startup_steps
             y_n.solution[:, index_steps] = get_solution(y_n_startup)
         end
-        if num_G > 0 && remaining_startup_steps - num_G <= 0
-            index_implicit = num_steps + num_G + (remaining_startup_steps - num_G)
+        if num_G > 0 && num_G >= remaining_startup_steps
+            index_implicit = num_steps + remaining_startup_steps
             ode.implicitEvaluate!(
                 view(y_n.solution, :, index_implicit),
                 get_solution(y_n_startup),
                 t+dt;
-                kwargs...
+                kwargs...,
             )
             y_n.solution[:, index_implicit] .*= dt
         end
-        if num_F > 0 && remaining_startup_steps - num_F <= 0
-            index_explicit = num_steps + num_G + num_F + (remaining_startup_steps - num_F)
+        if num_F > 0 && num_F >= remaining_startup_steps
+            index_explicit = num_steps + num_G + remaining_startup_steps
             ode.explicitEvaluate!(view(y_n.solution, :, index_explicit), ynm1, t; kwargs...)
             y_n.solution[:, index_explicit] .*= dt
         end
@@ -136,152 +154,133 @@ end
 function _time_integrate!(
     y_n::TimeIntegrationSolution,
     scheme::Explicit{num_stages, num_steps},
-    ode::TimeIntegrationOperators{Nothing, IF, IE},
+    ode::TimeIntegrationOperators{Nothing, IS, IE},
     t::Float64,
     dt::Float64;
     kwargs...,
-) where {num_steps, num_stages, IF, IE}
-    throw(
+) where {num_steps, num_stages, IS, IE}
+    return throw(
         ArgumentError(
             LazyString(
                 "You are trying to use an Explicit scheme but have provided an ",
                 "ode (in a TimeIntegrationOperators struct) which does not have an ",
-                "explicitEvaluate! function."
-            )
-        )
+                "explicitEvaluate! function.",
+            ),
+        ),
     )
 end
 
 function _time_integrate!(
     y_n::TimeIntegrationSolution,
     scheme::DiagonallyImplicit{num_stages, num_steps},
-    ode::TimeIntegrationOperators{EF, Nothing, IE},
+    ode::TimeIntegrationOperators{EE, Nothing, IE},
     t::Float64,
     dt::Float64;
     kwargs...,
-) where {num_steps, num_stages, EF, IE}
-    throw(
+) where {num_steps, num_stages, EE, IE}
+    return throw(
         ArgumentError(
             LazyString(
                 "You are trying to use a DiagonallyImplicit scheme but have provided an ",
                 "ode (in a TimeIntegrationOperators struct) which does not have an ",
-                "implicitSolve! function."
-            )
-        )
+                "implicitSolve! function.",
+            ),
+        ),
     )
 end
 
 function _time_integrate!(
     y_n::TimeIntegrationSolution,
     scheme::Implicit{num_stages, num_steps},
-    ode::TimeIntegrationOperators{EF, Nothing, IE},
+    ode::TimeIntegrationOperators{EE, Nothing, IE},
     t::Float64,
     dt::Float64;
     kwargs...,
-) where {num_steps, num_stages, EF, IE}
-    throw(
+) where {num_steps, num_stages, EE, IE}
+    return throw(
         ArgumentError(
             LazyString(
                 "You are trying to use an Implicit scheme but have provided an ",
                 "ode (in a TimeIntegrationOperators struct) which does not have an ",
-                "implicitSolve! function."
-            )
-        )
+                "implicitSolve! function.",
+            ),
+        ),
     )
 end
 
 function _time_integrate!(
     y_n::TimeIntegrationSolution,
     scheme::Implicit{num_stages, num_steps},
-    ode::TimeIntegrationOperators{EF, IF, Nothing},
+    ode::TimeIntegrationOperators{EE, IS, Nothing},
     t::Float64,
     dt::Float64;
     kwargs...,
-) where {num_steps, num_stages, EF, IF}
-    throw(
+) where {num_steps, num_stages, EE, IS}
+    return throw(
         ArgumentError(
             LazyString(
                 "You are trying to use an Implicit scheme but have provided an ",
                 "ode (in a TimeIntegrationOperators struct) which does not have an ",
-                "implicitEvaluate! function."
-            )
-        )
+                "implicitEvaluate! function.",
+            ),
+        ),
     )
 end
 
 function _time_integrate!(
     y_n::TimeIntegrationSolution,
     scheme::Implicit{num_stages, num_steps},
-    ode::TimeIntegrationOperators{EF, Nothing, Nothing},
+    ode::TimeIntegrationOperators{EE, Nothing, Nothing},
     t::Float64,
     dt::Float64;
     kwargs...,
-) where {num_steps, num_stages, EF}
-    throw(
+) where {num_steps, num_stages, EE}
+    return throw(
         ArgumentError(
             LazyString(
                 "You are trying to use an Implicit scheme but have provided an ",
                 "ode (in a TimeIntegrationOperators struct) which does not have an ",
-                "implicitSolve! nor an implicitEvaluate! function."
-            )
-        )
+                "implicitSolve! nor an implicitEvaluate! function.",
+            ),
+        ),
     )
 end
 
 function _time_integrate!(
     y_n::TimeIntegrationSolution,
     scheme::IMEX{num_stages, num_steps},
-    ode::TimeIntegrationOperators{Nothing, IF, IE},
+    ode::TimeIntegrationOperators{Nothing, IS, IE},
     t::Float64,
     dt::Float64;
     kwargs...,
-) where {num_steps, num_stages, IF, IE}
-    throw(
+) where {num_steps, num_stages, IS, IE}
+    return throw(
         ArgumentError(
             LazyString(
                 "You are trying to use an IMEX scheme but have provided an ",
                 "ode (in a TimeIntegrationOperators struct) which does not have an ",
-                "explicitEvaluate! function."
-            )
-        )
+                "explicitEvaluate! function.",
+            ),
+        ),
     )
 end
 
 function _time_integrate!(
     y_n::TimeIntegrationSolution,
     scheme::IMEX{num_stages, num_steps},
-    ode::TimeIntegrationOperators{EF, Nothing, IE},
+    ode::TimeIntegrationOperators{EE, Nothing, IE},
     t::Float64,
     dt::Float64;
     kwargs...,
-) where {num_steps, num_stages, EF, IE}
-    throw(
+) where {num_steps, num_stages, EE, IE}
+    return throw(
         ArgumentError(
             LazyString(
                 "You are trying to use an IMEX scheme but have provided an ",
                 "ode (in a TimeIntegrationOperators struct) which does not have an ",
-                "implicitSolve! function."
-            )
-        )
-    )
-end
-
-function _time_integrate!(
-    y_n::TimeIntegrationSolution,
-    scheme::IMEX{num_stages, num_steps},
-    ode::TimeIntegrationOperators{Nothing, Nothing, IE},
-    t::Float64,
-    dt::Float64;
-    kwargs...,
-) where {num_steps, num_stages, IE}
-    throw(
-        ArgumentError(
-            LazyString(
-                "You are trying to use an IMEX scheme but have provided an ",
-                "ode (in a TimeIntegrationOperators struct) which does not have an ",
-                "explicitEvaluate! nor an implicitSolve! function."
-            )
-        )
+                "implicitSolve! function.",
+            ),
+        ),
     )
 end
 
@@ -335,7 +334,7 @@ function _time_integrate!(
     @inbounds for i in 1:num_stages
         stage_values .= zero(T)
         # Calculate the stage value Yi
-        for k in 1:i
+        for k in 1:(i - 1)
             for n in 1:N
                 stage_values[n] += F_allocated[n, k] * scheme.A[i, k] * dt
             end
@@ -428,7 +427,7 @@ function _time_integrate!(
     @inbounds for i in 1:num_stages
         # calculate the temporary value xᵢ
         temp_var .= zero(T)
-        for k in 1:i
+        for k in 1:(i - 1)
             for n in 1:N
                 temp_var[n] += G[n, k] * scheme.A[i, k] * dt
             end
@@ -451,9 +450,9 @@ function _time_integrate!(
                     G[n, i] = (y_n.stage_values[n] - temp_var[n]) / (a_ii * dt)
                 end
             else
-                for n in 1:N
-                    G[n, i] = zero(T)
-                end
+                ode.implicitEvaluate!(
+                    view(G, :, i), y_n.stage_values, t + scheme.C[i] * dt; kwargs...
+                )
             end
         end
     end
@@ -602,7 +601,7 @@ function _time_integrate!(
     @inbounds for i in 1:num_stages
         # calculate the temporary value xᵢ
         temp_var .= zero(T)
-        for k in 1:i
+        for k in 1:(i - 1)
             for n in 1:N
                 temp_var[n] += G[n, k] * scheme.A_IM[i, k] * dt
                 temp_var[n] += F_allocated[n, k] * scheme.A_EX[i, k] * dt
@@ -636,9 +635,9 @@ function _time_integrate!(
                     G[n, i] = (stage_values[n] - temp_var[n]) / (a_ii * dt)
                 end
             else
-                for n in 1:N
-                    G[n, i] = zero(T)
-                end
+                ode.implicitEvaluate!(
+                    view(G, :, i), stage_values, t + scheme.C_IM[i] * dt; kwargs...
+                )
             end
         end
     end

--- a/src/TimeIntegrators/Schemes.jl
+++ b/src/TimeIntegrators/Schemes.jl
@@ -1,0 +1,814 @@
+"""
+    butcher_tableau_to_glm(
+        A::SMatrix{num_stages, num_stages, T},
+        B::SVector{num_stages, T},
+        C::SVector{num_stages, T},
+        order::Int,
+    ) where {num_stages, T}
+
+Convert the given `A`, `B`, and `C` matrices from a Butcher Tableau into the GLM framework.
+Will automatically choose the correct type for the integrator.
+"""
+function butcher_tableau_to_glm(
+    A::SMatrix{num_stages, num_stages, T},
+    B::SVector{num_stages, T},
+    C::SVector{num_stages, T},
+    order::Int,
+) where {num_stages, T}
+    # If the matrix A has non-zero elements in the upper triangular part (including the
+    # diagonal) then it is an implicit scheme. We do make a distinction between diagonally
+    # implicit (nonzero diagonal but all other uppper triangular entries are zero) and
+    # fully implicit schemes.
+    is_implicit, is_diagonally_implicit = check_implicit(A)
+
+    U = ones(SMatrix{num_stages, 1, T})
+    V = ones(SMatrix{1, 1, T})
+
+    time_levels = TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    )
+
+    if is_implicit
+        return Implicit(A, SMatrix{1, num_stages}(B'), U, V, C, time_levels, order)
+    elseif is_diagonally_implicit
+        return DiagonallyImplicit(
+            A, SMatrix{1, num_stages}(B'), U, V, C, time_levels, order
+        )
+    else
+        return Explicit(A, SMatrix{1, num_stages}(B'), U, V, C, time_levels, order)
+    end
+end
+
+############## Runge-Kutta ################
+
+# Explicit:
+
+# order 1
+"""
+    FORWARD_EULER
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const FORWARD_EULER = butcher_tableau_to_glm(
+    SMatrix{1, 1}(0.0), SVector(1.0), SVector(0.0), 1
+)
+# order 2
+"""
+    EXPLICIT_MIDPOINT
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const EXPLICIT_MIDPOINT = butcher_tableau_to_glm(
+    SMatrix{2, 2}(0.0, 1/2, 0.0, 0.0), SVector(0.0, 1.0), SVector(0.0, 1 / 2), 2
+)
+
+"""
+    HEUN2
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const HEUN2 = butcher_tableau_to_glm(
+    SMatrix{2, 2}(0.0, 1.0, 0.0, 0.0), SVector(1 / 2, 1 / 2), SVector(0.0, 1.0), 2
+)
+
+"""
+    RALSTON2
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const RALSTON2 = butcher_tableau_to_glm(
+    SMatrix{2, 2}(0.0, 2/3, 0.0, 0.0), SVector(1 / 4, 3 / 4), SVector(0.0, 2 / 3), 2
+)
+
+# order 3
+"""
+    HEUN3
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const HEUN3 = butcher_tableau_to_glm(
+    SMatrix{3, 3}(0.0, 1/3, 0.0, 0.0, 0.0, 2/3, 0.0, 0.0, 0.0),
+    SVector(1 / 4, 0.0, 3 / 4),
+    SVector(0.0, 1 / 3, 2 / 3),
+    3,
+)
+
+"""
+    RK3
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const RK3 = butcher_tableau_to_glm(
+    SMatrix{3, 3}(0.0, 1/2, -1.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0),
+    SVector(1 / 6, 2 / 3, 1 / 6),
+    SVector(0.0, 1 / 2, 1.0),
+    3,
+)
+
+"""
+    RALSTON3
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const RALSTON3 = butcher_tableau_to_glm(
+    SMatrix{3, 3}(0.0, 1/2, 0.0, 0.0, 0.0, 3/4, 0.0, 0.0, 0.0),
+    SVector(2 / 9, 1 / 3, 4 / 9),
+    SVector(0.0, 1 / 2, 3 / 4),
+    3,
+)
+
+"""
+    VDHW3
+
+Van der Houwen's/Wray's third-order method
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const VDHW3 = butcher_tableau_to_glm(
+    SMatrix{3, 3}(0.0, 8/15, 1/4, 0.0, 0.0, 5/12, 0.0, 0.0, 0.0),
+    SVector(1 / 4, 0, 3 / 4),
+    SVector(0.0, 8 / 15, 2 / 3),
+    3,
+)
+
+"""
+    SSPRK3
+
+Third-order Strong Stability Preserving Runge-Kutta.
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const SSPRK3 = butcher_tableau_to_glm(
+    SMatrix{3, 3}(0.0, 1.0, 1/4, 0.0, 0.0, 1/4, 0.0, 0.0, 0.0),
+    SVector(1 / 6, 1 / 6, 2 / 3),
+    SVector(0.0, 1.0, 1 / 2),
+    3,
+)
+
+# order 4
+"""
+    RK4
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const RK4 = butcher_tableau_to_glm(
+    SMatrix{4, 4}(
+        0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0
+    ),
+    SVector(1 / 6, 1 / 3, 1 / 3, 1 / 6),
+    SVector(0.0, 0.5, 0.5, 1.0),
+    4,
+)
+
+"""
+    RK4_3_8
+
+3/8-rule fourth-order method.
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const RK4_3_8 = butcher_tableau_to_glm(
+    SMatrix{4, 4}(
+        0.0, 1/3, -1/3, 1.0, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0
+    ),
+    SVector(1 / 8, 3 / 8, 3 / 8, 1 / 8),
+    SVector(0.0, 1 / 3, 2 / 3, 1.0),
+    4,
+)
+
+"""
+    RALSTON4
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const RALSTON4 = butcher_tableau_to_glm(
+    SMatrix{4, 4}(
+        0.0,
+        2/5,
+        (-2889 + 1428*sqrt(5))/1024,
+        (-3365 + 2094*sqrt(5))/6040,
+        0.0,
+        0.0,
+        (3785 - 1620*sqrt(5))/1024,
+        (-975 - 3046*sqrt(5))/2552,
+        0.0,
+        0.0,
+        0.0,
+        (467040 + 203968*sqrt(5))/240845,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ),
+    SVector(
+        (263 + 24*sqrt(5)) / 1812,
+        (125 - 1000*sqrt(5)) / 3828,
+        (3426304 + 1661952*sqrt(5)) / 5924787,
+        (30 - 4*sqrt(5)) / 123,
+    ),
+    SVector(0.0, 2 / 5, (14 - 3*sqrt(5)) / 16, 1.0),
+    4,
+)
+
+# Implicit:
+
+# order 1
+"""
+    BACKWARD_EULER
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const BACKWARD_EULER = butcher_tableau_to_glm(
+    SMatrix{1, 1}(1.0), SVector(1.0), SVector(1.0), 1
+)
+
+"""
+    RADAU_IA_1
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const RADAU_IA_1 = butcher_tableau_to_glm(SMatrix{1, 1}(1.0), SVector(1.0), SVector(1.0), 1)
+
+# order 2
+"""
+    IMPLICIT_MIDPOINT
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const IMPLICIT_MIDPOINT = butcher_tableau_to_glm(
+    SMatrix{1, 1}(0.5), SVector(1.0), SVector(1 / 2), 2
+)
+
+const _α_DIRK2 = 1 - sqrt(2)/2
+"""
+    DIRK2
+
+Strongly S-stable, two-stage, DIRK scheme of order 2. See [Alexander1977](@cite) page 1012.
+For this scheme, ``\\alpha = 1 - sqrt(2)/2``.
+"""
+const DIRK2 = butcher_tableau_to_glm(
+    SMatrix{2, 2}(_α_DIRK2, 1-_α_DIRK2, 0.0, _α_DIRK2),
+    SVector(1-_α_DIRK2, _α_DIRK2),
+    SVector(_α_DIRK2, 1),
+    2,
+)
+
+# order 3
+"""
+    DIRK3
+
+Crouzeix's two-stage, 3rd order, A-stable DIRK scheme. See [Alexander1977](@cite) page 1008.
+"""
+const DIRK3 = butcher_tableau_to_glm(
+    SMatrix{2, 2}(1/2 + 1/(2*sqrt(3)), -1/sqrt(3), 0.0, 1/2+1/(2*sqrt(3))),
+    SVector(1 / 2, 1 / 2),
+    SVector(1 / 2 + 1/(2*sqrt(3)), 1 / 2 - 1/(2*sqrt(3))),
+    3,
+)
+
+"""
+    RADAU_IA_3
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const RADAU_IA_3 = butcher_tableau_to_glm(
+    SMatrix{2, 2}(1/4, 1/4, -1/4, 5/12), SVector(1 / 4, 3 / 4), SVector(0, 2 / 3), 3
+)
+
+# order 4
+const _α_DIRK4 = 2 / sqrt(3) * cos(pi / 18)
+"""
+    DIRK4
+
+Crouzeix's three-stage, 4th order, A-stable DIRK scheme. See [Alexander1977](@cite) page
+1008.
+"""
+const DIRK4 = butcher_tableau_to_glm(
+    SMatrix{3, 3}(
+        (1+_α_DIRK4)/2,
+        -_α_DIRK4/2,
+        1+_α_DIRK4,
+        0.0,
+        (1+_α_DIRK4)/2,
+        -(1.0 + 2*_α_DIRK4),
+        0.0,
+        0.0,
+        (1+_α_DIRK4)/2,
+    ),
+    SVector(1 / (6 * _α_DIRK4^2), 1.0 - 1 / (3 * _α_DIRK4^2), 1 / (6 * _α_DIRK4^2)),
+    SVector((1 + _α_DIRK4) / 2, 1 / 2, (1 - _α_DIRK4) / 2),
+    4,
+)
+
+"""
+    GAUSS_LEGENDRE_4
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const GAUSS_LEGENDRE_4 = butcher_tableau_to_glm(
+    SMatrix{2, 2}(1/4, 1/4+sqrt(3)/6, 1/4-sqrt(3)/6, 1/4),
+    SVector(1 / 2, 1 / 2),
+    SVector(1 / 2 - sqrt(3) / 6, 1 / 2 + sqrt(3) / 6),
+    4,
+)
+
+# order 6
+"""
+    GAUSS_LEGENDRE_6
+
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+"""
+const GAUSS_LEGENDRE_6 = butcher_tableau_to_glm(
+    SMatrix{3, 3}(
+        5/36,
+        5 / 36+sqrt(15) / 24,
+        5 / 36+sqrt(15) / 30,
+        2 / 9-sqrt(15) / 15,
+        2/9,
+        2 / 9+sqrt(15) / 15,
+        5 / 36-sqrt(15) / 30,
+        5 / 36-sqrt(15) / 24,
+        5/36,
+    ),
+    SVector(5 / 18, 4 / 9, 5 / 18),
+    SVector(1 / 2 - sqrt(15) / 10, 1 / 2, 1 / 2 + sqrt(15) / 10),
+    6,
+)
+
+############## Multi-step  ################
+
+# Explicit:
+
+# Adams-Bashforth
+"""
+    AB1
+
+Adams-Bashforth 1:
+```math
+y_{n+1} = y_{n} + \\Delta t f(y_{n})\\;.
+```
+"""
+const AB1 = Explicit(
+    SMatrix{1, 1}(0.0), # A
+    SMatrix{1, 1}(1.0), # B
+    SMatrix{1, 1}(1.0), # U
+    SMatrix{1, 1}(1.0), # V
+    SVector(0.0),
+    TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    ),
+    1,
+)
+
+"""
+    AB2
+
+Adams-Bashforth 2:
+```math
+y_{n+1} = y_{n} + \\Delta t (\\frac{3}{2} f(y_{n}) - \\frac{1}{2} f(y_{n-1}))\\;.
+```
+"""
+const AB2 = Explicit(
+    SMatrix{1, 1}(0.0), # A
+    SMatrix{2, 1}(3/2, 1.0), # B
+    SMatrix{1, 2}(1.0, 0.0), # U
+    SMatrix{2, 2}(1.0, 0.0, -1/2, 0.0), # V
+    SVector(0.0),
+    TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        [1],  # Δt F
+    ),
+    2,
+)
+
+"""
+    AB3
+
+Adams-Bashforth 3:
+```math
+y_{n+1} = y_{n} + \\Delta t (\\frac{23}{12} f(y_{n}) - \\frac{4}{3} f(y_{n-1}) + \\frac{5}{12} f(y_{n-2}))\\;.
+```
+"""
+const AB3 = Explicit(
+    SMatrix{1, 1}(0.0), # A
+    SMatrix{3, 1}(23/12, 1.0, 0.0), # B
+    SMatrix{1, 3}(1.0, 0.0, 0.0), # U
+    SMatrix{3, 3}(1.0, 0.0, 0.0, -16/12, 0.0, 1.0, 5/12, 0.0, 0.0), # V
+    SVector(0.0),
+    TimeLevels(
+        [0], # y(n)
+        Int[], # Δt G
+        [1, 2],  # Δt F(n-1), Δt F(n-2)
+    ),
+    3,
+)
+
+"""
+    AB4
+
+Adams-Bashforth 4:
+```math
+y_{n+1} = y_{n} + \\Delta t (\\frac{55}{24} f(y_{n}) - \\frac{59}{24} f(y_{n-1}) + \\frac{37}{24} f(y_{n-2}) - \\frac{9}{24} f(y_{n-3}))\\;.
+```
+"""
+const AB4 = Explicit(
+    SMatrix{1, 1}(0.0), # A
+    SMatrix{4, 1}(55/24, 1.0, 0.0, 0.0), # B
+    SMatrix{1, 4}(1.0, 0.0, 0.0, 0.0), # U
+    SMatrix{4, 4}(
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        -59/24,
+        0.0,
+        1.0,
+        0.0,
+        37/24,
+        0.0,
+        0.0,
+        1.0,
+        -9/24,
+        0.0,
+        0.0,
+        0.0,
+    ), # V
+    SVector(0.0),
+    TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        [1, 2, 3],  # Δt F
+    ),
+    4,
+)
+
+# Implicit:
+
+# Adams-Moulton
+"""
+    AM0
+
+Adams-Moulton 0:
+```math
+y_{n+1} = y_{n} + \\Delta t g(y_{n})\\;.
+```
+"""
+const AM0 = DiagonallyImplicit(
+    SMatrix{1, 1}(1.0), # A
+    SMatrix{1, 1}(1.0), # B
+    SMatrix{1, 1}(1.0), # U
+    SMatrix{1, 1}(1.0), # V
+    SVector(1.0),
+    TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    ),
+    1,
+)
+
+"""
+    AM1
+
+Adams-Moulton 1:
+```math
+y_{n+1} = y_{n} + \\Delta t (\\frac{1}{2} g(y_{n+1}) + \\frac{1}{2} g(y_{n}))\\;.
+```
+"""
+const AM1 = DiagonallyImplicit(
+    SMatrix{1, 1}(0.5), # A
+    SMatrix{2, 1}(0.5, 1.0), # B
+    SMatrix{1, 2}(1.0, 0.5), # U
+    SMatrix{2, 2}(1.0, 0.0, 0.5, 0.0), # V
+    SVector(1.0),
+    TimeLevels(
+        [0], # y
+        [0], # Δt G
+        Int[],  # Δt F
+    ),
+    2,
+)
+
+"""
+    AM2
+
+Adams-Moulton 2:
+```math
+y_{n+1} = y_{n} + \\Delta t (\\frac{5}{12} g(y_{n+1}) + \\frac{8}{12} g(y_{n}) - \\frac{1}{12} g(y_{n-1})\\;.
+```
+"""
+const AM2 = DiagonallyImplicit(
+    SMatrix{1, 1}(5/12), # A
+    SMatrix{3, 1}(5/12, 1.0, 0.0), # B
+    SMatrix{1, 3}(1.0, 8/12, -1/12), # U
+    SMatrix{3, 3}(1.0, 0.0, 0.0, 8/12, 0.0, 1.0, -1/12, 0.0, 0.0), # V
+    SVector(1.0),
+    TimeLevels(
+        [0], # y
+        [0, 1], # Δt G
+        Int[],  # Δt F
+    ),
+    3,
+)
+
+"""
+    AM3
+
+Adams-Moulton 3:
+```math
+y_{n+1} = y_{n} + \\Delta t (\\frac{9}{24} g(y_{n+1}) + \\frac{19}{24} g(y_{n}) - \\frac{5}{24} g(y_{n-1}) + \\frac{1}{24} g(y_{n-2}))\\;.
+```
+"""
+const AM3 = DiagonallyImplicit(
+    SMatrix{1, 1}(9/24), # A
+    SMatrix{4, 1}(9/24, 1.0, 0.0, 0.0), # B
+    SMatrix{1, 4}(1.0, 19/24, -5/24, 1/24), # U
+    SMatrix{4, 4}(
+        1.0, 0.0, 0.0, 0.0, 19/24, 0.0, 1.0, 0.0, -5/24, 0.0, 0.0, 1.0, 1/24, 0.0, 0.0, 0.0
+    ), # V
+    SVector(1.0),
+    TimeLevels(
+        [0], # y
+        [0, 1, 2], # Δt G
+        Int[],  # Δt F
+    ),
+    4,
+)
+
+"""
+    AM4
+
+Adams-Moulton 4:
+```math
+y_{n+1} = y_{n} + \\Delta t (\\frac{251}{720} g(y_{n+1}) + \\frac{646}{720} g(y_{n}) - \\frac{264}{720} g(y_{n-1}) + \\frac{106}{720} g(y_{n-2}) - \\frac{19}{720} g(y_{n-3}))\\;.
+```
+"""
+const AM4 = DiagonallyImplicit(
+    SMatrix{1, 1}(251/720), # A
+    SMatrix{5, 1}(251/720, 1.0, 0.0, 0.0, 0.0), # B
+    SMatrix{1, 5}(1.0, 646/720, -264/720, 106/720, -19/720), # U
+    SMatrix{5, 5}(
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        646/720,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        -264/720,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        106/720,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        -19/720,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ), # V
+    SVector(1.0),
+    TimeLevels(
+        [0], # y
+        [0, 1, 2, 3], # Δt G
+        Int[],  # Δt F
+    ),
+    5,
+)
+
+# backward differentiation formulas
+"""
+    BDF1
+
+Backward differentiation formula 1:
+```math
+y_{n+1} = y_{n} + \\Delta t f(y_n)\\;.
+```
+"""
+const BDF1 = DiagonallyImplicit(
+    SMatrix{1, 1}(1.0), # A
+    SMatrix{1, 1}(1.0), # B
+    SMatrix{1, 1}(1.0), # U
+    SMatrix{1, 1}(1.0), # V
+    SVector(1.0),
+    TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    ),
+    1,
+)
+
+"""
+    BDF2
+
+Backward differentiation formula 2:
+```math
+y_{n+1} = \\frac{4}{3} y_{n} - \\frac{1}{3} y_{n-1} + \\frac{2}{3} \\Delta t f(y_{n})\\;.
+```
+"""
+const BDF2 = DiagonallyImplicit(
+    SMatrix{1, 1}(2/3), # A
+    SMatrix{2, 1}(2/3, 0.0), # B
+    SMatrix{1, 2}(4/3, -1/3), # U
+    SMatrix{2, 2}(4/3, 1.0, -1/3, 0.0), # V
+    SVector(1.0),
+    TimeLevels(
+        [0, 1], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    ),
+    2,
+)
+
+"""
+    BDF3
+
+Backward differentiation formula 3:
+```math
+y_{n+1} = \\frac{18}{11} y_{n} - \\frac{9}{11} y_{n-1} + \\frac{2}{11} y_{n-2} + \\frac{6}{11} \\Delta t f(y_{n})\\;.
+```
+"""
+const BDF3 = DiagonallyImplicit(
+    SMatrix{1, 1}(6/11), # A
+    SMatrix{3, 1}(6/11, 0.0, 0.0), # B
+    SMatrix{1, 3}(18/11, -9/11, 2/11), # U
+    SMatrix{3, 3}(18/11, 1.0, 0.0, -9/11, 0.0, 1.0, 2/11, 0.0, 0.0), # V
+    SVector(1.0),
+    TimeLevels(
+        [0, 1, 2], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    ),
+    3,
+)
+
+"""
+    BDF4
+
+Backward differentiation formula 4:
+```math
+y_{n+1} = \\frac{48}{25} y_{n} - \\frac{36}{25} y_{n-1} + \\frac{16}{25} y_{n-2} - \\frac{3}{25} y_{n-3} + \\frac{12}{25} \\Delta t f(y_{n})\\;.
+```
+"""
+const BDF4 = DiagonallyImplicit(
+    SMatrix{1, 1}(12/25), # A
+    SMatrix{4, 1}(12/25, 0.0, 0.0, 0.0), # B
+    SMatrix{1, 4}(48/25, -36/25, 16/25, -3/25), # U
+    SMatrix{4, 4}(
+        48/25,
+        1.0,
+        0.0,
+        0.0,
+        -36/25,
+        0.0,
+        1.0,
+        0.0,
+        16/25,
+        0.0,
+        0.0,
+        1.0,
+        -3/25,
+        0.0,
+        0.0,
+        0.0,
+    ), # V
+    SVector(1.0),
+    TimeLevels(
+        [0, 1, 2, 3], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    ),
+    4,
+)
+
+##############    IMEX     ################
+
+# Multi-stage
+"""
+    BACKWARD_FORWARD_EULER
+
+See equation A10 in [Vos2011](@cite).
+"""
+const BACKWARD_FORWARD_EULER = IMEX(
+    SMatrix{1, 1}(1.0), # A Implicit
+    SMatrix{1, 1}(0.0), # A Explicit
+    SMatrix{2, 1}(1.0, 0.0), # B Implicit
+    SMatrix{2, 1}(0.0, 1.0), # B Explicit
+    SMatrix{1, 2}(1.0, 1.0), # U
+    SMatrix{2, 2}(1.0, 0.0, 1.0, 0.0), # V
+    SVector(1.0), # C Implicit
+    SVector(0.0), # C Explicit
+    TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        [0],  # Δt F
+    ),
+    1,
+)
+
+"""
+    MIDPOINT_IMEX
+"""
+const MIDPOINT_IMEX = IMEX(
+    SMatrix{2, 2}(0.0, 0.0, 0.0, 1/2), # A Implicit
+    SMatrix{2, 2}(0.0, 1/2, 0.0, 0.0), # A Explicit
+    SMatrix{1, 2}(0.0, 1.0), # B Implicit
+    SMatrix{1, 2}(0.0, 1.0), # B Explicit
+    SMatrix{2, 1}(1.0, 1.0), # U
+    SMatrix{1, 1}(1.0), # V
+    SVector(0.0, 1/2), # C Implicit
+    SVector(0.0, 1/2), # C Explicit
+    TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    ),
+    2,
+)
+
+const _γ = (3 + sqrt(3)) / 6
+"""
+    RK3_IMEX
+
+See equation A13 in [Vos2011](@cite).
+"""
+const RK3_IMEX = IMEX(
+    SMatrix{3, 3}(0.0, 0.0, 0.0, 0.0, _γ, 1.0-2.0*_γ, 0.0, 0.0, _γ), # A Implicit
+    SMatrix{3, 3}(0.0, _γ, _γ-1.0, 0.0, 0.0, 2.0*(1.0-_γ), 0.0, 0.0, 0.0), # A Explicit
+    SMatrix{1, 3}(0.0, 0.5, 0.5), # B Implicit
+    SMatrix{1, 3}(0.0, 0.5, 0.5), # B Explicit
+    SMatrix{3, 1}(1.0, 1.0, 1.0), # U
+    SMatrix{1, 1}(1.0), # V
+    SVector(0.0, _γ, 1 - _γ), # C Implicit
+    SVector(0.0, _γ, 1 - _γ), # C Explicit
+    TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    ),
+    3,
+)
+
+# Multi-step
+"""
+    CNAB2
+
+Second-order Crank-Nicolson/Adams-Bashforth linear multistep scheme. See equation A12 in
+[Vos2011](@cite).
+"""
+const CNAB2 = IMEX(
+    SMatrix{1, 1}(1/2), # A Implicit
+    SMatrix{1, 1}(0.0), # A Explicit
+    SMatrix{4, 1}(1 / 2, 1.0, 0.0, 0.0), # B Implicit
+    SMatrix{4, 1}(0.0, 0.0, 1.0, 0.0), # B Explicit
+    SMatrix{1, 4}(1.0, 1/2, 3/2, -1/2), # U
+    SMatrix{4, 4}(
+        1.0, 0.0, 0.0, 0.0, 1/2, 0.0, 0.0, 0.0, 3/2, 0.0, 0.0, 1.0, -1/2, 0.0, 0.0, 0.0
+    ), # V
+    SVector(1.0), # C Implicit
+    SVector(1.0), # C Explicit
+    TimeLevels(
+        [0], # y
+        [0], # Δt G
+        [0, 1],  # Δt F
+    ),
+    2,
+)
+
+"""
+    SSSS2
+
+Stiffly stable splitting scheme of order 2. See [Karniadakis1991](@cite) table IV and
+[Vos2011](@cite) equation 59.
+"""
+const SSSS2 = IMEX(
+    SMatrix{1, 1}(2/3),
+    SMatrix{1, 1}(0.0),
+    SMatrix{4, 1}(2 / 3, 0.0, 0.0, 0.0),
+    SMatrix{4, 1}(0.0, 0.0, 1.0, 0.0),
+    SMatrix{1, 4}(4/3, -1/3, 4/3, -2/3),
+    SMatrix{4, 4}(
+        4/3, 1.0, 0.0, 0.0, -1/3, 0.0, 0.0, 0.0, 4/3, 0.0, 0.0, 1.0, -2/3, 0.0, 0.0, 0.0
+    ),
+    SVector(1.0),
+    SVector(1.0),
+    TimeLevels(
+        [0, 1], # y
+        Int[], # Δt G
+        [0, 1],  # Δt F
+    ),
+    2,
+)

--- a/src/TimeIntegrators/Schemes.jl
+++ b/src/TimeIntegrators/Schemes.jl
@@ -31,13 +31,17 @@ function butcher_tableau_to_glm(
     )
 
     if is_implicit
-        return Implicit(A, SMatrix{1, num_stages}(B'), U, V, C, time_levels, order)
+        return Implicit(
+            A, SMatrix{1, num_stages}(transpose(B)), U, V, C, time_levels, order
+        )
     elseif is_diagonally_implicit
         return DiagonallyImplicit(
-            A, SMatrix{1, num_stages}(B'), U, V, C, time_levels, order
+            A, SMatrix{1, num_stages}(transpose(B)), U, V, C, time_levels, order
         )
     else
-        return Explicit(A, SMatrix{1, num_stages}(B'), U, V, C, time_levels, order)
+        return Explicit(
+            A, SMatrix{1, num_stages}(transpose(B)), U, V, C, time_levels, order
+        )
     end
 end
 
@@ -49,7 +53,7 @@ end
 """
     FORWARD_EULER
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const FORWARD_EULER = butcher_tableau_to_glm(
     SMatrix{1, 1}(0.0), SVector(1.0), SVector(0.0), 1
@@ -58,7 +62,7 @@ const FORWARD_EULER = butcher_tableau_to_glm(
 """
     EXPLICIT_MIDPOINT
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const EXPLICIT_MIDPOINT = butcher_tableau_to_glm(
     SMatrix{2, 2}(0.0, 1/2, 0.0, 0.0), SVector(0.0, 1.0), SVector(0.0, 1 / 2), 2
@@ -67,7 +71,7 @@ const EXPLICIT_MIDPOINT = butcher_tableau_to_glm(
 """
     HEUN2
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const HEUN2 = butcher_tableau_to_glm(
     SMatrix{2, 2}(0.0, 1.0, 0.0, 0.0), SVector(1 / 2, 1 / 2), SVector(0.0, 1.0), 2
@@ -76,7 +80,7 @@ const HEUN2 = butcher_tableau_to_glm(
 """
     RALSTON2
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const RALSTON2 = butcher_tableau_to_glm(
     SMatrix{2, 2}(0.0, 2/3, 0.0, 0.0), SVector(1 / 4, 3 / 4), SVector(0.0, 2 / 3), 2
@@ -86,7 +90,7 @@ const RALSTON2 = butcher_tableau_to_glm(
 """
     HEUN3
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const HEUN3 = butcher_tableau_to_glm(
     SMatrix{3, 3}(0.0, 1/3, 0.0, 0.0, 0.0, 2/3, 0.0, 0.0, 0.0),
@@ -98,7 +102,7 @@ const HEUN3 = butcher_tableau_to_glm(
 """
     RK3
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const RK3 = butcher_tableau_to_glm(
     SMatrix{3, 3}(0.0, 1/2, -1.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0),
@@ -110,7 +114,7 @@ const RK3 = butcher_tableau_to_glm(
 """
     RALSTON3
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const RALSTON3 = butcher_tableau_to_glm(
     SMatrix{3, 3}(0.0, 1/2, 0.0, 0.0, 0.0, 3/4, 0.0, 0.0, 0.0),
@@ -124,7 +128,7 @@ const RALSTON3 = butcher_tableau_to_glm(
 
 Van der Houwen's/Wray's third-order method
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const VDHW3 = butcher_tableau_to_glm(
     SMatrix{3, 3}(0.0, 8/15, 1/4, 0.0, 0.0, 5/12, 0.0, 0.0, 0.0),
@@ -138,7 +142,7 @@ const VDHW3 = butcher_tableau_to_glm(
 
 Third-order Strong Stability Preserving Runge-Kutta.
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const SSPRK3 = butcher_tableau_to_glm(
     SMatrix{3, 3}(0.0, 1.0, 1/4, 0.0, 0.0, 1/4, 0.0, 0.0, 0.0),
@@ -151,7 +155,7 @@ const SSPRK3 = butcher_tableau_to_glm(
 """
     RK4
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const RK4 = butcher_tableau_to_glm(
     SMatrix{4, 4}(
@@ -167,7 +171,7 @@ const RK4 = butcher_tableau_to_glm(
 
 3/8-rule fourth-order method.
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const RK4_3_8 = butcher_tableau_to_glm(
     SMatrix{4, 4}(
@@ -181,7 +185,7 @@ const RK4_3_8 = butcher_tableau_to_glm(
 """
     RALSTON4
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const RALSTON4 = butcher_tableau_to_glm(
     SMatrix{4, 4}(
@@ -218,7 +222,7 @@ const RALSTON4 = butcher_tableau_to_glm(
 """
     BACKWARD_EULER
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const BACKWARD_EULER = butcher_tableau_to_glm(
     SMatrix{1, 1}(1.0), SVector(1.0), SVector(1.0), 1
@@ -227,7 +231,7 @@ const BACKWARD_EULER = butcher_tableau_to_glm(
 """
     RADAU_IA_1
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const RADAU_IA_1 = butcher_tableau_to_glm(SMatrix{1, 1}(1.0), SVector(1.0), SVector(1.0), 1)
 
@@ -235,10 +239,20 @@ const RADAU_IA_1 = butcher_tableau_to_glm(SMatrix{1, 1}(1.0), SVector(1.0), SVec
 """
     IMPLICIT_MIDPOINT
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const IMPLICIT_MIDPOINT = butcher_tableau_to_glm(
     SMatrix{1, 1}(0.5), SVector(1.0), SVector(1 / 2), 2
+)
+
+"""
+    CRANK_NICOLSON
+
+Crank-Nicolson method of order 2. From
+[Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
+"""
+const CRANK_NICOLSON = butcher_tableau_to_glm(
+    SMatrix{2, 2}(0.0, 0.5, 0.0, 0.5), SVector(0.5, 0.5), SVector(0.0, 1.0), 2
 )
 
 const _α_DIRK2 = 1 - sqrt(2)/2
@@ -268,10 +282,46 @@ const DIRK3 = butcher_tableau_to_glm(
     3,
 )
 
+const _ESDIRK32_g = 0.4358665215
+"""
+    ESDIRK32
+
+Four-stage, 3rd order, stiffly accurate, A- and L-stable ESDIRK scheme. See
+[Kvaerno2004](@cite) page 497.
+"""
+const ESDIRK32 = butcher_tableau_to_glm(
+    SMatrix{4, 4}(
+        0.0,
+        _ESDIRK32_g,
+        (-4.0*_ESDIRK32_g^2 + 6*_ESDIRK32_g - 1.0)/(4.0 * _ESDIRK32_g),
+        (6.0*_ESDIRK32_g - 1.0)/(12.0 * _ESDIRK32_g),
+        0.0,
+        _ESDIRK32_g,
+        (-2.0*_ESDIRK32_g+1.0)/(4.0*_ESDIRK32_g),
+        -1.0/((24.0*_ESDIRK32_g-12.0)*_ESDIRK32_g),
+        0.0,
+        0.0,
+        _ESDIRK32_g,
+        (-6.0*_ESDIRK32_g^2 + 6*_ESDIRK32_g - 1.0)/(6.0*_ESDIRK32_g - 3.0),
+        0.0,
+        0.0,
+        0.0,
+        _ESDIRK32_g,
+    ),
+    SVector(
+        (6.0*_ESDIRK32_g - 1.0)/(12.0 * _ESDIRK32_g),
+        -1.0/((24.0*_ESDIRK32_g-12.0)*_ESDIRK32_g),
+        (-6.0*_ESDIRK32_g^2 + 6*_ESDIRK32_g - 1.0)/(6.0*_ESDIRK32_g - 3.0),
+        _ESDIRK32_g,
+    ),
+    SVector(0.0, 2.0*_ESDIRK32_g, 1.0, 1.0),
+    3,
+)
+
 """
     RADAU_IA_3
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const RADAU_IA_3 = butcher_tableau_to_glm(
     SMatrix{2, 2}(1/4, 1/4, -1/4, 5/12), SVector(1 / 4, 3 / 4), SVector(0, 2 / 3), 3
@@ -305,7 +355,7 @@ const DIRK4 = butcher_tableau_to_glm(
 """
     GAUSS_LEGENDRE_4
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const GAUSS_LEGENDRE_4 = butcher_tableau_to_glm(
     SMatrix{2, 2}(1/4, 1/4+sqrt(3)/6, 1/4-sqrt(3)/6, 1/4),
@@ -318,7 +368,7 @@ const GAUSS_LEGENDRE_4 = butcher_tableau_to_glm(
 """
     GAUSS_LEGENDRE_6
 
-From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods)
+From [Wikipedia's list of Runge-Kutta methods](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods).
 """
 const GAUSS_LEGENDRE_6 = butcher_tableau_to_glm(
     SMatrix{3, 3}(
@@ -721,6 +771,9 @@ const BACKWARD_FORWARD_EULER = IMEX(
 
 """
     MIDPOINT_IMEX
+
+IMEX combination of the implicit and explicit midpoint rules. See equation 4.14 in
+[Ern2023](@cite).
 """
 const MIDPOINT_IMEX = IMEX(
     SMatrix{2, 2}(0.0, 0.0, 0.0, 1/2), # A Implicit
@@ -754,6 +807,30 @@ const RK3_IMEX = IMEX(
     SMatrix{1, 1}(1.0), # V
     SVector(0.0, _γ, 1 - _γ), # C Implicit
     SVector(0.0, _γ, 1 - _γ), # C Explicit
+    TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        Int[],  # Δt F
+    ),
+    3,
+)
+
+const _γ331 = 0.5 + 1/(2*sqrt(3))
+"""
+    IMEX331
+
+3-stage, 3rd order, A-stable IMEX scheme with optimal efficiency. See equation 4.18 in
+[Ern2023](@cite).
+"""
+const IMEX331 = IMEX(
+    SMatrix{3, 3}(0.0, 1/3-_γ331, _γ331, 0.0, _γ331, 2/3-2.0*_γ, 0.0, 0.0, _γ), # A Implicit
+    SMatrix{3, 3}(0.0, 1/3, 0.0, 0.0, 0.0, 2.0/3.0, 0.0, 0.0, 0.0), # A Explicit
+    SMatrix{1, 3}(0.25, 0.0, 0.75), # B Implicit
+    SMatrix{1, 3}(0.25, 0.0, 0.75), # B Explicit
+    SMatrix{3, 1}(1.0, 1.0, 1.0), # U
+    SMatrix{1, 1}(1.0), # V
+    SVector(0.0, 1/3, 2/3), # C Implicit
+    SVector(0.0, 1/3, 2/3), # C Explicit
     TimeLevels(
         [0], # y
         Int[], # Δt G

--- a/src/TimeIntegrators/TimeIntegrators.jl
+++ b/src/TimeIntegrators/TimeIntegrators.jl
@@ -4,45 +4,87 @@ using LinearAlgebra
 using StaticArrays
 import SparseArrays
 
-# These exports make these symbols/functions/etc. available outside the Forms module. Only
-# if they are also exported in the Mantis.jl file will they be available when using Mantis.
-
 # Abstract types
 # The public keyword is only available in Julia 1.11 and up. Since we also support LTS
 # (currently 1.10), we add the following line from the manual:
 # https://docs.julialang.org/en/v1.12/manual/modules/#Export-lists
-VERSION >= v"1.11.0-DEV.469" && eval(
-    Meta.parse(
-        "public AbstractTimeIntegrator",
-    ),
-)
+VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse("public AbstractTimeIntegrator"))
+
+# These exports make these symbols/functions/etc. available outside the TimeIntegrators
+# module. Only if they are also exported in the Mantis.jl file will they be available when
+# using Mantis.
 
 # Type parameter methods
 export get_num_stages, get_num_steps
 # Problem-specific information
-export TimeIntegrationOperators, define_explicit_ode, define_diagonally_implicit_ode,
-    define_implicit_ode, define_imex_ode
+export TimeIntegrationOperators,
+    define_explicit_ode,
+    define_diagonally_implicit_ode,
+    define_implicit_ode,
+    define_imex_ode
 # TimeLevels
-export TimeLevels
+export TimeLevels,
+    get_num_step_values, get_num_implicit_derivatives, get_num_explicit_derivatives
 # Integrator (Types)
 export check_implicit, Explicit, DiagonallyImplicit, Implicit, IMEX, get_order
 # Solution objects
-export TimeIntegrationSolution, get_num_variables, get_solution, get_scheme,
-    get_startup_scheme, get_remaining_startup_steps
+export TimeIntegrationSolution,
+    get_num_variables,
+    get_solution,
+    get_scheme,
+    get_startup_scheme,
+    get_remaining_startup_steps
 
 # Schemes
-export butcher_tableau_to_glm, FORWARD_EULER, EXPLICIT_MIDPOINT, HEUN2, RALSTON2, HEUN3,
-    RK3, RALSTON3, VDHW3, SSPRK3, RK4, RK4_3_8, RALSTON4, BACKWARD_EULER, RADAU_IA_1,
-    IMPLICIT_MIDPOINT, DIRK2, DIRK3, RADAU_IA_3, DIRK4, GAUSS_LEGENDRE_4, GAUSS_LEGENDRE_6,
-    AB1, AB2, AB3, AB4, BDF1, BDF2, BDF3, BDF4, AM0, AM1, AM2, AM3, AM4,
-    BACKWARD_FORWARD_EULER, MIDPOINT_IMEX, RK3_IMEX, CNAB2, SSSS2
+export butcher_tableau_to_glm,
+    FORWARD_EULER,
+    EXPLICIT_MIDPOINT,
+    HEUN2,
+    RALSTON2,
+    HEUN3,
+    RK3,
+    RALSTON3,
+    VDHW3,
+    SSPRK3,
+    RK4,
+    RK4_3_8,
+    RALSTON4,
+    BACKWARD_EULER,
+    RADAU_IA_1,
+    IMPLICIT_MIDPOINT,
+    CRANK_NICOLSON,
+    DIRK2,
+    DIRK3,
+    ESDIRK32,
+    RADAU_IA_3,
+    DIRK4,
+    GAUSS_LEGENDRE_4,
+    GAUSS_LEGENDRE_6,
+    AB1,
+    AB2,
+    AB3,
+    AB4,
+    BDF1,
+    BDF2,
+    BDF3,
+    BDF4,
+    AM0,
+    AM1,
+    AM2,
+    AM3,
+    AM4,
+    BACKWARD_FORWARD_EULER,
+    MIDPOINT_IMEX,
+    RK3_IMEX,
+    IMEX331,
+    CNAB2,
+    SSSS2
 
 # Initialisations
-export initialize_scheme
+export initialise_scheme
 
 # Integrations
 export time_integrate, time_integrate!
-
 
 include("Definitions.jl")
 include("Schemes.jl")

--- a/src/TimeIntegrators/TimeIntegrators.jl
+++ b/src/TimeIntegrators/TimeIntegrators.jl
@@ -1,0 +1,52 @@
+module TimeIntegrators
+
+using LinearAlgebra
+using StaticArrays
+import SparseArrays
+
+# These exports make these symbols/functions/etc. available outside the Forms module. Only
+# if they are also exported in the Mantis.jl file will they be available when using Mantis.
+
+# Abstract types
+# The public keyword is only available in Julia 1.11 and up. Since we also support LTS
+# (currently 1.10), we add the following line from the manual:
+# https://docs.julialang.org/en/v1.12/manual/modules/#Export-lists
+VERSION >= v"1.11.0-DEV.469" && eval(
+    Meta.parse(
+        "public AbstractTimeIntegrator",
+    ),
+)
+
+# Type parameter methods
+export get_num_stages, get_num_steps
+# Problem-specific information
+export TimeIntegrationOperators, define_explicit_ode, define_diagonally_implicit_ode,
+    define_implicit_ode, define_imex_ode
+# TimeLevels
+export TimeLevels
+# Integrator (Types)
+export check_implicit, Explicit, DiagonallyImplicit, Implicit, IMEX, get_order
+# Solution objects
+export TimeIntegrationSolution, get_num_variables, get_solution, get_scheme,
+    get_startup_scheme, get_remaining_startup_steps
+
+# Schemes
+export butcher_tableau_to_glm, FORWARD_EULER, EXPLICIT_MIDPOINT, HEUN2, RALSTON2, HEUN3,
+    RK3, RALSTON3, VDHW3, SSPRK3, RK4, RK4_3_8, RALSTON4, BACKWARD_EULER, RADAU_IA_1,
+    IMPLICIT_MIDPOINT, DIRK2, DIRK3, RADAU_IA_3, DIRK4, GAUSS_LEGENDRE_4, GAUSS_LEGENDRE_6,
+    AB1, AB2, AB3, AB4, BDF1, BDF2, BDF3, BDF4, AM0, AM1, AM2, AM3, AM4,
+    BACKWARD_FORWARD_EULER, MIDPOINT_IMEX, RK3_IMEX, CNAB2, SSSS2
+
+# Initialisations
+export initialize_scheme
+
+# Integrations
+export time_integrate, time_integrate!
+
+
+include("Definitions.jl")
+include("Schemes.jl")
+include("Initialisations.jl")
+include("Integrations.jl")
+
+end

--- a/test/Inference/TimeIntegratorsInferenceTests.jl
+++ b/test/Inference/TimeIntegratorsInferenceTests.jl
@@ -1,0 +1,190 @@
+module TimeIntegratorsInferenceTests
+
+import Pkg
+
+using Mantis
+using Test
+using JET
+using LinearAlgebra
+using StaticArrays
+
+# Test problem, to have some parameters and equations
+const lambda = -4
+const t_final = 1
+
+y_0 = 1.0
+function exact_sol(t)
+    return exp(lambda * t)
+end
+
+function test_ode_explicit_func(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n]
+    end
+    return nothing
+end
+@test_opt TimeIntegrators.define_explicit_ode(test_ode_explicit_func)
+test_ode_explicit = TimeIntegrators.define_explicit_ode(test_ode_explicit_func)
+
+function implicitSolve(output, x, h, t)
+    output .= (LinearAlgebra.I - h * lambda) \ x
+    return nothing
+end
+function implicitEvaluate(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n]
+    end
+    return nothing
+end
+@test_opt TimeIntegrators.define_diagonally_implicit_ode(implicitSolve, implicitEvaluate)
+test_ode_dimplicit = TimeIntegrators.define_diagonally_implicit_ode(
+    implicitSolve, implicitEvaluate
+)
+@test_opt TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate)
+test_ode_implicit = TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate)
+
+function test_ode_explicit_imex_func(output, yn, t)
+    for n in eachindex(output)
+        output[n] = 0.5 * lambda * yn[n]
+    end
+    return nothing
+end
+@test_opt TimeIntegrators.define_imex_ode(
+    test_ode_explicit_imex_func,  # Explcit evaluation
+    (output, x, h, t) -> LinearAlgebra.ldiv!(
+        output, LinearAlgebra.lu(LinearAlgebra.I - 0.5 * h * lambda), x
+    ),  # Implicit solver
+)
+test_ode_imex = TimeIntegrators.define_imex_ode(
+    test_ode_explicit_imex_func,  # Explcit evaluation
+    (output, x, h, t) -> LinearAlgebra.ldiv!(
+        output, LinearAlgebra.lu(LinearAlgebra.I - 0.5 * h * lambda), x
+    ),  # Implicit solver
+)
+
+const schemes = (
+    # Single-step, multi-stage, Explicit
+    (TimeIntegrators.FORWARD_EULER, nothing),
+    (TimeIntegrators.EXPLICIT_MIDPOINT, nothing),
+    (TimeIntegrators.HEUN2, nothing),
+    (TimeIntegrators.RALSTON2, nothing),
+    (TimeIntegrators.HEUN3, nothing),
+    (TimeIntegrators.RK3, nothing),
+    (TimeIntegrators.RALSTON3, nothing),
+    (TimeIntegrators.VDHW3, nothing),
+    (TimeIntegrators.SSPRK3, nothing),
+    (TimeIntegrators.RK4, nothing),
+    (TimeIntegrators.RK4_3_8, nothing),
+    (TimeIntegrators.RALSTON4, nothing),
+    # Multi-step, single-stage, Explicit
+    (TimeIntegrators.AB1, nothing),
+    (TimeIntegrators.AB2, TimeIntegrators.HEUN2),
+    (TimeIntegrators.AB3, TimeIntegrators.HEUN3),
+    (TimeIntegrators.AB4, TimeIntegrators.RK4),
+    # Single-step, multi-stage, Implicit
+    (TimeIntegrators.BACKWARD_EULER, nothing),
+    (TimeIntegrators.RADAU_IA_1, nothing),
+    (TimeIntegrators.IMPLICIT_MIDPOINT, nothing),
+    (TimeIntegrators.DIRK2, nothing),
+    (TimeIntegrators.RADAU_IA_3, nothing),
+    (TimeIntegrators.DIRK3, nothing),
+    (TimeIntegrators.DIRK4, nothing),
+    (TimeIntegrators.GAUSS_LEGENDRE_4, nothing),
+    (TimeIntegrators.GAUSS_LEGENDRE_6, nothing),
+    # Multi-step, single-stage, Implicit
+    (TimeIntegrators.AM0, nothing),
+    (TimeIntegrators.AM1, TimeIntegrators.BACKWARD_EULER),
+    (TimeIntegrators.AM2, TimeIntegrators.DIRK2),
+    (TimeIntegrators.AM3, TimeIntegrators.DIRK3),
+    (TimeIntegrators.AM4, TimeIntegrators.GAUSS_LEGENDRE_6),
+    (TimeIntegrators.BDF1, nothing),
+    (TimeIntegrators.BDF2, TimeIntegrators.BACKWARD_EULER),
+    (TimeIntegrators.BDF3, TimeIntegrators.DIRK2),
+    (TimeIntegrators.BDF4, TimeIntegrators.DIRK3),
+    # Single-step, multi-stage, IMEX
+    (TimeIntegrators.BACKWARD_FORWARD_EULER, nothing),
+    (TimeIntegrators.MIDPOINT_IMEX, nothing),
+    (TimeIntegrators.RK3_IMEX, nothing),
+    # Multi-step, single-stage, IMEX
+    (TimeIntegrators.CNAB2, TimeIntegrators.MIDPOINT_IMEX),
+    (TimeIntegrators.SSSS2, TimeIntegrators.MIDPOINT_IMEX),
+)
+
+const dt = 0.2
+const t = 0.0
+
+# Test the convenience function
+@test_opt TimeIntegrators.butcher_tableau_to_glm( # Explicit RK4
+    SMatrix{4, 4}(
+        0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0
+    ),
+    SVector(1 / 6, 1 / 3, 1 / 3, 1 / 6),
+    SVector(0.0, 0.5, 0.5, 1.0),
+    4,
+)
+@test_opt TimeIntegrators.butcher_tableau_to_glm( # DiagonallyImplicit DIRK3
+    SMatrix{2, 2}(1/2 + sqrt(3)/6, -sqrt(3)/3, 0.0, 1/2+sqrt(3)/6),
+    SVector(1 / 2, 1 / 2),
+    SVector(1 / 2 + sqrt(3) / 6, 1 / 2 - sqrt(3) / 6),
+    3,
+)
+@test_opt TimeIntegrators.butcher_tableau_to_glm( # Implicit GAUSS_LEGENDRE_4
+    SMatrix{2, 2}(1/4, 1/4+sqrt(3)/6, 1/4-sqrt(3)/6, 1/4),
+    SVector(1 / 2, 1 / 2),
+    SVector(1 / 2 - sqrt(3) / 6, 1 / 2 + sqrt(3) / 6),
+    4,
+)
+
+# Test functions defining the odes.
+@test_opt TimeIntegrators.define_explicit_ode(test_ode_explicit_func)
+@test_opt TimeIntegrators.define_implicit_ode(implicitSolve, x -> lambda * x)
+@test_opt TimeIntegrators.define_imex_ode(
+    (yn, t) -> 0.5 * lambda * yn,  # Explcit evaluation
+    (x, h, t) -> (LinearAlgebra.I - 0.5 * h * lambda) \ x,  # Implicit solver
+    x -> 0.5 * lambda * x,  # Implicit evaluate
+)
+
+foreach(schemes) do (scheme, startup_scheme)
+    #@show scheme
+
+    if isnothing(startup_scheme)
+        @test_opt TimeIntegrators.initialize_scheme([y_0], scheme)
+        y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+    else
+        @test_opt TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+        y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+    end
+
+    if isa(scheme, TimeIntegrators.Explicit)
+        @test_opt TimeIntegrators.time_integrate!(y_n, test_ode_explicit, t, dt)
+        TimeIntegrators.time_integrate!(y_n, test_ode_explicit, t, dt)
+    elseif isa(scheme, TimeIntegrators.DiagonallyImplicit)
+        @test_opt TimeIntegrators.time_integrate!(y_n, test_ode_dimplicit, t, dt)
+        TimeIntegrators.time_integrate!(y_n, test_ode_dimplicit, t, dt)
+    elseif isa(scheme, TimeIntegrators.Implicit)
+        @test_opt TimeIntegrators.time_integrate!(y_n, test_ode_implicit, t, dt)
+        TimeIntegrators.time_integrate!(y_n, test_ode_implicit, t, dt)
+    elseif isa(scheme, TimeIntegrators.IMEX)
+        @test_opt TimeIntegrators.time_integrate!(y_n, test_ode_imex, t, dt)
+        TimeIntegrators.time_integrate!(y_n, test_ode_imex, t, dt)
+    else
+        @warn "Unknown TimeIntegrator type: $(typeof(scheme))"
+    end
+
+    # Test the functions applied to a TimeIntegrationSolution
+    @test_opt eltype(y_n)
+    @test_opt TimeIntegrators.get_num_variables(y_n)
+    @test_opt TimeIntegrators.get_solution(y_n)
+    @test_opt TimeIntegrators.get_scheme(y_n)
+    @test_opt TimeIntegrators.get_startup_scheme(y_n)
+    @test_opt TimeIntegrators.get_remaining_startup_steps(y_n)
+    @test_opt TimeIntegrators.get_F_allocated(y_n)
+    @test_opt TimeIntegrators.get_G_allocated(y_n)
+
+    # Test the functions applied to a scheme (other than integration and startup).
+    @test_opt TimeIntegrators.get_num_stages(scheme)
+    @test_opt TimeIntegrators.get_num_steps(scheme)
+    @test_opt TimeIntegrators.get_order(scheme)
+end
+
+end

--- a/test/Inference/TimeIntegratorsInferenceTests.jl
+++ b/test/Inference/TimeIntegratorsInferenceTests.jl
@@ -23,8 +23,6 @@ function test_ode_explicit_func(output, yn, t)
     end
     return nothing
 end
-@test_opt TimeIntegrators.define_explicit_ode(test_ode_explicit_func)
-test_ode_explicit = TimeIntegrators.define_explicit_ode(test_ode_explicit_func)
 
 function implicitSolve(output, x, h, t)
     output .= (LinearAlgebra.I - h * lambda) \ x
@@ -36,12 +34,6 @@ function implicitEvaluate(output, yn, t)
     end
     return nothing
 end
-@test_opt TimeIntegrators.define_diagonally_implicit_ode(implicitSolve, implicitEvaluate)
-test_ode_dimplicit = TimeIntegrators.define_diagonally_implicit_ode(
-    implicitSolve, implicitEvaluate
-)
-@test_opt TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate)
-test_ode_implicit = TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate)
 
 function test_ode_explicit_imex_func(output, yn, t)
     for n in eachindex(output)
@@ -49,17 +41,37 @@ function test_ode_explicit_imex_func(output, yn, t)
     end
     return nothing
 end
+
+# Test functions defining the odes.
+@test_opt TimeIntegrators.define_explicit_ode(test_ode_explicit_func)
+@test_opt TimeIntegrators.define_diagonally_implicit_ode(implicitSolve)
+@test_opt TimeIntegrators.define_diagonally_implicit_ode(implicitSolve, implicitEvaluate)
+@test_opt TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate)
 @test_opt TimeIntegrators.define_imex_ode(
-    test_ode_explicit_imex_func,  # Explcit evaluation
+    test_ode_explicit_imex_func,
     (output, x, h, t) -> LinearAlgebra.ldiv!(
         output, LinearAlgebra.lu(LinearAlgebra.I - 0.5 * h * lambda), x
-    ),  # Implicit solver
+    ),
 )
+@test_opt TimeIntegrators.define_imex_ode(
+    test_ode_explicit_imex_func,
+    (output, x, h, t) -> LinearAlgebra.ldiv!(
+        output, LinearAlgebra.lu(LinearAlgebra.I - 0.5 * h * lambda), x
+    ),
+    test_ode_explicit_imex_func,  # Implicit evaluate is the same as the explicit one here.
+)
+
+test_ode_explicit = TimeIntegrators.define_explicit_ode(test_ode_explicit_func)
+test_ode_dimplicit = TimeIntegrators.define_diagonally_implicit_ode(
+    implicitSolve, implicitEvaluate
+)
+test_ode_implicit = TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate)
 test_ode_imex = TimeIntegrators.define_imex_ode(
     test_ode_explicit_imex_func,  # Explcit evaluation
     (output, x, h, t) -> LinearAlgebra.ldiv!(
         output, LinearAlgebra.lu(LinearAlgebra.I - 0.5 * h * lambda), x
     ),  # Implicit solver
+    test_ode_explicit_imex_func,
 )
 
 const schemes = (
@@ -85,9 +97,11 @@ const schemes = (
     (TimeIntegrators.BACKWARD_EULER, nothing),
     (TimeIntegrators.RADAU_IA_1, nothing),
     (TimeIntegrators.IMPLICIT_MIDPOINT, nothing),
+    (TimeIntegrators.CRANK_NICOLSON, nothing),
     (TimeIntegrators.DIRK2, nothing),
     (TimeIntegrators.RADAU_IA_3, nothing),
     (TimeIntegrators.DIRK3, nothing),
+    (TimeIntegrators.ESDIRK32, nothing),
     (TimeIntegrators.DIRK4, nothing),
     (TimeIntegrators.GAUSS_LEGENDRE_4, nothing),
     (TimeIntegrators.GAUSS_LEGENDRE_6, nothing),
@@ -96,7 +110,7 @@ const schemes = (
     (TimeIntegrators.AM1, TimeIntegrators.BACKWARD_EULER),
     (TimeIntegrators.AM2, TimeIntegrators.DIRK2),
     (TimeIntegrators.AM3, TimeIntegrators.DIRK3),
-    (TimeIntegrators.AM4, TimeIntegrators.GAUSS_LEGENDRE_6),
+    (TimeIntegrators.AM4, TimeIntegrators.DIRK4),
     (TimeIntegrators.BDF1, nothing),
     (TimeIntegrators.BDF2, TimeIntegrators.BACKWARD_EULER),
     (TimeIntegrators.BDF3, TimeIntegrators.DIRK2),
@@ -105,6 +119,7 @@ const schemes = (
     (TimeIntegrators.BACKWARD_FORWARD_EULER, nothing),
     (TimeIntegrators.MIDPOINT_IMEX, nothing),
     (TimeIntegrators.RK3_IMEX, nothing),
+    (TimeIntegrators.IMEX331, nothing),
     # Multi-step, single-stage, IMEX
     (TimeIntegrators.CNAB2, TimeIntegrators.MIDPOINT_IMEX),
     (TimeIntegrators.SSSS2, TimeIntegrators.MIDPOINT_IMEX),
@@ -135,24 +150,13 @@ const t = 0.0
     4,
 )
 
-# Test functions defining the odes.
-@test_opt TimeIntegrators.define_explicit_ode(test_ode_explicit_func)
-@test_opt TimeIntegrators.define_implicit_ode(implicitSolve, x -> lambda * x)
-@test_opt TimeIntegrators.define_imex_ode(
-    (yn, t) -> 0.5 * lambda * yn,  # Explcit evaluation
-    (x, h, t) -> (LinearAlgebra.I - 0.5 * h * lambda) \ x,  # Implicit solver
-    x -> 0.5 * lambda * x,  # Implicit evaluate
-)
-
 foreach(schemes) do (scheme, startup_scheme)
-    #@show scheme
-
     if isnothing(startup_scheme)
-        @test_opt TimeIntegrators.initialize_scheme([y_0], scheme)
-        y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+        @test_opt TimeIntegrators.initialise_scheme([y_0], scheme)
+        y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
     else
-        @test_opt TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
-        y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+        @test_opt TimeIntegrators.initialise_scheme([y_0], scheme, startup_scheme)
+        y_n = TimeIntegrators.initialise_scheme([y_0], scheme, startup_scheme)
     end
 
     if isa(scheme, TimeIntegrators.Explicit)

--- a/test/Inference/runtests.jl
+++ b/test/Inference/runtests.jl
@@ -4,5 +4,6 @@ using Test
 
 @testset "Geometry" begin include("GeometryInferenceTests.jl") end
 @testset "FESpaces" begin include("FESpacesInferenceTests.jl") end
+@testset "TimeIntegrators" begin include("TimeIntegratorsInferenceTests.jl") end
 
 end

--- a/test/TimeIntegrators/AdvectionTests.jl
+++ b/test/TimeIntegrators/AdvectionTests.jl
@@ -1,0 +1,50 @@
+module TimeIntegrationAdvectionTests
+
+import SparseArrays
+import LinearAlgebra
+using Mantis
+using Test
+
+# We can test (some) numerical schemes by considering a simple advection equation. For
+# example, the forward Euler scheme with CFL exactly equal to 1 is exact in this case, so
+# we can easily compare the solution to the initial condition.
+
+# Consider the advection equation on a 1D domain (x_L, x_R) as
+# dc/dt = Ac
+# where c is the vector of unknowns, and A is the (N-1, N-1) discretisation matrix.
+
+# Special case backward FD + Forward Euler at CFL = 1 --------------------------------------
+# If we construct A as first-order upwind finite difference method, the scheme with forward
+# Euler time integration with CFL 1 will be exact.
+const dx = 0.01
+const L = 1.0
+const velocity = 0.1
+const dt = dx / velocity  # gives CFL = 1
+const grid = 0.0:dx:L
+const A =
+    (velocity / dx) *
+    SparseArrays.spdiagm(0 => ones(length(grid)), -1 => -1 .* ones(length(grid)-1))
+# Set periodic boundary conditions.
+A[1, end] = -(velocity / dx)
+
+function discretised_advection_equation(output, c, t)
+    LinearAlgebra.mul!(output, -A, c)
+    return nothing
+end
+
+c_0 = sinpi.(2.0 .* grid)
+
+linear_advection_ode = TimeIntegrators.define_explicit_ode(discretised_advection_equation)
+
+@testset "Forward Euler CFL 1 Advection Tests" verbose = true begin
+    c_n = TimeIntegrators.initialize_scheme(c_0, TimeIntegrators.FORWARD_EULER)
+
+    # Pick the end time such that the IC traverses our domain exactly 10 times.
+    for t in 0.0:dt:(20.0 + dt)
+        TimeIntegrators.time_integrate!(c_n, linear_advection_ode, t, dt)
+    end
+
+    @test isapprox(c_0, TimeIntegrators.get_solution(c_n), atol=1e-15, rtol=1e-15)
+end
+
+end

--- a/test/TimeIntegrators/AdvectionTests.jl
+++ b/test/TimeIntegrators/AdvectionTests.jl
@@ -37,7 +37,7 @@ c_0 = sinpi.(2.0 .* grid)
 linear_advection_ode = TimeIntegrators.define_explicit_ode(discretised_advection_equation)
 
 @testset "Forward Euler CFL 1 Advection Tests" verbose = true begin
-    c_n = TimeIntegrators.initialize_scheme(c_0, TimeIntegrators.FORWARD_EULER)
+    c_n = TimeIntegrators.initialise_scheme(c_0, TimeIntegrators.FORWARD_EULER)
 
     # Pick the end time such that the IC traverses our domain exactly 10 times.
     for t in 0.0:dt:(20.0 + dt)

--- a/test/TimeIntegrators/BasicTests.jl
+++ b/test/TimeIntegrators/BasicTests.jl
@@ -1,0 +1,168 @@
+module TimeIntegrationConvergenceTests
+
+using Mantis
+using Test
+
+# Explicit integrator
+@test TimeIntegrators.get_num_steps(TimeIntegrators.RK4) == 1
+@test TimeIntegrators.get_num_stages(TimeIntegrators.RK4) == 4
+@test typeof(TimeIntegrators.RK4) == TimeIntegrators.Explicit{4, 1, Float64, 16, 4, 1}
+@test TimeIntegrators.get_order(TimeIntegrators.RK4) == 4
+
+# Diagonally implicit integrator
+@test TimeIntegrators.get_num_steps(TimeIntegrators.DIRK2) == 1
+@test TimeIntegrators.get_num_stages(TimeIntegrators.DIRK2) == 2
+@test typeof(TimeIntegrators.DIRK2) == TimeIntegrators.DiagonallyImplicit{
+    2, 1, Float64, 4, 2, 1
+}
+@test TimeIntegrators.get_order(TimeIntegrators.DIRK2) == 2
+
+# Implicit integrator
+@test TimeIntegrators.get_num_steps(TimeIntegrators.GAUSS_LEGENDRE_6) == 1
+@test TimeIntegrators.get_num_stages(TimeIntegrators.GAUSS_LEGENDRE_6) == 3
+@test typeof(TimeIntegrators.GAUSS_LEGENDRE_6) == TimeIntegrators.Implicit{
+    3, 1, Float64, 9, 3, 1
+}
+@test TimeIntegrators.get_order(TimeIntegrators.GAUSS_LEGENDRE_6) == 6
+
+# IMEX integrator
+@test TimeIntegrators.get_num_steps(TimeIntegrators.CNAB2) == 4
+@test TimeIntegrators.get_num_stages(TimeIntegrators.CNAB2) == 1
+@test typeof(TimeIntegrators.CNAB2) == TimeIntegrators.IMEX{1, 4, Float64, 1, 4, 16}
+@test TimeIntegrators.get_order(TimeIntegrators.CNAB2) == 2
+
+# Incorrect matrices
+@test_throws ArgumentError TimeIntegrators.Explicit(
+    TimeIntegrators.GAUSS_LEGENDRE_6.A,
+    TimeIntegrators.GAUSS_LEGENDRE_6.B,
+    TimeIntegrators.GAUSS_LEGENDRE_6.U,
+    TimeIntegrators.GAUSS_LEGENDRE_6.V,
+    TimeIntegrators.GAUSS_LEGENDRE_6.C,
+    TimeIntegrators.GAUSS_LEGENDRE_6.time_levels,
+    TimeIntegrators.GAUSS_LEGENDRE_6.order,
+)
+
+@test_throws ArgumentError TimeIntegrators.DiagonallyImplicit(
+    TimeIntegrators.GAUSS_LEGENDRE_6.A,
+    TimeIntegrators.GAUSS_LEGENDRE_6.B,
+    TimeIntegrators.GAUSS_LEGENDRE_6.U,
+    TimeIntegrators.GAUSS_LEGENDRE_6.V,
+    TimeIntegrators.GAUSS_LEGENDRE_6.C,
+    TimeIntegrators.GAUSS_LEGENDRE_6.time_levels,
+    TimeIntegrators.GAUSS_LEGENDRE_6.order,
+)
+
+@test_throws ArgumentError TimeIntegrators.Explicit(
+    TimeIntegrators.DIRK2.A,
+    TimeIntegrators.DIRK2.B,
+    TimeIntegrators.DIRK2.U,
+    TimeIntegrators.DIRK2.V,
+    TimeIntegrators.DIRK2.C,
+    TimeIntegrators.DIRK2.time_levels,
+    TimeIntegrators.DIRK2.order,
+)
+
+@test_throws ArgumentError TimeIntegrators.IMEX(
+    TimeIntegrators.GAUSS_LEGENDRE_6.A,
+    TimeIntegrators.GAUSS_LEGENDRE_6.A,
+    TimeIntegrators.GAUSS_LEGENDRE_6.B,
+    TimeIntegrators.GAUSS_LEGENDRE_6.B,
+    TimeIntegrators.GAUSS_LEGENDRE_6.U,
+    TimeIntegrators.GAUSS_LEGENDRE_6.V,
+    TimeIntegrators.GAUSS_LEGENDRE_6.C,
+    TimeIntegrators.GAUSS_LEGENDRE_6.C,
+    TimeIntegrators.GAUSS_LEGENDRE_6.time_levels,
+    TimeIntegrators.GAUSS_LEGENDRE_6.order,
+)
+
+# TimeIntegrationOperators should have at least one Function.
+@test_throws ArgumentError TimeIntegrators.TimeIntegrationOperators(
+    nothing, nothing, nothing
+)
+@test_throws ArgumentError TimeIntegrators.TimeIntegrationOperators(
+    Union{}(), Union{}(), Union{}()
+)
+
+
+
+# Setup some ODEs. Then check if we throw an error if the wrong ODE/scheme pairing is used.
+const lambda = -4
+const t_final = 1
+
+y_0 = 1.0
+function exact_sol(t)
+    return exp(lambda * t)
+end
+
+function test_ode_explicit_func!(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n]
+    end
+    return nothing
+end
+test_ode_explicit = TimeIntegrators.define_explicit_ode(test_ode_explicit_func!)
+
+function implicitSolve(output, x, h, t)
+    output .= (LinearAlgebra.I - h * lambda) \ x
+    return nothing
+end
+test_ode_dimplicit = TimeIntegrators.define_diagonally_implicit_ode(implicitSolve)
+
+function implicitEvaluate!(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n]
+    end
+    return nothing
+end
+test_ode_implicit = TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate!)
+
+function explicit_imex_function!(output, yn, t)
+    for n in axes(output, 1)
+        output[n] = 0.5 * lambda * yn[n]
+    end
+    return nothing
+end
+function implicit_imex_function!(output, yn, t)
+    for n in axes(output, 1)
+        output[n] = 0.5 * lambda * yn[n]
+    end
+    return nothing
+end
+test_ode_imex = TimeIntegrators.define_imex_ode(
+    explicit_imex_function!,
+    (output, x, h, t) -> LinearAlgebra.ldiv!(
+        output, LinearAlgebra.lu(LinearAlgebra.I - 0.5 * h * lambda), x
+    ),
+    implicit_imex_function!,
+)
+
+y_ne = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.RK4)
+@test_throws ArgumentError TimeIntegrators.time_integrate!(
+    y_ne, test_ode_dimplicit, 0.0, 0.1
+)
+@test_throws ArgumentError TimeIntegrators.time_integrate!(
+    y_ne, test_ode_implicit, 0.0, 0.1
+)
+
+y_ndi = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.DIRK2)
+@test_throws ArgumentError TimeIntegrators.time_integrate!(
+    y_ndi, test_ode_explicit, 0.0, 0.1
+)
+
+y_ni = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.GAUSS_LEGENDRE_6)
+@test_throws ArgumentError TimeIntegrators.time_integrate!(
+    y_ni, test_ode_explicit, 0.0, 0.1
+)
+
+y_nimex = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.MIDPOINT_IMEX)
+@test_throws ArgumentError TimeIntegrators.time_integrate!(
+    y_nimex, test_ode_explicit, 0.0, 0.1
+)
+@test_throws ArgumentError TimeIntegrators.time_integrate!(
+    y_nimex, test_ode_dimplicit, 0.0, 0.1
+)
+@test_throws ArgumentError TimeIntegrators.time_integrate!(
+    y_nimex, test_ode_implicit, 0.0, 0.1
+)
+
+end

--- a/test/TimeIntegrators/BasicTests.jl
+++ b/test/TimeIntegrators/BasicTests.jl
@@ -1,7 +1,8 @@
-module TimeIntegrationConvergenceTests
+module TimeIntegrationBasicTests
 
 using Mantis
 using Test
+using StaticArrays
 
 # Explicit integrator
 @test TimeIntegrators.get_num_steps(TimeIntegrators.RK4) == 1
@@ -9,20 +10,24 @@ using Test
 @test typeof(TimeIntegrators.RK4) == TimeIntegrators.Explicit{4, 1, Float64, 16, 4, 1}
 @test TimeIntegrators.get_order(TimeIntegrators.RK4) == 4
 
-# Diagonally implicit integrator
+# Diagonally implicit integrators
 @test TimeIntegrators.get_num_steps(TimeIntegrators.DIRK2) == 1
 @test TimeIntegrators.get_num_stages(TimeIntegrators.DIRK2) == 2
-@test typeof(TimeIntegrators.DIRK2) == TimeIntegrators.DiagonallyImplicit{
-    2, 1, Float64, 4, 2, 1
-}
+@test typeof(TimeIntegrators.DIRK2) ==
+    TimeIntegrators.DiagonallyImplicit{2, 1, Float64, 4, 2, 1}
 @test TimeIntegrators.get_order(TimeIntegrators.DIRK2) == 2
+
+@test TimeIntegrators.get_num_steps(TimeIntegrators.CRANK_NICOLSON) == 1
+@test TimeIntegrators.get_num_stages(TimeIntegrators.CRANK_NICOLSON) == 2
+@test typeof(TimeIntegrators.CRANK_NICOLSON) ==
+    TimeIntegrators.DiagonallyImplicit{2, 1, Float64, 4, 2, 1}
+@test TimeIntegrators.get_order(TimeIntegrators.CRANK_NICOLSON) == 2
 
 # Implicit integrator
 @test TimeIntegrators.get_num_steps(TimeIntegrators.GAUSS_LEGENDRE_6) == 1
 @test TimeIntegrators.get_num_stages(TimeIntegrators.GAUSS_LEGENDRE_6) == 3
-@test typeof(TimeIntegrators.GAUSS_LEGENDRE_6) == TimeIntegrators.Implicit{
-    3, 1, Float64, 9, 3, 1
-}
+@test typeof(TimeIntegrators.GAUSS_LEGENDRE_6) ==
+    TimeIntegrators.Implicit{3, 1, Float64, 9, 3, 1}
 @test TimeIntegrators.get_order(TimeIntegrators.GAUSS_LEGENDRE_6) == 6
 
 # IMEX integrator
@@ -31,18 +36,161 @@ using Test
 @test typeof(TimeIntegrators.CNAB2) == TimeIntegrators.IMEX{1, 4, Float64, 1, 4, 16}
 @test TimeIntegrators.get_order(TimeIntegrators.CNAB2) == 2
 
-# Incorrect matrices
-@test_throws ArgumentError TimeIntegrators.Explicit(
-    TimeIntegrators.GAUSS_LEGENDRE_6.A,
-    TimeIntegrators.GAUSS_LEGENDRE_6.B,
-    TimeIntegrators.GAUSS_LEGENDRE_6.U,
-    TimeIntegrators.GAUSS_LEGENDRE_6.V,
-    TimeIntegrators.GAUSS_LEGENDRE_6.C,
-    TimeIntegrators.GAUSS_LEGENDRE_6.time_levels,
-    TimeIntegrators.GAUSS_LEGENDRE_6.order,
+# Correct matrices
+function check_equal(scheme1, scheme2)
+    if !all(isequal.(scheme1.A, scheme2.A))
+        return false
+    elseif !all(isequal.(scheme1.B, scheme2.B))
+        return false
+    elseif !all(isequal.(scheme1.U, scheme2.U))
+        return false
+    elseif !all(isequal.(scheme1.V, scheme2.V))
+        return false
+    elseif !all(isequal.(scheme1.C, scheme2.C))
+        return false
+    elseif !(
+        all(isequal.(scheme1.time_levels.step_values, scheme2.time_levels.step_values)) &&
+        all(
+            isequal.(
+                scheme1.time_levels.step_derivatives_implicit,
+                scheme2.time_levels.step_derivatives_implicit,
+            ),
+        ) &&
+        all(
+            isequal.(
+                scheme1.time_levels.step_derivatives_explicit,
+                scheme2.time_levels.step_derivatives_explicit,
+            ),
+        )
+    )
+        return false
+    elseif scheme1.order != scheme2.order
+        return false
+    end
+
+    return true
+end
+function check_equal_imex(scheme1, scheme2)
+    if !all(isequal.(scheme1.A_IM, scheme2.A_IM))
+        return false
+    elseif !all(isequal.(scheme1.A_EX, scheme2.A_EX))
+        return false
+    elseif !all(isequal.(scheme1.B_IM, scheme2.B_IM))
+        return false
+    elseif !all(isequal.(scheme1.B_EX, scheme2.B_EX))
+        return false
+    elseif !all(isequal.(scheme1.U, scheme2.U))
+        return false
+    elseif !all(isequal.(scheme1.V, scheme2.V))
+        return false
+    elseif !all(isequal.(scheme1.C_IM, scheme2.C_IM))
+        return false
+    elseif !all(isequal.(scheme1.C_EX, scheme2.C_EX))
+        return false
+    elseif !(
+        all(isequal.(scheme1.time_levels.step_values, scheme2.time_levels.step_values)) &&
+        all(
+            isequal.(
+                scheme1.time_levels.step_derivatives_implicit,
+                scheme2.time_levels.step_derivatives_implicit,
+            ),
+        ) &&
+        all(
+            isequal.(
+                scheme1.time_levels.step_derivatives_explicit,
+                scheme2.time_levels.step_derivatives_explicit,
+            ),
+        )
+    )
+        return false
+    elseif scheme1.order != scheme2.order
+        return false
+    end
+
+    return true
+end
+
+@test check_equal(
+    TimeIntegrators.butcher_tableau_to_glm(
+        SMatrix{3, 3}(0.0, 1/2, -1.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0),
+        SVector(1 / 6, 2 / 3, 1 / 6),
+        SVector(0.0, 1 / 2, 1.0),
+        3,
+    ),
+    TimeIntegrators.RK3,
+)
+@test check_equal(
+    TimeIntegrators.Explicit(
+        SMatrix{3, 3}(0.0, 1/2, -1.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0),
+        SMatrix{1, 3}(1 / 6, 2 / 3, 1 / 6),
+        ones(SMatrix{3, 1}),
+        ones(SMatrix{1, 1}),
+        SVector(0.0, 1 / 2, 1.0),
+        TimeIntegrators.TimeLevels([0], Int[], Int[]),
+        3,
+    ),
+    TimeIntegrators.RK3,
 )
 
-@test_throws ArgumentError TimeIntegrators.DiagonallyImplicit(
+@test check_equal(
+    TimeIntegrators.butcher_tableau_to_glm(
+        SMatrix{2, 2}(1/2 + 1/(2*sqrt(3)), -1/sqrt(3), 0.0, 1/2+1/(2*sqrt(3))),
+        SVector(1 / 2, 1 / 2),
+        SVector(1 / 2 + 1/(2*sqrt(3)), 1 / 2 - 1/(2*sqrt(3))),
+        3,
+    ),
+    TimeIntegrators.DIRK3,
+)
+@test check_equal(
+    TimeIntegrators.DiagonallyImplicit(
+        SMatrix{2, 2}(1/2 + 1/(2*sqrt(3)), -1/sqrt(3), 0.0, 1/2+1/(2*sqrt(3))),
+        SMatrix{1, 2}(1 / 2, 1 / 2),
+        ones(SMatrix{2, 1}),
+        ones(SMatrix{1, 1}),
+        SVector(1 / 2 + 1/(2*sqrt(3)), 1 / 2 - 1/(2*sqrt(3))),
+        TimeIntegrators.TimeLevels([0], Int[], Int[]),
+        3,
+    ),
+    TimeIntegrators.DIRK3,
+)
+
+@test check_equal(
+    TimeIntegrators.butcher_tableau_to_glm(
+        SMatrix{2, 2}(1/4, 1/4, -1/4, 5/12), SVector(1 / 4, 3 / 4), SVector(0, 2 / 3), 3
+    ),
+    TimeIntegrators.RADAU_IA_3,
+)
+@test check_equal(
+    TimeIntegrators.Implicit(
+        SMatrix{2, 2}(1/4, 1/4, -1/4, 5/12),
+        SMatrix{1, 2}(1 / 4, 3 / 4),
+        ones(SMatrix{2, 1}),
+        ones(SMatrix{1, 1}),
+        SVector(0, 2 / 3),
+        TimeIntegrators.TimeLevels([0], Int[], Int[]),
+        3,
+    ),
+    TimeIntegrators.RADAU_IA_3,
+)
+
+@test check_equal_imex(
+    TimeIntegrators.IMEX(
+        SMatrix{2, 2}(0.0, 0.0, 0.0, 1/2),
+        SMatrix{2, 2}(0.0, 1/2, 0.0, 0.0),
+        SMatrix{1, 2}(0.0, 1.0),
+        SMatrix{1, 2}(0.0, 1.0),
+        SMatrix{2, 1}(1.0, 1.0),
+        SMatrix{1, 1}(1.0),
+        SVector(0.0, 1/2),
+        SVector(0.0, 1/2),
+        TimeIntegrators.TimeLevels([0], Int[], Int[]),
+        2,
+    ),
+    TimeIntegrators.MIDPOINT_IMEX,
+)
+
+# Incorrect matrices
+@test_throws ArgumentError TimeIntegrators.Explicit(
     TimeIntegrators.GAUSS_LEGENDRE_6.A,
     TimeIntegrators.GAUSS_LEGENDRE_6.B,
     TimeIntegrators.GAUSS_LEGENDRE_6.U,
@@ -60,6 +208,16 @@ using Test
     TimeIntegrators.DIRK2.C,
     TimeIntegrators.DIRK2.time_levels,
     TimeIntegrators.DIRK2.order,
+)
+
+@test_throws ArgumentError TimeIntegrators.DiagonallyImplicit(
+    TimeIntegrators.GAUSS_LEGENDRE_6.A,
+    TimeIntegrators.GAUSS_LEGENDRE_6.B,
+    TimeIntegrators.GAUSS_LEGENDRE_6.U,
+    TimeIntegrators.GAUSS_LEGENDRE_6.V,
+    TimeIntegrators.GAUSS_LEGENDRE_6.C,
+    TimeIntegrators.GAUSS_LEGENDRE_6.time_levels,
+    TimeIntegrators.GAUSS_LEGENDRE_6.order,
 )
 
 @test_throws ArgumentError TimeIntegrators.IMEX(
@@ -83,7 +241,21 @@ using Test
     Union{}(), Union{}(), Union{}()
 )
 
+# Check the length getters for TimeLevels.
+tl1 = TimeIntegrators.TimeLevels([0, 1, 2], [0], [0, 1])
+@test TimeIntegrators.get_num_step_values(tl1) == 3
+@test TimeIntegrators.get_num_implicit_derivatives(tl1) == 1
+@test TimeIntegrators.get_num_explicit_derivatives(tl1) == 2
 
+tl2 = TimeIntegrators.TimeLevels(Int[], Int[], Int[])
+@test TimeIntegrators.get_num_step_values(tl2) == 0
+@test TimeIntegrators.get_num_implicit_derivatives(tl2) == 0
+@test TimeIntegrators.get_num_explicit_derivatives(tl2) == 0
+
+tl3 = TimeIntegrators.TimeLevels([6, -8], [2, 4], [3])
+@test TimeIntegrators.get_num_step_values(tl3) == 2
+@test TimeIntegrators.get_num_implicit_derivatives(tl3) == 2
+@test TimeIntegrators.get_num_explicit_derivatives(tl3) == 1
 
 # Setup some ODEs. Then check if we throw an error if the wrong ODE/scheme pairing is used.
 const lambda = -4
@@ -136,7 +308,15 @@ test_ode_imex = TimeIntegrators.define_imex_ode(
     implicit_imex_function!,
 )
 
-y_ne = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.RK4)
+test_ode_ee = TimeIntegrators.TimeIntegrationOperators(
+    test_ode_explicit_func!, nothing, implicitEvaluate!
+)
+
+@test_throws ArgumentError TimeIntegrators.TimeIntegrationOperators(
+    nothing, nothing, implicitEvaluate!
+)
+
+y_ne = TimeIntegrators.initialise_scheme([y_0], TimeIntegrators.RK4)
 @test_throws ArgumentError TimeIntegrators.time_integrate!(
     y_ne, test_ode_dimplicit, 0.0, 0.1
 )
@@ -144,17 +324,21 @@ y_ne = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.RK4)
     y_ne, test_ode_implicit, 0.0, 0.1
 )
 
-y_ndi = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.DIRK2)
+y_ndi = TimeIntegrators.initialise_scheme([y_0], TimeIntegrators.DIRK2)
 @test_throws ArgumentError TimeIntegrators.time_integrate!(
     y_ndi, test_ode_explicit, 0.0, 0.1
 )
 
-y_ni = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.GAUSS_LEGENDRE_6)
+y_ni = TimeIntegrators.initialise_scheme([y_0], TimeIntegrators.GAUSS_LEGENDRE_6)
 @test_throws ArgumentError TimeIntegrators.time_integrate!(
     y_ni, test_ode_explicit, 0.0, 0.1
 )
+@test_throws ArgumentError TimeIntegrators.time_integrate!(
+    y_ni, test_ode_dimplicit, 0.0, 0.1
+)
+@test_throws ArgumentError TimeIntegrators.time_integrate!(y_ni, test_ode_ee, 0.0, 0.1)
 
-y_nimex = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.MIDPOINT_IMEX)
+y_nimex = TimeIntegrators.initialise_scheme([y_0], TimeIntegrators.MIDPOINT_IMEX)
 @test_throws ArgumentError TimeIntegrators.time_integrate!(
     y_nimex, test_ode_explicit, 0.0, 0.1
 )
@@ -164,5 +348,52 @@ y_nimex = TimeIntegrators.initialize_scheme([y_0], TimeIntegrators.MIDPOINT_IMEX
 @test_throws ArgumentError TimeIntegrators.time_integrate!(
     y_nimex, test_ode_implicit, 0.0, 0.1
 )
+@test_throws ArgumentError TimeIntegrators.time_integrate!(y_nimex, test_ode_ee, 0.0, 0.1)
+
+# Provide a startup-scheme when not needed, and vice versa
+@test_throws ArgumentError TimeIntegrators.initialise_scheme([y_0], TimeIntegrators.BDF2)
+@test_throws ArgumentError TimeIntegrators.initialise_scheme(
+    [y_0], TimeIntegrators.DIRK3, TimeIntegrators.DIRK2
+)
+
+# Get the startup scheme
+y_nbdf3 = TimeIntegrators.initialise_scheme(
+    [y_0], TimeIntegrators.BDF3, TimeIntegrators.DIRK3
+)
+@test TimeIntegrators.get_startup_scheme(y_nbdf3) == TimeIntegrators.DIRK3
+
+# Copying integrate should do the same as the non-copying one.
+function check_equal_sol(sol1, sol2)
+    if !(sol1.N == sol2.N)
+        return false
+    elseif !all(isequal.(sol1.solution, sol2.solution))
+        return false
+    elseif !check_equal(sol1.scheme, sol2.scheme)
+        return false
+    elseif !(isnothing(sol1.startup_scheme) && isnothing(sol1.startup_scheme))
+        return false
+    elseif !(sol1.remaining_startup_steps == sol2.remaining_startup_steps)
+        return false
+    elseif !all(isequal.(sol1.solution_allocated, sol2.solution_allocated))
+        return false
+    elseif !all(isequal.(sol1.F_allocated, sol2.F_allocated))
+        return false
+    elseif !all(isequal.(sol1.G_allocated, sol2.G_allocated))
+        return false
+    elseif !(isnothing(sol1.startup_solution) && isnothing(sol1.startup_solution))
+        return false
+    elseif !all(isequal.(sol1.stage_values, sol2.stage_values))
+        return false
+    elseif !all(isequal.(sol1.temp_var, sol2.temp_var))
+        return false
+    end
+
+    return true
+end
+
+y_ne = TimeIntegrators.initialise_scheme([y_0], TimeIntegrators.RK4)
+y_ne2 = TimeIntegrators.time_integrate(y_ne, test_ode_explicit, 0.0, 0.1)
+TimeIntegrators.time_integrate!(y_ne, test_ode_explicit, 0.0, 0.1)
+@test check_equal_sol(y_ne2, y_ne)
 
 end

--- a/test/TimeIntegrators/ConvergenceTests.jl
+++ b/test/TimeIntegrators/ConvergenceTests.jl
@@ -1,0 +1,372 @@
+module TimeIntegrationConvergenceTests
+
+using Mantis
+using Test
+import LinearAlgebra
+import StaticArrays
+
+# We can check the correctness of the implemented schemes by computing their rate of
+# convergence and checking if this matches the expected rate. Here, we use a simple ODE
+# with one unknown.
+#
+# Consider the ODE:
+# dy/dt = lambda y,  y(t=0) = 1.0
+# which has exact solution y(t) = exp(lambda t).
+
+const lambda = -4
+const t_final = 1
+
+y_0 = 1.0
+function exact_sol(t)
+    return exp(lambda * t)
+end
+
+# Fully explicit ---------------------------------------------------------------------------
+function test_ode_explicit_func!(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n]
+    end
+    return nothing
+end
+test_ode_explicit = TimeIntegrators.define_explicit_ode(test_ode_explicit_func!)
+
+# function implicitSolve(output, x::Vector, h, t)
+#     LinearAlgebra.ldiv!(output, LinearAlgebra.I - h * lambda, x)
+#     return nothing
+# end
+function implicitSolve(output, x, h, t)
+    output .= (LinearAlgebra.I - h * lambda) \ x
+    return nothing
+end
+test_ode_dimplicit = TimeIntegrators.define_diagonally_implicit_ode(implicitSolve)
+function implicitEvaluate!(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n]
+    end
+    return nothing
+end
+test_ode_implicit = TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate!)
+
+function explicit_imex_function!(output, yn, t)
+    for n in axes(output, 1)
+        output[n] = 0.5 * lambda * yn[n]
+    end
+    return nothing
+end
+function implicit_imex_function!(output, yn, t)
+    for n in axes(output, 1)
+        output[n] = 0.5 * lambda * yn[n]
+    end
+    return nothing
+end
+test_ode_imex = TimeIntegrators.define_imex_ode(
+    explicit_imex_function!,
+    (output, x, h, t) -> LinearAlgebra.ldiv!(
+        output, LinearAlgebra.lu(LinearAlgebra.I - 0.5 * h * lambda), x
+    ),
+    implicit_imex_function!,
+)
+
+const explicit_integrators = (
+    # Single-step, multi-stage
+    TimeIntegrators.FORWARD_EULER,
+    TimeIntegrators.EXPLICIT_MIDPOINT,
+    TimeIntegrators.HEUN2,
+    TimeIntegrators.RALSTON2,
+    TimeIntegrators.HEUN3,
+    TimeIntegrators.RK3,
+    TimeIntegrators.RALSTON3,
+    TimeIntegrators.VDHW3,
+    TimeIntegrators.SSPRK3,
+    TimeIntegrators.RK4,
+    TimeIntegrators.RK4_3_8,
+    TimeIntegrators.RALSTON4,
+)
+
+@testset "Single-Step Multi-Stage Explicit Integrators" verbose = true begin
+    foreach(explicit_integrators) do scheme
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_explicit, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+const explicit_multi_step_integrators = (
+    # Multi-step, single-stage
+    (TimeIntegrators.AB1, nothing),
+    (TimeIntegrators.AB2, TimeIntegrators.HEUN2),
+    (TimeIntegrators.AB3, TimeIntegrators.HEUN3),
+    (TimeIntegrators.AB4, TimeIntegrators.RK4),
+)
+@testset "Multi-Step Single-Stage Explicit Integrators" verbose = true begin
+    foreach(explicit_multi_step_integrators) do (scheme, startup_scheme)
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            if !isnothing(startup_scheme)
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+            else
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            end
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_explicit, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+# Fully implicit ---------------------------------------------------------------------------
+const implicit_integrators = (
+    # Single-step, multi-stage
+    TimeIntegrators.BACKWARD_EULER,
+    TimeIntegrators.RADAU_IA_1,
+    TimeIntegrators.IMPLICIT_MIDPOINT,
+    TimeIntegrators.DIRK2,
+    TimeIntegrators.RADAU_IA_3,
+    TimeIntegrators.DIRK3,
+    TimeIntegrators.DIRK4,
+    TimeIntegrators.GAUSS_LEGENDRE_4,
+    TimeIntegrators.GAUSS_LEGENDRE_6,
+)
+
+@testset "Single-Step Multi-Stage Implicit Integrators" verbose = true begin
+    foreach(implicit_integrators) do scheme
+        ode = scheme isa TimeIntegrators.DiagonallyImplicit ? test_ode_dimplicit : test_ode_implicit
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, ode, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        if TimeIntegrators.get_order(scheme) > 4
+            # For high-order methods, we reach machine precision so the rate bottoms out.
+            # We can pick an earlier rate to check correctness.
+            test_rate = rates[3]
+        else
+            test_rate = rates[end]
+        end
+
+        @test isapprox(test_rate, TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+# The BDF schemes also test the initialisation of schemes that only require previous
+# solutions, but not previous stage derivatives. The AM schemes require implicit stage
+# derivatives, but no additional previous solutions. The AB schemes require explicit stage
+# derivatives, but no additional previous solutions.
+const implicit_multi_step_integrators = (
+    # Multi-step, single-stage
+    (TimeIntegrators.AM0, nothing),
+    (TimeIntegrators.AM1, TimeIntegrators.BACKWARD_EULER),
+    (TimeIntegrators.AM2, TimeIntegrators.DIRK2),
+    (TimeIntegrators.AM3, TimeIntegrators.DIRK3),
+    (TimeIntegrators.AM4, TimeIntegrators.GAUSS_LEGENDRE_6),
+    (TimeIntegrators.BDF1, nothing),
+    (TimeIntegrators.BDF2, TimeIntegrators.BACKWARD_EULER),
+    (TimeIntegrators.BDF3, TimeIntegrators.DIRK2),
+    (TimeIntegrators.BDF4, TimeIntegrators.DIRK3),
+)
+@testset "Multi-Step Single-Stage Implicit Integrators" verbose = true begin
+    foreach(implicit_multi_step_integrators) do (scheme, startup_scheme)
+        ode = scheme isa TimeIntegrators.DiagonallyImplicit ? test_ode_dimplicit : test_ode_implicit
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            dt = dt / 2
+            if !isnothing(startup_scheme)
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+            else
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            end
+
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_implicit, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        if TimeIntegrators.get_order(scheme) > 4
+            # For high-order methods, we reach machine precision so the rate bottoms out.
+            # We can pick an earlier rate to check correctness.
+            test_rate = rates[4]
+        else
+            test_rate = rates[end]
+        end
+        @test isapprox(test_rate, TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+# IMEX -------------------------------------------------------------------------------------
+const one_step_imex_integrators = (
+    # Single-step, multi-stage
+    TimeIntegrators.BACKWARD_FORWARD_EULER,
+    TimeIntegrators.MIDPOINT_IMEX,
+    TimeIntegrators.RK3_IMEX,
+)
+
+@testset "Single-Step Multi-Stage IMEX Integrators" verbose = true begin
+    foreach(one_step_imex_integrators) do scheme
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_imex, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+const multi_step_imex_integrators = (
+    # Multi-step, single-stage
+    (TimeIntegrators.CNAB2, TimeIntegrators.MIDPOINT_IMEX),
+    (TimeIntegrators.SSSS2, TimeIntegrators.MIDPOINT_IMEX),
+)
+
+@testset "Multi-Step Single-Stage IMEX Integrators" verbose = true begin
+    foreach(multi_step_imex_integrators) do (scheme, startup_scheme)
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            if !isnothing(startup_scheme)
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+            else
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            end
+
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_imex, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+# Combined multi-step multi-stage ----------------------------------------------------------
+
+# Almost Runge-Kutta methods----------------------------------------------------------------
+# Rattenbury, N., 2005. Almost Runge–Kutta methods for stiff  and non-stiff problems.
+# Thesis (PhD). The University of Auckland.
+# This scheme requires a specialised initialisation, since it needs an estimate of the
+# second derivative which is not accounted for in the available initialisations. As a
+# result, this scheme is not part of Mantis.
+const ARK3 = TimeIntegrators.Explicit(
+    StaticArrays.SMatrix{3, 3}(0.0, 1/2, 0.0, 0.0, 0.0, 3/4, 0.0, 0.0, 0.0), # A
+    StaticArrays.SMatrix{3, 3}(0.0, 0.0, 3.0, 3/4, 0.0, -3.0, 0.0, 1.0, 2.0), # B
+    StaticArrays.SMatrix{3, 3}(1.0, 1.0, 1.0, 1/3, 1/6, 1/4, 1/18, 1/18, 0.0), # U
+    StaticArrays.SMatrix{3, 3}(1.0, 0.0, 0.0, 1/4, 0, -2.0, 0.0, 0.0, 0.0), # V
+    StaticArrays.SVector(1 / 3, 2 / 3, 1.0),
+    TimeIntegrators.TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        [0, 1],  # Δt F and Δt^2 F'
+    ),
+    3,
+)
+const explicit_multi_multi_integrators = (ARK3,)
+@testset "Multi-Step Multi-Stage Explicit Integrators" verbose = true begin
+    foreach(explicit_multi_multi_integrators) do scheme
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            dt = dt / 2
+            yn = zeros(Float64, 1, 3)
+            yn[:, 1] .= [y_0]
+            yn[:, 2] .= lambda .* [y_0] .* dt
+            yn[:, 3] .= lambda^2 .* [y_0] .* dt^2
+            y_n = TimeIntegrators.TimeIntegrationSolution(yn, scheme, nothing, 0)
+
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_explicit, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+end

--- a/test/TimeIntegrators/ConvergenceTests.jl
+++ b/test/TimeIntegrators/ConvergenceTests.jl
@@ -30,10 +30,6 @@ function test_ode_explicit_func!(output, yn, t)
 end
 test_ode_explicit = TimeIntegrators.define_explicit_ode(test_ode_explicit_func!)
 
-# function implicitSolve(output, x::Vector, h, t)
-#     LinearAlgebra.ldiv!(output, LinearAlgebra.I - h * lambda, x)
-#     return nothing
-# end
 function implicitSolve(output, x, h, t)
     output .= (LinearAlgebra.I - h * lambda) \ x
     return nothing
@@ -89,7 +85,7 @@ const explicit_integrators = (
         dts = zeros(length(errors))
         dt = 0.2
         for i in eachindex(errors)
-            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             dt = dt / 2
             dts[i] = dt
             for t in 0.0:dt:(t_final - dt)
@@ -122,9 +118,9 @@ const explicit_multi_step_integrators = (
         dt = 0.2
         for i in eachindex(errors)
             if !isnothing(startup_scheme)
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme, startup_scheme)
             else
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             end
             dt = dt / 2
             dts[i] = dt
@@ -150,9 +146,11 @@ const implicit_integrators = (
     TimeIntegrators.BACKWARD_EULER,
     TimeIntegrators.RADAU_IA_1,
     TimeIntegrators.IMPLICIT_MIDPOINT,
+    TimeIntegrators.CRANK_NICOLSON,
     TimeIntegrators.DIRK2,
-    TimeIntegrators.RADAU_IA_3,
     TimeIntegrators.DIRK3,
+    TimeIntegrators.ESDIRK32,
+    TimeIntegrators.RADAU_IA_3,
     TimeIntegrators.DIRK4,
     TimeIntegrators.GAUSS_LEGENDRE_4,
     TimeIntegrators.GAUSS_LEGENDRE_6,
@@ -160,12 +158,59 @@ const implicit_integrators = (
 
 @testset "Single-Step Multi-Stage Implicit Integrators" verbose = true begin
     foreach(implicit_integrators) do scheme
-        ode = scheme isa TimeIntegrators.DiagonallyImplicit ? test_ode_dimplicit : test_ode_implicit
+        ode = if scheme isa TimeIntegrators.DiagonallyImplicit
+            test_ode_dimplicit
+        else
+            test_ode_implicit
+        end
+        if size(scheme.A) == (2, 2) &&
+            all(isequal.(scheme.A, StaticArrays.SMatrix{2, 2}(0.0, 0.5, 0.0, 0.5)))
+            # CN also needs the implicit evaluate
+            ode = test_ode_implicit
+        end
+        if size(scheme.A) == (4, 4) && all(
+            isequal.(
+                scheme.A,
+                StaticArrays.SMatrix{4, 4}(
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                    (
+                        -4.0*TimeIntegrators._ESDIRK32_g^2 + 6*TimeIntegrators._ESDIRK32_g -
+                        1.0
+                    )/(4.0 * TimeIntegrators._ESDIRK32_g),
+                    (6.0*TimeIntegrators._ESDIRK32_g - 1.0)/(
+                        12.0 * TimeIntegrators._ESDIRK32_g
+                    ),
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                    (-2.0*TimeIntegrators._ESDIRK32_g+1.0)/(
+                        4.0*TimeIntegrators._ESDIRK32_g
+                    ),
+                    -1.0/(
+                        (24.0*TimeIntegrators._ESDIRK32_g-12.0)*TimeIntegrators._ESDIRK32_g
+                    ),
+                    0.0,
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                    (
+                        -6.0*TimeIntegrators._ESDIRK32_g^2 + 6*TimeIntegrators._ESDIRK32_g -
+                        1.0
+                    )/(6.0*TimeIntegrators._ESDIRK32_g - 3.0),
+                    0.0,
+                    0.0,
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                ),
+            ),
+        )
+            # ESDIRK32 also needs the implicit evaluate
+            ode = test_ode_implicit
+        end
         errors = zeros(8)
         dts = zeros(length(errors))
         dt = 0.2
         for i in eachindex(errors)
-            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             dt = dt / 2
             dts[i] = dt
             for t in 0.0:dt:(t_final - dt)
@@ -210,16 +255,20 @@ const implicit_multi_step_integrators = (
 )
 @testset "Multi-Step Single-Stage Implicit Integrators" verbose = true begin
     foreach(implicit_multi_step_integrators) do (scheme, startup_scheme)
-        ode = scheme isa TimeIntegrators.DiagonallyImplicit ? test_ode_dimplicit : test_ode_implicit
+        ode = if scheme isa TimeIntegrators.DiagonallyImplicit
+            test_ode_dimplicit
+        else
+            test_ode_implicit
+        end
         errors = zeros(8)
         dts = zeros(length(errors))
         dt = 0.2
         for i in eachindex(errors)
             dt = dt / 2
             if !isnothing(startup_scheme)
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme, startup_scheme)
             else
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             end
 
             dts[i] = dt
@@ -252,6 +301,7 @@ const one_step_imex_integrators = (
     TimeIntegrators.BACKWARD_FORWARD_EULER,
     TimeIntegrators.MIDPOINT_IMEX,
     TimeIntegrators.RK3_IMEX,
+    TimeIntegrators.IMEX331,
 )
 
 @testset "Single-Step Multi-Stage IMEX Integrators" verbose = true begin
@@ -260,7 +310,7 @@ const one_step_imex_integrators = (
         dts = zeros(length(errors))
         dt = 0.2
         for i in eachindex(errors)
-            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             dt = dt / 2
             dts[i] = dt
             for t in 0.0:dt:(t_final - dt)
@@ -293,9 +343,9 @@ const multi_step_imex_integrators = (
         dt = 0.2
         for i in eachindex(errors)
             if !isnothing(startup_scheme)
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme, startup_scheme)
             else
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             end
 
             dt = dt / 2

--- a/test/TimeIntegrators/StabilityTests.jl
+++ b/test/TimeIntegrators/StabilityTests.jl
@@ -1,0 +1,422 @@
+module TimeIntegrationStabilityTests
+
+import SparseArrays
+import LinearAlgebra
+using Mantis
+using Test
+
+# We can test (some) numerical schemes by performing a numerical Von Neumann analysis over
+# one time step and then check if the computed eigenmode is the same as predicted by theory.
+# The theoretical stability functions are exact, so we can match the value to machine
+# precision.
+# Because the eigenmodes are expressed as complex numbers, this test also ensures that we
+# can use more general number types than just Float64.
+
+# We use the advection equation in 1D with a simple finite difference spatial
+# discretisation to verify stability in the case where we solve for multiple variables.
+
+# Consider the advection equation on a 1D domain (x_L, x_R) as
+# dc/dt = Ac
+# where c is the vector of unknowns, and A is the (N-1, N-1) discretisation matrix.
+
+const dx = 0.01
+const L = 1.0
+const velocity = 0.1
+const dt = dx / velocity  # gives CFL = 1
+const grid = 0.0:dx:L
+const A =
+    (velocity / dx) *
+    SparseArrays.spdiagm(0 => ones(length(grid)), -1 => -1 .* ones(length(grid)-1))
+# Set periodic boundary conditions.
+A[1, end] = -(velocity / dx)
+
+function discretised_advection_equation(output, c, t)
+    LinearAlgebra.mul!(output, -A, c)
+    return nothing
+end
+
+c_0 = sinpi.(2.0 .* grid)
+
+linear_advection_ode = TimeIntegrators.define_explicit_ode(discretised_advection_equation)
+
+# Amplification factor analysis ------------------------------------------------------------
+const k = 2 * pi  # wavenumber
+const ck_0 = exp.(im .* k .* grid)
+
+# From the spatial discretisation:
+const lambda_k = - velocity * (1 - exp(-im * k * dx)) / dx
+
+const z_k = dt * lambda_k
+
+# Known stability functions:
+# Note that these functions hold for rk methods of the same order if they have the same
+# number of stages. This means that, for example, HEUN2 and RALSTON2 have the same
+# stability function because they are both 2-stage RK methods of order 2.
+function exact_stability(z, order)
+    if order == 1
+        return 1 + z
+    elseif order == 2
+        return 1 + z + 1/2 * z^2
+    elseif order == 3
+        return 1 + z + 1/2 * z^2 + 1/6 * z^3
+    elseif order == 4
+        return 1 + z + 1/2 * z^2 + 1/6 * z^3 + 1/24 * z^4
+    end
+end
+
+const integrators = (
+    TimeIntegrators.FORWARD_EULER,
+    TimeIntegrators.EXPLICIT_MIDPOINT,
+    TimeIntegrators.HEUN2,
+    TimeIntegrators.RALSTON2,
+    TimeIntegrators.HEUN3,
+    TimeIntegrators.RK3,
+    TimeIntegrators.RALSTON3,
+    TimeIntegrators.VDHW3,
+    TimeIntegrators.SSPRK3,
+    TimeIntegrators.RK4,
+    TimeIntegrators.RK4_3_8,
+    TimeIntegrators.RALSTON4,
+)
+
+@testset "Single-Step Multi-Stage Explicit Integrators" verbose = true begin
+    foreach(integrators) do scheme
+        ck_n = TimeIntegrators.initialize_scheme(ck_0, scheme)
+        TimeIntegrators.time_integrate!(ck_n, linear_advection_ode, 0.0, dt)
+
+        # Pick just one factor to test (away from the boundary condition).
+        amplification_factor_scheme = (TimeIntegrators.get_solution(ck_n) ./ ck_0)[14]
+        @test isapprox(
+            exact_stability(z_k, TimeIntegrators.get_order(scheme)),
+            amplification_factor_scheme,
+            rtol=1e-15,
+        )
+    end
+end
+
+# Known stability functions for diagonally implicit schemes. Here, the stability functions
+# are usually not the same per order, so we specify them per integrator.
+const gamma4 = (1 + TimeIntegrators._α_DIRK4) / 2
+const diagonally_implicit_integrators = (
+    (TimeIntegrators.BACKWARD_EULER, z -> 1 / (1-z)),
+    (TimeIntegrators.RADAU_IA_1, z -> 1 / (1-z)),
+    (TimeIntegrators.IMPLICIT_MIDPOINT, z -> (1 + 1/2 * z) / (1 - 1/2*z)),
+    (
+        TimeIntegrators.DIRK2,
+        z ->
+            (
+                1 +
+                (1 - 2*TimeIntegrators._α_DIRK2)z +
+                (TimeIntegrators._α_DIRK2^2 - 2*TimeIntegrators._α_DIRK2 + 1/2) * z^2
+            ) / (1 - TimeIntegrators._α_DIRK2*z)^2,
+    ),
+    (
+        TimeIntegrators.DIRK3,
+        z ->
+            (
+                1 +
+                (1 - 2*(1/2 + sqrt(3)/6))z +
+                ((1/2 + sqrt(3)/6)^2 - 2*(1/2 + sqrt(3)/6) + 1/2) * z^2
+            ) / (1 - (1/2 + sqrt(3)/6)*z)^2,
+    ),
+    (
+        TimeIntegrators.DIRK4,
+        z ->
+            (
+                1 +
+                (1 - 3*gamma4)z +
+                (3*gamma4^2 - 3*gamma4 + 1/2) * z^2 +
+                (-gamma4^3 + 3*gamma4^2 - 3/2*gamma4 + 1/6) * z^3
+            ) / (1 - gamma4*z)^3,
+    ),
+)
+
+function implicitSolve(output, x, h, t)
+    LinearAlgebra.ldiv!(output, LinearAlgebra.lu(LinearAlgebra.I + h * A), x)
+    return nothing
+end
+dimplicit_linear_advection_ode = TimeIntegrators.define_diagonally_implicit_ode(
+    implicitSolve
+)
+
+@testset "Single-Step Multi-Stage Diagonally Implicit Integrators" verbose = true begin
+    foreach(diagonally_implicit_integrators) do (scheme, exact_stability_function)
+        ck_n = TimeIntegrators.initialize_scheme(ck_0, scheme)
+        TimeIntegrators.time_integrate!(ck_n, dimplicit_linear_advection_ode, 0.0, dt)
+
+        # Pick just one factor to test (away from the boundary condition).
+        amplification_factor_scheme = (TimeIntegrators.get_solution(ck_n) ./ ck_0)[84]
+        @test isapprox(
+            exact_stability_function(z_k), amplification_factor_scheme, rtol=1e-15
+        )
+    end
+end
+
+const implicit_integrators = (
+    TimeIntegrators.RADAU_IA_3,
+    TimeIntegrators.GAUSS_LEGENDRE_4,
+    TimeIntegrators.GAUSS_LEGENDRE_6,
+)
+function rk_stability(A, b, z)
+    A = Matrix(A)
+    b = vec(Matrix(b))
+    s = size(A, 1)
+    e = ones(ComplexF64, s)
+    return 1 + z * LinearAlgebra.dot(b, (LinearAlgebra.I - z*A) \ e)
+end
+function large_solve(output, x, h, t; num_stages)
+    # Julia's kron is column major, so we have to reverse the arguments.
+    output .= (LinearAlgebra.I - kron(h, -A)) \ x
+    return nothing
+end
+function large_eval(output, c, t; num_stages)
+    bigA = SparseArrays.blockdiag([-A for i in 1:num_stages]...)
+    LinearAlgebra.mul!(output, bigA, c)
+    return nothing
+end
+implicit_linear_advection_ode = TimeIntegrators.define_implicit_ode(large_solve, large_eval)
+
+@testset "Single-Step Multi-Stage Implicit Integrators" verbose = true begin
+    foreach(implicit_integrators) do scheme
+        ck_n = TimeIntegrators.initialize_scheme(ck_0, scheme)
+        TimeIntegrators.time_integrate!(
+            ck_n,
+            implicit_linear_advection_ode,
+            0.0,
+            dt;
+            num_stages=TimeIntegrators.get_num_stages(scheme)
+        )
+
+        # Pick just one factor to test (away from the boundary condition).
+        amplification_factor_scheme = (TimeIntegrators.get_solution(ck_n) ./ ck_0)[84]
+        @test isapprox(
+            rk_stability(scheme.A, scheme.B, z_k), amplification_factor_scheme, rtol=1e-15
+        )
+    end
+end
+
+
+
+function glm_amplification(scheme, z)
+
+    A = Matrix(scheme.A)
+    B = Matrix(scheme.B)
+    U = Matrix(scheme.U)
+    V = Matrix(scheme.V)
+
+    s = size(A,1)
+
+    M = V + z * B * ((LinearAlgebra.I - z*A) \ U)
+
+    λ = LinearAlgebra.eigvals(M)
+
+    return λ[argmin(abs.(λ .- 1))]
+end
+
+function create_history(scheme, z)
+    ξ = glm_amplification(scheme, z)
+
+    history = zeros(
+        ComplexF64,
+        length(grid),
+        length(scheme.time_levels.step_values) + length(scheme.time_levels.step_derivatives_implicit) + length(scheme.time_levels.step_derivatives_explicit)
+    )
+
+    history[:,1] .= ck_0
+    idx = 1
+
+    for lag in scheme.time_levels.step_values
+        history[:,idx] .= ξ^(-lag) .* ck_0
+        idx += 1
+    end
+
+    for lag in scheme.time_levels.step_derivatives_implicit
+        history[:,idx] .= z_k * ξ^(-lag) .* ck_0
+        idx += 1
+    end
+
+    for lag in scheme.time_levels.step_derivatives_explicit
+        history[:,idx] .= z_k * ξ^(-lag) .* ck_0
+        idx += 1
+    end
+
+    return ξ, history
+end
+
+multistep_integrators_explicit = (
+    TimeIntegrators.AB1,
+    TimeIntegrators.AB2,
+    TimeIntegrators.AB3,
+    TimeIntegrators.AB4,
+)
+
+@testset "Multi-Step Single-Stage Explicit Integrators" verbose=true begin
+    foreach(multistep_integrators_explicit) do scheme
+        ξ, history = create_history(scheme, z_k)
+
+        yn = TimeIntegrators.TimeIntegrationSolution(history, scheme, nothing, 0)
+
+        TimeIntegrators.time_integrate!(
+            yn,
+            linear_advection_ode,
+            0.0,
+            dt,
+        )
+
+        amplification = TimeIntegrators.get_solution(yn) ./ history
+
+        @test maximum(abs.(amplification[84,:] .- ξ)) < 1e-14
+    end
+end
+
+
+multistep_integrators_diag_impl = (
+    TimeIntegrators.AM0,
+    TimeIntegrators.AM1,
+    TimeIntegrators.AM2,
+    TimeIntegrators.AM3,
+    TimeIntegrators.AM4,
+    TimeIntegrators.BDF1,
+    TimeIntegrators.BDF2,
+    TimeIntegrators.BDF3,
+    TimeIntegrators.BDF4,
+)
+
+@testset "Multi-Step Single-Stage (Diagonally) Implicit Integrators" verbose=true begin
+    foreach(multistep_integrators_diag_impl) do scheme
+        ξ, history = create_history(scheme, z_k)
+
+        yn = TimeIntegrators.TimeIntegrationSolution(history, scheme, nothing, 0)
+
+        TimeIntegrators.time_integrate!(
+            yn,
+            implicit_linear_advection_ode,
+            0.0,
+            dt;
+            num_stages=TimeIntegrators.get_num_stages(scheme)
+        )
+
+        amplification = TimeIntegrators.get_solution(yn) ./ history
+
+        @test maximum(abs.(amplification[84,:] .- ξ)) < 2e-14
+    end
+end
+
+# IMEX -------------------------------------------------------------------------------------
+function imex_solve(output, x, h, t; num_stages)
+    output .= (LinearAlgebra.I - (h* -0.8*A)) \ x
+    return nothing
+end
+function imex_eval(output, c, t; num_stages)
+    LinearAlgebra.mul!(output, -0.8*A, c)
+    return nothing
+end
+function imex_expl(output, c, t; num_stages)
+    LinearAlgebra.mul!(output, -0.2*A, c)
+    return nothing
+end
+imex_linear_advection_ode = TimeIntegrators.define_imex_ode(
+    imex_expl, imex_solve, imex_eval
+)
+
+function glm_amplification_imex(scheme, ze, zi)
+
+    AE = Matrix(scheme.A_EX)
+    AI = Matrix(scheme.A_IM)
+
+    BE = Matrix(scheme.B_EX)
+    BI = Matrix(scheme.B_IM)
+
+    U = Matrix(scheme.U)
+    V = Matrix(scheme.V)
+
+    M =V + (ze*BE + zi*BI) * ((LinearAlgebra.I - ze*AE - zi*AI) \ U)
+
+    λ = LinearAlgebra.eigvals(M)
+
+    return λ[argmin(abs.(λ .- 1))]
+end
+
+function create_history_imex(scheme, ze, zi)
+    ξ = glm_amplification_imex(scheme, ze, zi)
+
+    history = zeros(
+        ComplexF64,
+        length(grid),
+        length(scheme.time_levels.step_values) + length(scheme.time_levels.step_derivatives_implicit) + length(scheme.time_levels.step_derivatives_explicit)
+    )
+
+    history[:,1] .= ck_0
+    idx = 1
+
+    for lag in scheme.time_levels.step_values
+        history[:,idx] .= ξ^(-lag) .* ck_0
+        idx += 1
+    end
+
+    for lag in scheme.time_levels.step_derivatives_implicit
+        history[:,idx] .= zi * ξ^(-lag) .* ck_0
+        idx += 1
+    end
+
+    for lag in scheme.time_levels.step_derivatives_explicit
+        history[:,idx] .= ze * ξ^(-lag) .* ck_0
+        idx += 1
+    end
+
+    return ξ, history
+end
+
+const one_step_imex_integrators = (
+    # Single-step, multi-stage
+    TimeIntegrators.BACKWARD_FORWARD_EULER,
+    TimeIntegrators.MIDPOINT_IMEX,
+    TimeIntegrators.RK3_IMEX,
+)
+@testset "Single-Step Multi-Stage IMEX Integrators" verbose=true begin
+    foreach(one_step_imex_integrators) do scheme
+        ξ, history = create_history_imex(scheme, 0.2*z_k, 0.8*z_k)
+
+        yn = TimeIntegrators.TimeIntegrationSolution(history, scheme, nothing, 0)
+
+        TimeIntegrators.time_integrate!(
+            yn,
+            imex_linear_advection_ode,
+            0.0,
+            dt;
+            num_stages=TimeIntegrators.get_num_stages(scheme)
+        )
+
+        amplification = TimeIntegrators.get_solution(yn) ./ history
+
+        @test maximum(abs.(amplification[84,:] .- ξ)) < 1e-14
+    end
+end
+
+const multi_step_imex_integrators = (
+    # Multi-step, single-stage
+    TimeIntegrators.CNAB2,
+    TimeIntegrators.SSSS2,
+)
+
+@testset "Multi-Step Single-Stage IMEX Integrators" verbose=true begin
+    foreach(multi_step_imex_integrators) do scheme
+        ξ, history = create_history_imex(scheme, 0.2*z_k, 0.8*z_k)
+
+        yn = TimeIntegrators.TimeIntegrationSolution(history, scheme, nothing, 0)
+
+        TimeIntegrators.time_integrate!(
+            yn,
+            imex_linear_advection_ode,
+            0.0,
+            dt;
+            num_stages=TimeIntegrators.get_num_stages(scheme)
+        )
+
+        amplification = TimeIntegrators.get_solution(yn) ./ history
+
+        @test maximum(abs.(amplification[84,:] .- ξ)) < 1e-14
+    end
+end
+
+end

--- a/test/TimeIntegrators/StabilityTests.jl
+++ b/test/TimeIntegrators/StabilityTests.jl
@@ -2,6 +2,7 @@ module TimeIntegrationStabilityTests
 
 import SparseArrays
 import LinearAlgebra
+import StaticArrays
 using Mantis
 using Test
 
@@ -81,7 +82,7 @@ const integrators = (
 
 @testset "Single-Step Multi-Stage Explicit Integrators" verbose = true begin
     foreach(integrators) do scheme
-        ck_n = TimeIntegrators.initialize_scheme(ck_0, scheme)
+        ck_n = TimeIntegrators.initialise_scheme(ck_0, scheme)
         TimeIntegrators.time_integrate!(ck_n, linear_advection_ode, 0.0, dt)
 
         # Pick just one factor to test (away from the boundary condition).
@@ -96,39 +97,23 @@ end
 
 # Known stability functions for diagonally implicit schemes. Here, the stability functions
 # are usually not the same per order, so we specify them per integrator.
+function rk_stability(A, b, z)
+    A = Matrix(A)
+    b = vec(Matrix(b))
+    s = size(A, 1)
+    e = ones(ComplexF64, s)
+    return 1 + z * LinearAlgebra.dot(b, (LinearAlgebra.I - z*A) \ e)
+end
 const gamma4 = (1 + TimeIntegrators._α_DIRK4) / 2
 const diagonally_implicit_integrators = (
-    (TimeIntegrators.BACKWARD_EULER, z -> 1 / (1-z)),
-    (TimeIntegrators.RADAU_IA_1, z -> 1 / (1-z)),
-    (TimeIntegrators.IMPLICIT_MIDPOINT, z -> (1 + 1/2 * z) / (1 - 1/2*z)),
-    (
-        TimeIntegrators.DIRK2,
-        z ->
-            (
-                1 +
-                (1 - 2*TimeIntegrators._α_DIRK2)z +
-                (TimeIntegrators._α_DIRK2^2 - 2*TimeIntegrators._α_DIRK2 + 1/2) * z^2
-            ) / (1 - TimeIntegrators._α_DIRK2*z)^2,
-    ),
-    (
-        TimeIntegrators.DIRK3,
-        z ->
-            (
-                1 +
-                (1 - 2*(1/2 + sqrt(3)/6))z +
-                ((1/2 + sqrt(3)/6)^2 - 2*(1/2 + sqrt(3)/6) + 1/2) * z^2
-            ) / (1 - (1/2 + sqrt(3)/6)*z)^2,
-    ),
-    (
-        TimeIntegrators.DIRK4,
-        z ->
-            (
-                1 +
-                (1 - 3*gamma4)z +
-                (3*gamma4^2 - 3*gamma4 + 1/2) * z^2 +
-                (-gamma4^3 + 3*gamma4^2 - 3/2*gamma4 + 1/6) * z^3
-            ) / (1 - gamma4*z)^3,
-    ),
+    TimeIntegrators.BACKWARD_EULER,
+    TimeIntegrators.RADAU_IA_1,
+    TimeIntegrators.IMPLICIT_MIDPOINT,
+    TimeIntegrators.CRANK_NICOLSON,
+    TimeIntegrators.DIRK2,
+    TimeIntegrators.DIRK3,
+    TimeIntegrators.ESDIRK32,
+    TimeIntegrators.DIRK4,
 )
 
 function implicitSolve(output, x, h, t)
@@ -138,16 +123,67 @@ end
 dimplicit_linear_advection_ode = TimeIntegrators.define_diagonally_implicit_ode(
     implicitSolve
 )
+function implicitEval(output, c, t)
+    LinearAlgebra.mul!(output, -A, c)
+    return nothing
+end
+dimplicit_linear_advection_ode2 = TimeIntegrators.define_diagonally_implicit_ode(
+    implicitSolve, implicitEval
+)
 
 @testset "Single-Step Multi-Stage Diagonally Implicit Integrators" verbose = true begin
-    foreach(diagonally_implicit_integrators) do (scheme, exact_stability_function)
-        ck_n = TimeIntegrators.initialize_scheme(ck_0, scheme)
-        TimeIntegrators.time_integrate!(ck_n, dimplicit_linear_advection_ode, 0.0, dt)
+    foreach(diagonally_implicit_integrators) do scheme
+        ck_n = TimeIntegrators.initialise_scheme(ck_0, scheme)
+
+        if size(scheme.A) == (2, 2) &&
+            all(isequal.(scheme.A, StaticArrays.SMatrix{2, 2}(0.0, 0.5, 0.0, 0.5)))
+            # CN also needs the implicit evaluate
+            TimeIntegrators.time_integrate!(ck_n, dimplicit_linear_advection_ode2, 0.0, dt)
+        elseif size(scheme.A) == (4, 4) && all(
+            isequal.(
+                scheme.A,
+                StaticArrays.SMatrix{4, 4}(
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                    (
+                        -4.0*TimeIntegrators._ESDIRK32_g^2 + 6*TimeIntegrators._ESDIRK32_g -
+                        1.0
+                    )/(4.0 * TimeIntegrators._ESDIRK32_g),
+                    (6.0*TimeIntegrators._ESDIRK32_g - 1.0)/(
+                        12.0 * TimeIntegrators._ESDIRK32_g
+                    ),
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                    (-2.0*TimeIntegrators._ESDIRK32_g+1.0)/(
+                        4.0*TimeIntegrators._ESDIRK32_g
+                    ),
+                    -1.0/(
+                        (24.0*TimeIntegrators._ESDIRK32_g-12.0)*TimeIntegrators._ESDIRK32_g
+                    ),
+                    0.0,
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                    (
+                        -6.0*TimeIntegrators._ESDIRK32_g^2 + 6*TimeIntegrators._ESDIRK32_g -
+                        1.0
+                    )/(6.0*TimeIntegrators._ESDIRK32_g - 3.0),
+                    0.0,
+                    0.0,
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                ),
+            ),
+        )
+            # ESDIRK32 also needs the implicit evaluate
+            TimeIntegrators.time_integrate!(ck_n, dimplicit_linear_advection_ode2, 0.0, dt)
+        else
+            TimeIntegrators.time_integrate!(ck_n, dimplicit_linear_advection_ode, 0.0, dt)
+        end
 
         # Pick just one factor to test (away from the boundary condition).
         amplification_factor_scheme = (TimeIntegrators.get_solution(ck_n) ./ ck_0)[84]
         @test isapprox(
-            exact_stability_function(z_k), amplification_factor_scheme, rtol=1e-15
+            rk_stability(scheme.A, scheme.B, z_k), amplification_factor_scheme, rtol=1e-15
         )
     end
 end
@@ -157,13 +193,6 @@ const implicit_integrators = (
     TimeIntegrators.GAUSS_LEGENDRE_4,
     TimeIntegrators.GAUSS_LEGENDRE_6,
 )
-function rk_stability(A, b, z)
-    A = Matrix(A)
-    b = vec(Matrix(b))
-    s = size(A, 1)
-    e = ones(ComplexF64, s)
-    return 1 + z * LinearAlgebra.dot(b, (LinearAlgebra.I - z*A) \ e)
-end
 function large_solve(output, x, h, t; num_stages)
     # Julia's kron is column major, so we have to reverse the arguments.
     output .= (LinearAlgebra.I - kron(h, -A)) \ x
@@ -178,13 +207,13 @@ implicit_linear_advection_ode = TimeIntegrators.define_implicit_ode(large_solve,
 
 @testset "Single-Step Multi-Stage Implicit Integrators" verbose = true begin
     foreach(implicit_integrators) do scheme
-        ck_n = TimeIntegrators.initialize_scheme(ck_0, scheme)
+        ck_n = TimeIntegrators.initialise_scheme(ck_0, scheme)
         TimeIntegrators.time_integrate!(
             ck_n,
             implicit_linear_advection_ode,
             0.0,
             dt;
-            num_stages=TimeIntegrators.get_num_stages(scheme)
+            num_stages=TimeIntegrators.get_num_stages(scheme),
         )
 
         # Pick just one factor to test (away from the boundary condition).
@@ -195,16 +224,13 @@ implicit_linear_advection_ode = TimeIntegrators.define_implicit_ode(large_solve,
     end
 end
 
-
-
 function glm_amplification(scheme, z)
-
     A = Matrix(scheme.A)
     B = Matrix(scheme.B)
     U = Matrix(scheme.U)
     V = Matrix(scheme.V)
 
-    s = size(A,1)
+    s = size(A, 1)
 
     M = V + z * B * ((LinearAlgebra.I - z*A) \ U)
 
@@ -219,24 +245,26 @@ function create_history(scheme, z)
     history = zeros(
         ComplexF64,
         length(grid),
-        length(scheme.time_levels.step_values) + length(scheme.time_levels.step_derivatives_implicit) + length(scheme.time_levels.step_derivatives_explicit)
+        length(scheme.time_levels.step_values) +
+        length(scheme.time_levels.step_derivatives_implicit) +
+        length(scheme.time_levels.step_derivatives_explicit),
     )
 
-    history[:,1] .= ck_0
+    history[:, 1] .= ck_0
     idx = 1
 
     for lag in scheme.time_levels.step_values
-        history[:,idx] .= ξ^(-lag) .* ck_0
+        history[:, idx] .= ξ^(-lag) .* ck_0
         idx += 1
     end
 
     for lag in scheme.time_levels.step_derivatives_implicit
-        history[:,idx] .= z_k * ξ^(-lag) .* ck_0
+        history[:, idx] .= z_k * ξ^(-lag) .* ck_0
         idx += 1
     end
 
     for lag in scheme.time_levels.step_derivatives_explicit
-        history[:,idx] .= z_k * ξ^(-lag) .* ck_0
+        history[:, idx] .= z_k * ξ^(-lag) .* ck_0
         idx += 1
     end
 
@@ -244,10 +272,7 @@ function create_history(scheme, z)
 end
 
 multistep_integrators_explicit = (
-    TimeIntegrators.AB1,
-    TimeIntegrators.AB2,
-    TimeIntegrators.AB3,
-    TimeIntegrators.AB4,
+    TimeIntegrators.AB1, TimeIntegrators.AB2, TimeIntegrators.AB3, TimeIntegrators.AB4
 )
 
 @testset "Multi-Step Single-Stage Explicit Integrators" verbose=true begin
@@ -256,19 +281,13 @@ multistep_integrators_explicit = (
 
         yn = TimeIntegrators.TimeIntegrationSolution(history, scheme, nothing, 0)
 
-        TimeIntegrators.time_integrate!(
-            yn,
-            linear_advection_ode,
-            0.0,
-            dt,
-        )
+        TimeIntegrators.time_integrate!(yn, linear_advection_ode, 0.0, dt)
 
         amplification = TimeIntegrators.get_solution(yn) ./ history
 
-        @test maximum(abs.(amplification[84,:] .- ξ)) < 1e-14
+        @test maximum(abs.(amplification[84, :] .- ξ)) < 1e-14
     end
 end
-
 
 multistep_integrators_diag_impl = (
     TimeIntegrators.AM0,
@@ -293,18 +312,18 @@ multistep_integrators_diag_impl = (
             implicit_linear_advection_ode,
             0.0,
             dt;
-            num_stages=TimeIntegrators.get_num_stages(scheme)
+            num_stages=TimeIntegrators.get_num_stages(scheme),
         )
 
         amplification = TimeIntegrators.get_solution(yn) ./ history
 
-        @test maximum(abs.(amplification[84,:] .- ξ)) < 2e-14
+        @test maximum(abs.(amplification[84, :] .- ξ)) < 2e-14
     end
 end
 
 # IMEX -------------------------------------------------------------------------------------
 function imex_solve(output, x, h, t; num_stages)
-    output .= (LinearAlgebra.I - (h* -0.8*A)) \ x
+    output .= (LinearAlgebra.I - (h * -0.8 * A)) \ x
     return nothing
 end
 function imex_eval(output, c, t; num_stages)
@@ -320,7 +339,6 @@ imex_linear_advection_ode = TimeIntegrators.define_imex_ode(
 )
 
 function glm_amplification_imex(scheme, ze, zi)
-
     AE = Matrix(scheme.A_EX)
     AI = Matrix(scheme.A_IM)
 
@@ -330,7 +348,7 @@ function glm_amplification_imex(scheme, ze, zi)
     U = Matrix(scheme.U)
     V = Matrix(scheme.V)
 
-    M =V + (ze*BE + zi*BI) * ((LinearAlgebra.I - ze*AE - zi*AI) \ U)
+    M = V + (ze*BE + zi*BI) * ((LinearAlgebra.I - ze*AE - zi*AI) \ U)
 
     λ = LinearAlgebra.eigvals(M)
 
@@ -343,24 +361,26 @@ function create_history_imex(scheme, ze, zi)
     history = zeros(
         ComplexF64,
         length(grid),
-        length(scheme.time_levels.step_values) + length(scheme.time_levels.step_derivatives_implicit) + length(scheme.time_levels.step_derivatives_explicit)
+        length(scheme.time_levels.step_values) +
+        length(scheme.time_levels.step_derivatives_implicit) +
+        length(scheme.time_levels.step_derivatives_explicit),
     )
 
-    history[:,1] .= ck_0
+    history[:, 1] .= ck_0
     idx = 1
 
     for lag in scheme.time_levels.step_values
-        history[:,idx] .= ξ^(-lag) .* ck_0
+        history[:, idx] .= ξ^(-lag) .* ck_0
         idx += 1
     end
 
     for lag in scheme.time_levels.step_derivatives_implicit
-        history[:,idx] .= zi * ξ^(-lag) .* ck_0
+        history[:, idx] .= zi * ξ^(-lag) .* ck_0
         idx += 1
     end
 
     for lag in scheme.time_levels.step_derivatives_explicit
-        history[:,idx] .= ze * ξ^(-lag) .* ck_0
+        history[:, idx] .= ze * ξ^(-lag) .* ck_0
         idx += 1
     end
 
@@ -372,6 +392,7 @@ const one_step_imex_integrators = (
     TimeIntegrators.BACKWARD_FORWARD_EULER,
     TimeIntegrators.MIDPOINT_IMEX,
     TimeIntegrators.RK3_IMEX,
+    TimeIntegrators.IMEX331,
 )
 @testset "Single-Step Multi-Stage IMEX Integrators" verbose=true begin
     foreach(one_step_imex_integrators) do scheme
@@ -384,12 +405,12 @@ const one_step_imex_integrators = (
             imex_linear_advection_ode,
             0.0,
             dt;
-            num_stages=TimeIntegrators.get_num_stages(scheme)
+            num_stages=TimeIntegrators.get_num_stages(scheme),
         )
 
         amplification = TimeIntegrators.get_solution(yn) ./ history
 
-        @test maximum(abs.(amplification[84,:] .- ξ)) < 1e-14
+        @test maximum(abs.(amplification[84, :] .- ξ)) < 1e-14
     end
 end
 
@@ -410,12 +431,12 @@ const multi_step_imex_integrators = (
             imex_linear_advection_ode,
             0.0,
             dt;
-            num_stages=TimeIntegrators.get_num_stages(scheme)
+            num_stages=TimeIntegrators.get_num_stages(scheme),
         )
 
         amplification = TimeIntegrators.get_solution(yn) ./ history
 
-        @test maximum(abs.(amplification[84,:] .- ξ)) < 1e-14
+        @test maximum(abs.(amplification[84, :] .- ξ)) < 1e-14
     end
 end
 

--- a/test/TimeIntegrators/TimeConvergenceTests.jl
+++ b/test/TimeIntegrators/TimeConvergenceTests.jl
@@ -1,0 +1,383 @@
+module TimeIntegrationTimeConvergenceTests
+
+using Mantis
+using Test
+import LinearAlgebra
+import StaticArrays
+
+# We can check the correctness of the implemented schemes by computing their rate of
+# convergence and checking if this matches the expected rate. Here, we use a simple ODE
+# with one unknown and a time-dependent forcing.
+#
+# Consider the ODE:
+# dy/dt = lambda y - lambda sin(t) + cos(t),  y(t=0) = 1.0
+# which has exact solution y(t) = exp(lambda t) + sin(t).
+
+const lambda = -4
+const t_final = 1
+
+y_0 = 1.0
+function exact_sol(t)
+    return exp(lambda * t) + sin(t)
+end
+
+# Fully explicit ---------------------------------------------------------------------------
+function test_ode_explicit_func!(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n] - lambda * sin(t) + cos(t)
+    end
+    return nothing
+end
+test_ode_explicit = TimeIntegrators.define_explicit_ode(test_ode_explicit_func!)
+
+function dimplicitSolve(output, x, h, t)
+    rhs_mod = -lambda * h * sin(t) + h * cos(t)
+    output .= (LinearAlgebra.I - h * lambda) \ (x .+ rhs_mod)
+    return nothing
+end
+test_ode_dimplicit = TimeIntegrators.define_diagonally_implicit_ode(dimplicitSolve)
+
+function dimplicitEvaluate!(output, yn, t)
+    for n in eachindex(output)
+        output[n] = lambda * yn[n] - lambda * sin(t) + cos(t)
+    end
+    return nothing
+end
+test_ode_dimplicit2 = TimeIntegrators.define_diagonally_implicit_ode(
+    dimplicitSolve, dimplicitEvaluate!
+)
+
+function implicitSolve(output, x, h, t)
+    rhs_mod = -lambda * h * sin.(t) + h * cos.(t)
+    output .= (LinearAlgebra.I - h .* lambda) \ (x .+ rhs_mod)
+    return nothing
+end
+function implicitEvaluate!(output, yn, t)
+    output .= lambda * yn - lambda * sin.(t) + cos.(t)
+    return nothing
+end
+test_ode_implicit = TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate!)
+
+
+function explicit_imex_function!(output, yn, t)
+    for n in axes(output, 1)
+        output[n] = - lambda * sin(t) + cos(t)
+    end
+    return nothing
+end
+function implicit_imex_function!(output, yn, t)
+    for n in axes(output, 1)
+        output[n] = lambda * yn[n]
+    end
+    return nothing
+end
+test_ode_imex = TimeIntegrators.define_imex_ode(
+    explicit_imex_function!,
+    (output, x, h, t) -> LinearAlgebra.ldiv!(
+        output, LinearAlgebra.lu(LinearAlgebra.I - h * lambda), x
+    ),
+    implicit_imex_function!,
+)
+
+const explicit_integrators = (
+    # Single-step, multi-stage
+    TimeIntegrators.FORWARD_EULER,
+    TimeIntegrators.EXPLICIT_MIDPOINT,
+    TimeIntegrators.HEUN2,
+    TimeIntegrators.RALSTON2,
+    TimeIntegrators.HEUN3,
+    TimeIntegrators.RK3,
+    TimeIntegrators.RALSTON3,
+    TimeIntegrators.VDHW3,
+    TimeIntegrators.SSPRK3,
+    TimeIntegrators.RK4,
+    TimeIntegrators.RK4_3_8,
+    TimeIntegrators.RALSTON4,
+)
+
+@testset "Single-Step Multi-Stage Explicit Integrators" verbose = true begin
+    foreach(explicit_integrators) do scheme
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_explicit, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=2e-2)
+    end
+end
+
+const explicit_multi_step_integrators = (
+    # Multi-step, single-stage
+    (TimeIntegrators.AB1, nothing),
+    (TimeIntegrators.AB2, TimeIntegrators.HEUN2),
+    (TimeIntegrators.AB3, TimeIntegrators.HEUN3),
+    (TimeIntegrators.AB4, TimeIntegrators.RK4),
+)
+@testset "Multi-Step Single-Stage Explicit Integrators" verbose = true begin
+    foreach(explicit_multi_step_integrators) do (scheme, startup_scheme)
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            if !isnothing(startup_scheme)
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+            else
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            end
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_explicit, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+# Fully implicit ---------------------------------------------------------------------------
+const implicit_integrators = (
+    # Single-step, multi-stage
+    TimeIntegrators.BACKWARD_EULER,
+    TimeIntegrators.RADAU_IA_1,
+    TimeIntegrators.IMPLICIT_MIDPOINT,
+    TimeIntegrators.DIRK2,
+    TimeIntegrators.RADAU_IA_3,
+    TimeIntegrators.DIRK3,
+    TimeIntegrators.DIRK4,
+    TimeIntegrators.GAUSS_LEGENDRE_4,
+    TimeIntegrators.GAUSS_LEGENDRE_6,
+)
+
+@testset "Single-Step Multi-Stage Implicit Integrators" verbose = true begin
+    foreach(implicit_integrators) do scheme
+        ode = scheme isa TimeIntegrators.DiagonallyImplicit ? test_ode_dimplicit : test_ode_implicit
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, ode, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        if TimeIntegrators.get_order(scheme) > 4
+            # For high-order methods, we reach machine precision so the rate bottoms out.
+            # We can pick an earlier rate to check correctness.
+            test_rate = rates[3]
+        else
+            test_rate = rates[end]
+        end
+
+        @test isapprox(test_rate, TimeIntegrators.get_order(scheme), rtol=1e-1)
+    end
+end
+
+# The BDF schemes also test the initialisation of schemes that only require previous
+# solutions, but not previous stage derivatives. The AM schemes require implicit stage
+# derivatives, but no additional previous solutions. The AB schemes require explicit stage
+# derivatives, but no additional previous solutions.
+const implicit_multi_step_integrators = (
+    # Multi-step, single-stage
+    (TimeIntegrators.AM0, nothing),
+    (TimeIntegrators.AM1, TimeIntegrators.BACKWARD_EULER),
+    (TimeIntegrators.AM2, TimeIntegrators.DIRK2),
+    (TimeIntegrators.AM3, TimeIntegrators.DIRK3),
+    (TimeIntegrators.AM4, TimeIntegrators.DIRK4),
+    (TimeIntegrators.BDF1, nothing),
+    (TimeIntegrators.BDF2, TimeIntegrators.BACKWARD_EULER),
+    (TimeIntegrators.BDF3, TimeIntegrators.DIRK2),
+    (TimeIntegrators.BDF4, TimeIntegrators.DIRK3),
+)
+@testset "Multi-Step Single-Stage Implicit Integrators" verbose = true begin
+    foreach(implicit_multi_step_integrators) do (scheme, startup_scheme)
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            dt = dt / 2
+            if !isnothing(startup_scheme)
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+            else
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            end
+
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_dimplicit2, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        if TimeIntegrators.get_order(scheme) > 4
+            # For high-order methods, we reach machine precision so the rate bottoms out.
+            # We can pick an earlier rate to check correctness.
+            test_rate = rates[4]
+        else
+            test_rate = rates[end]
+        end
+        @test isapprox(test_rate, TimeIntegrators.get_order(scheme), rtol=2e-1)
+    end
+end
+
+# IMEX -------------------------------------------------------------------------------------
+const one_step_imex_integrators = (
+    # Single-step, multi-stage
+    TimeIntegrators.BACKWARD_FORWARD_EULER,
+    TimeIntegrators.MIDPOINT_IMEX,
+    TimeIntegrators.RK3_IMEX,
+)
+
+@testset "Single-Step Multi-Stage IMEX Integrators" verbose = true begin
+    foreach(one_step_imex_integrators) do scheme
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_imex, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+const multi_step_imex_integrators = (
+    # Multi-step, single-stage
+    (TimeIntegrators.CNAB2, TimeIntegrators.MIDPOINT_IMEX),
+    (TimeIntegrators.SSSS2, TimeIntegrators.MIDPOINT_IMEX),
+)
+
+@testset "Multi-Step Single-Stage IMEX Integrators" verbose = true begin
+    foreach(multi_step_imex_integrators) do (scheme, startup_scheme)
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            if !isnothing(startup_scheme)
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+            else
+                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            end
+
+            dt = dt / 2
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_imex, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+# Combined multi-step multi-stage ----------------------------------------------------------
+
+# Almost Runge-Kutta methods----------------------------------------------------------------
+# Rattenbury, N., 2005. Almost Runge–Kutta methods for stiff  and non-stiff problems.
+# Thesis (PhD). The University of Auckland.
+# This scheme requires a specialised initialisation, since it needs an estimate of the
+# second derivative which is not accounted for in the available initialisations. As a
+# result, this scheme is not part of Mantis.
+const ARK3 = TimeIntegrators.Explicit(
+    StaticArrays.SMatrix{3, 3}(0.0, 1/2, 0.0, 0.0, 0.0, 3/4, 0.0, 0.0, 0.0), # A
+    StaticArrays.SMatrix{3, 3}(0.0, 0.0, 3.0, 3/4, 0.0, -3.0, 0.0, 1.0, 2.0), # B
+    StaticArrays.SMatrix{3, 3}(1.0, 1.0, 1.0, 1/3, 1/6, 1/4, 1/18, 1/18, 0.0), # U
+    StaticArrays.SMatrix{3, 3}(1.0, 0.0, 0.0, 1/4, 0, -2.0, 0.0, 0.0, 0.0), # V
+    StaticArrays.SVector(1 / 3, 2 / 3, 1.0),
+    TimeIntegrators.TimeLevels(
+        [0], # y
+        Int[], # Δt G
+        [0, 1],  # Δt F and Δt^2 F'
+    ),
+    3,
+)
+const explicit_multi_multi_integrators = (ARK3,)
+@testset "Multi-Step Multi-Stage Explicit Integrators" verbose = true begin
+    foreach(explicit_multi_multi_integrators) do scheme
+        errors = zeros(8)
+        dts = zeros(length(errors))
+        dt = 0.2
+        for i in eachindex(errors)
+            dt = dt / 2
+            yn = zeros(Float64, 1, 3)
+            yn[:, 1] .= [y_0]
+            @. yn[:, 2] .= lambda * [y_0] * dt - lambda * sin(0.0) * dt + cos(0.0) * dt
+            @. yn[:, 3] .= lambda^2 * [y_0] * dt^2 - lambda^2 * cos(0.0) * dt^2 - sin(0.0) * dt^2
+            y_n = TimeIntegrators.TimeIntegrationSolution(yn, scheme, nothing, 0)
+
+            dts[i] = dt
+            for t in 0.0:dt:(t_final - dt)
+                TimeIntegrators.time_integrate!(y_n, test_ode_explicit, t, dt)
+            end
+
+            errors[i] = abs(exact_sol(t_final) - TimeIntegrators.get_solution(y_n)[1])
+        end
+        rates = [
+            log(errors[i]/errors[i + 1])/(log(dts[i]/dts[i + 1])) for
+            i in eachindex(errors)[1:(end - 1)]
+        ]
+
+        # The rate is computed to 2 decimal places.
+        @test isapprox(rates[end], TimeIntegrators.get_order(scheme), rtol=1e-2)
+    end
+end
+
+end

--- a/test/TimeIntegrators/TimeConvergenceTests.jl
+++ b/test/TimeIntegrators/TimeConvergenceTests.jl
@@ -58,7 +58,6 @@ function implicitEvaluate!(output, yn, t)
 end
 test_ode_implicit = TimeIntegrators.define_implicit_ode(implicitSolve, implicitEvaluate!)
 
-
 function explicit_imex_function!(output, yn, t)
     for n in axes(output, 1)
         output[n] = - lambda * sin(t) + cos(t)
@@ -73,9 +72,8 @@ function implicit_imex_function!(output, yn, t)
 end
 test_ode_imex = TimeIntegrators.define_imex_ode(
     explicit_imex_function!,
-    (output, x, h, t) -> LinearAlgebra.ldiv!(
-        output, LinearAlgebra.lu(LinearAlgebra.I - h * lambda), x
-    ),
+    (output, x, h, t) ->
+        LinearAlgebra.ldiv!(output, LinearAlgebra.lu(LinearAlgebra.I - h * lambda), x),
     implicit_imex_function!,
 )
 
@@ -101,7 +99,7 @@ const explicit_integrators = (
         dts = zeros(length(errors))
         dt = 0.2
         for i in eachindex(errors)
-            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             dt = dt / 2
             dts[i] = dt
             for t in 0.0:dt:(t_final - dt)
@@ -134,9 +132,9 @@ const explicit_multi_step_integrators = (
         dt = 0.2
         for i in eachindex(errors)
             if !isnothing(startup_scheme)
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme, startup_scheme)
             else
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             end
             dt = dt / 2
             dts[i] = dt
@@ -162,9 +160,11 @@ const implicit_integrators = (
     TimeIntegrators.BACKWARD_EULER,
     TimeIntegrators.RADAU_IA_1,
     TimeIntegrators.IMPLICIT_MIDPOINT,
+    TimeIntegrators.CRANK_NICOLSON,
     TimeIntegrators.DIRK2,
     TimeIntegrators.RADAU_IA_3,
     TimeIntegrators.DIRK3,
+    TimeIntegrators.ESDIRK32,
     TimeIntegrators.DIRK4,
     TimeIntegrators.GAUSS_LEGENDRE_4,
     TimeIntegrators.GAUSS_LEGENDRE_6,
@@ -172,12 +172,59 @@ const implicit_integrators = (
 
 @testset "Single-Step Multi-Stage Implicit Integrators" verbose = true begin
     foreach(implicit_integrators) do scheme
-        ode = scheme isa TimeIntegrators.DiagonallyImplicit ? test_ode_dimplicit : test_ode_implicit
+        ode = if scheme isa TimeIntegrators.DiagonallyImplicit
+            test_ode_dimplicit
+        else
+            test_ode_implicit
+        end
+        if size(scheme.A) == (2, 2) &&
+            all(isequal.(scheme.A, StaticArrays.SMatrix{2, 2}(0.0, 0.5, 0.0, 0.5)))
+            # CN also needs the implicit evaluate
+            ode = test_ode_dimplicit2
+        end
+        if size(scheme.A) == (4, 4) && all(
+            isequal.(
+                scheme.A,
+                StaticArrays.SMatrix{4, 4}(
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                    (
+                        -4.0*TimeIntegrators._ESDIRK32_g^2 + 6*TimeIntegrators._ESDIRK32_g -
+                        1.0
+                    )/(4.0 * TimeIntegrators._ESDIRK32_g),
+                    (6.0*TimeIntegrators._ESDIRK32_g - 1.0)/(
+                        12.0 * TimeIntegrators._ESDIRK32_g
+                    ),
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                    (-2.0*TimeIntegrators._ESDIRK32_g+1.0)/(
+                        4.0*TimeIntegrators._ESDIRK32_g
+                    ),
+                    -1.0/(
+                        (24.0*TimeIntegrators._ESDIRK32_g-12.0)*TimeIntegrators._ESDIRK32_g
+                    ),
+                    0.0,
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                    (
+                        -6.0*TimeIntegrators._ESDIRK32_g^2 + 6*TimeIntegrators._ESDIRK32_g -
+                        1.0
+                    )/(6.0*TimeIntegrators._ESDIRK32_g - 3.0),
+                    0.0,
+                    0.0,
+                    0.0,
+                    TimeIntegrators._ESDIRK32_g,
+                ),
+            ),
+        )
+            # ESDIRK32 also needs the implicit evaluate
+            ode = test_ode_dimplicit2
+        end
         errors = zeros(8)
         dts = zeros(length(errors))
         dt = 0.2
         for i in eachindex(errors)
-            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             dt = dt / 2
             dts[i] = dt
             for t in 0.0:dt:(t_final - dt)
@@ -228,9 +275,9 @@ const implicit_multi_step_integrators = (
         for i in eachindex(errors)
             dt = dt / 2
             if !isnothing(startup_scheme)
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme, startup_scheme)
             else
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             end
 
             dts[i] = dt
@@ -263,6 +310,7 @@ const one_step_imex_integrators = (
     TimeIntegrators.BACKWARD_FORWARD_EULER,
     TimeIntegrators.MIDPOINT_IMEX,
     TimeIntegrators.RK3_IMEX,
+    TimeIntegrators.IMEX331,
 )
 
 @testset "Single-Step Multi-Stage IMEX Integrators" verbose = true begin
@@ -271,7 +319,7 @@ const one_step_imex_integrators = (
         dts = zeros(length(errors))
         dt = 0.2
         for i in eachindex(errors)
-            y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+            y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             dt = dt / 2
             dts[i] = dt
             for t in 0.0:dt:(t_final - dt)
@@ -304,9 +352,9 @@ const multi_step_imex_integrators = (
         dt = 0.2
         for i in eachindex(errors)
             if !isnothing(startup_scheme)
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme, startup_scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme, startup_scheme)
             else
-                y_n = TimeIntegrators.initialize_scheme([y_0], scheme)
+                y_n = TimeIntegrators.initialise_scheme([y_0], scheme)
             end
 
             dt = dt / 2
@@ -360,7 +408,8 @@ const explicit_multi_multi_integrators = (ARK3,)
             yn = zeros(Float64, 1, 3)
             yn[:, 1] .= [y_0]
             @. yn[:, 2] .= lambda * [y_0] * dt - lambda * sin(0.0) * dt + cos(0.0) * dt
-            @. yn[:, 3] .= lambda^2 * [y_0] * dt^2 - lambda^2 * cos(0.0) * dt^2 - sin(0.0) * dt^2
+            @. yn[:, 3] .=
+                lambda^2 * [y_0] * dt^2 - lambda^2 * cos(0.0) * dt^2 - sin(0.0) * dt^2
             y_n = TimeIntegrators.TimeIntegrationSolution(yn, scheme, nothing, 0)
 
             dts[i] = dt

--- a/test/TimeIntegrators/runtests.jl
+++ b/test/TimeIntegrators/runtests.jl
@@ -1,0 +1,21 @@
+module TimeIntegratorsTests
+
+using Test
+
+@testset verbose=true "Basic Tests" begin
+    include("BasicTests.jl")
+end
+@testset verbose=true "Advection-Based Tests" begin
+    include("AdvectionTests.jl")
+end
+@testset verbose=true "Convergence Tests" begin
+    include("ConvergenceTests.jl")
+end
+@testset verbose=true "Amplification Factors" begin
+    include("StabilityTests.jl")
+end
+@testset verbose=true "Time-dependent Convergence Tests" begin
+    include("TimeConvergenceTests.jl")
+end
+
+end

--- a/test/TimeIntegrators/runtests.jl
+++ b/test/TimeIntegrators/runtests.jl
@@ -2,19 +2,19 @@ module TimeIntegratorsTests
 
 using Test
 
-@testset verbose=true "Basic Tests" begin
+@testset verbose=true "Basics" begin
     include("BasicTests.jl")
 end
-@testset verbose=true "Advection-Based Tests" begin
+@testset verbose=true "Advection-Based" begin
     include("AdvectionTests.jl")
 end
-@testset verbose=true "Convergence Tests" begin
+@testset verbose=true "Convergence" begin
     include("ConvergenceTests.jl")
 end
-@testset verbose=true "Amplification Factors" begin
+@testset verbose=true "Stability" begin
     include("StabilityTests.jl")
 end
-@testset verbose=true "Time-dependent Convergence Tests" begin
+@testset verbose=true "Time-dependent Convergence" begin
     include("TimeConvergenceTests.jl")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,16 +3,36 @@ module MantisTests
 using Pkg
 using Test
 
-@testset verbose=true "GeneralHelpers" begin include("GeneralHelpers/runtests.jl") end
-@testset verbose=true "Mesh" begin include("Mesh/runtests.jl") end
-@testset verbose=true "Points" begin include("Points/runtests.jl") end
-@testset verbose=true "Geometry" begin include("Geometry/runtests.jl") end
-@testset verbose=true "FunctionSpaces" begin include("FunctionSpaces/runtests.jl") end
-@testset verbose=true "Quadrature" begin include("Quadrature/runtests.jl") end
-@testset verbose=true "Forms" begin include("Forms/runtests.jl") end
-@testset verbose=true "Assembly" begin include("Assemblers/runtests.jl") end
-@testset verbose=true "TimeIntegrators" begin include("TimeIntegrators/runtests.jl") end
-@testset verbose=true "Plot" begin include("Plot/runtests.jl") end
+@testset verbose=true "GeneralHelpers" begin
+    include("GeneralHelpers/runtests.jl")
+end
+@testset verbose=true "Mesh" begin
+    include("Mesh/runtests.jl")
+end
+@testset verbose=true "Points" begin
+    include("Points/runtests.jl")
+end
+@testset verbose=true "Geometry" begin
+    include("Geometry/runtests.jl")
+end
+@testset verbose=true "FunctionSpaces" begin
+    include("FunctionSpaces/runtests.jl")
+end
+@testset verbose=true "Quadrature" begin
+    include("Quadrature/runtests.jl")
+end
+@testset verbose=true "Forms" begin
+    include("Forms/runtests.jl")
+end
+@testset verbose=true "Assembly" begin
+    include("Assemblers/runtests.jl")
+end
+@testset verbose=true "TimeIntegrators" begin
+    include("TimeIntegrators/runtests.jl")
+end
+@testset verbose=true "Plot" begin
+    include("Plot/runtests.jl")
+end
 
 # Do not run JET tests on pre-release versions, as JET is too unstable and the CI will
 # appear as failing. Also only run it from v1.12 onwards, also for compatibility reasons.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using Test
 @testset verbose=true "Quadrature" begin include("Quadrature/runtests.jl") end
 @testset verbose=true "Forms" begin include("Forms/runtests.jl") end
 @testset verbose=true "Assembly" begin include("Assemblers/runtests.jl") end
+@testset verbose=true "TimeIntegrators" begin include("TimeIntegrators/runtests.jl") end
 @testset verbose=true "Plot" begin include("Plot/runtests.jl") end
 
 # Do not run JET tests on pre-release versions, as JET is too unstable and the CI will
@@ -18,10 +19,11 @@ using Test
 @static if VERSION >= v"1.12"
     if isempty(VERSION.prerelease)
         Pkg.activate("Inference")
-        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+        Pkg.develop(PackageSpec(path=dirname(@__DIR__)))
         Pkg.instantiate()
         @testset verbose=true "Inference Tests" include("Inference/runtests.jl")
     end
 end
 
-end; nothing
+end;
+nothing


### PR DESCRIPTION
This pull request creates a TimeIntegrators module for Mantis, allowing time-dependent problems to be tackled.

This is not done yet. I think at least the following needs to be done:
- [x] Create documentation.
- [x] Update/complete time-dependent examples.
- [x] Add simpler example
- [x] Remove scripts for experimentation
- [x] Extend test to smaller unit-tests.
- [x] Check performance.
- [x] Update naming to be more in line with what we have now.
- [x] Define API