### PR TITLE
fix: license to EUPL-1.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,4 +36,4 @@ keywords:
   - Mimetic Discretizations
   - Adaptive Mesh Refinement
 doi: 10.5281/zenodo.17495870
-license: EUPL
+license: EUPL-1.2


### PR DESCRIPTION
Zenodo has strict license tags/names. See the list below:

https://spdx.org/licenses/