### PR TITLE
Update codifferential

### DIFF
--- a/docs/src/Design/Modules/Forms.md
+++ b/docs/src/Design/Modules/Forms.md
@@ -146,8 +146,6 @@ Hodge
 
 ### [Codifferential](@id FormsCodifferential)
 The codifferential, often denoted ``d^{\star}`` or ``\delta``, is a differential operator mapping ``k``-forms to ``k-1``-forms. 
-On manifolds without boundaries, it is the ``L^2``-adjoint of the exterior derivative. 
-That is, ``(\alpha^{k-1}, \delta\beta^k) = (d\alpha^{k-1}, \beta^k)``, where ``(\cdot, \cdot)`` is an ``L^2`` inner-product.
 ```@docs
 CoDifferential
 dstar

--- a/examples/src/Biharmonic.jl
+++ b/examples/src/Biharmonic.jl
@@ -11,7 +11,7 @@
 # In 1D the biharmonic problem is defined as:
 # ```math
 # \begin{alignat*}{2}
-#     &\frac{\partial^4 \phi(x)}{\partial x^4} = - f(x)  \quad &&\text{for}\ x \in [0, L] \;, \\
+#     &\frac{\partial^4 \phi(x)}{\partial x^4} = f(x)  \quad &&\text{for}\ x \in [0, L] \;, \\
 #     &\phi(0) = \phi(L) = 0 \;, \\
 #     &\frac{\partial^2 \phi}{\partial x^2}(0) = \frac{\partial^2 \phi}{\partial x^2}(L) = 0 \;,
 # \end{alignat*}
@@ -43,7 +43,7 @@
 # ``\Omega \subset \mathbb{R}^n`` with boundary ``\partial \Omega`` is
 # ```math
 # \begin{alignat*}{2}
-#     &\Delta^2 \phi^0 = - f^0  \quad &&\text{on}\ \Omega \;, \\
+#     &\Delta^2 \phi^0 = f^0  \quad &&\text{on}\ \Omega \;, \\
 #     &tr(\phi^0) = 0  \quad &&\text{on}\ \partial\Omega \;, \\
 #     &tr(\Delta \phi^0) = 0  \quad &&\text{on}\ \partial\Omega \;.
 # \end{alignat*}
@@ -88,7 +88,7 @@
 # ```
 # These expressions are for the Laplacian applied to ``0``-forms, in which case
 # ```math
-# \Delta = \delta \mathrm{d} = \star \mathrm{d} \star \mathrm{d} \;,
+# \Delta = \delta \mathrm{d} = -\star \mathrm{d} \star \mathrm{d} \;,
 # ```
 # with ``\delta`` the codifferential.
 #

--- a/examples/src/HodgeLaplacian.jl
+++ b/examples/src/HodgeLaplacian.jl
@@ -7,7 +7,7 @@
 # ``0``-form Hodge-Laplacian on a domain ``\Omega`` with boundary ``\partial \Omega`` is
 # ```math
 # \begin{alignat*}{2}
-#     &\mathrm{d}^* \mathrm{d} \phi^0 = - f^0  \quad &&\text{on}\ \Omega \;, \\
+#     &\mathrm{d}^* \mathrm{d} \phi^0 = f^0  \quad &&\text{on}\ \Omega \;, \\
 #     &tr(\phi^0) = 0  \quad &&\text{on}\ \partial\Omega \;.
 # \end{alignat*}
 # ```
@@ -154,4 +154,3 @@ weak_form_3D = Assemblers.WeakForm(lhs_expressions_3D, rhs_expressions_3D, wfi_3
 A_3D, b_3D = Assemblers.assemble(weak_form_3D, bc_3D)
 sol_3D = vec(A_3D \ b_3D)
 ϕ⁰_3D = Forms.build_form_field(Λ⁰_3D, sol_3D)
-

--- a/src/Forms/FormOperators/Codifferential.jl
+++ b/src/Forms/FormOperators/Codifferential.jl
@@ -152,27 +152,30 @@ function _evaluate_codifferential(
     fem_evals, form_basis_indices = _evaluate_form_in_canonical_coordinates(
         form_space, element_id, xi, 1
     )
+    T = eltype(fem_evals[1][1][1][1])
     n_coderivative_form_components = 1
     n_basis_functions = length(form_basis_indices[1])
     n_evaluation_points = Points.get_num_points(xi)
     # Preallocate memory for output array
     codiff_eval = [
-        zeros(Float64, n_evaluation_points, n_basis_functions) for
+        zeros(T, n_evaluation_points, n_basis_functions) for
         _ in 1:n_coderivative_form_components
     ]
     # Compute the metric terms, including derivative of the metric.
-    J, inv_g, g, sqrt_g, dgdu, dinv_g_du, dsqrt_g_du, Hs = Geometry.metric_derivatives(
+    J, inv_g, g, sqrt_g, (dgdu,), (dinv_g_du,), (dsqrt_g_du,), Hs = Geometry.metric_derivatives(
         get_geometry(form_space), element_id, xi
     )
     # Compute the codifferential.
     # α^1 = α¹ du
     # *d*α¹ = (1/sqrt(det(g))) * (α¹ d/dx(1/sqrt(det(g))) + (1/sqrt(det(g)))d/dx(α¹))
     # Note that d/dx(1/sqrt(det(g))) = - (d/dx(sqrt(g)))/(sqrt(g)^2)
+    # sign: (-1)^{n(k+1)+1}, n = manifold_dim, k = form_rank. 1-forms -> always -1.
+    sign = -one(T)
     idx_du = FunctionSpaces.get_derivative_idx((1,))
     for i in axes(codiff_eval[1], 1)
         inv_sqrt_point = 1.0 / sqrt_g[i]
         codiff_eval[1][i, :] .=
-            inv_sqrt_point .* (
+            sign .* inv_sqrt_point .* (
                 .-view(fem_evals[1][1][1], i, :) .* dsqrt_g_du[i] ./ (sqrt_g[i] .^ 2)  # - α¹ * (d/dx(sqrt(g)))/(sqrt(g)^2)
                 .+
                 view(fem_evals[2][idx_du][1], i, :) .* inv_sqrt_point  # ∂u α¹ * 1 / sqrt(g)
@@ -191,12 +194,13 @@ function _evaluate_codifferential(
     fem_evals, form_basis_indices = FunctionSpaces.evaluate(
         get_fe_space(form_space), element_id, xi, 2
     )
+    T = eltype(fem_evals[1][1][1][1])
     n_coderivative_form_components = 1
     n_basis_functions = length(form_basis_indices)
     n_evaluation_points = Points.get_num_points(xi)
     # Preallocate memory for output array
     codiff_eval = [
-        zeros(Float64, n_evaluation_points, n_basis_functions) for
+        zeros(T, n_evaluation_points, n_basis_functions) for
         _ in 1:n_coderivative_form_components
     ]
     # Compute the metric terms, including derivative of the metric.
@@ -208,12 +212,14 @@ function _evaluate_codifferential(
     # α¹ = d(β⁰) = ∂ᵤ β⁰ du
     # *d*α¹ = (1/sqrt(det(g))) * (α¹ d/dx(1/sqrt(det(g))) + (1/sqrt(det(g)))d/dx(α¹))
     # Note that d/dx(1/sqrt(det(g))) = - (d/dx(sqrt(g)))/(sqrt(g)^2)
+    # sign: (-1)^{n(k+1)+1}, n = manifold_dim, k = form_rank. 1-forms -> always -1.
+    sign = -one(T)
     idx_du = FunctionSpaces.get_derivative_idx((1,))
     idx_duu = FunctionSpaces.get_derivative_idx((2,))
     for i in axes(codiff_eval[1], 1)
         inv_sqrt_point = 1.0 / sqrt_g[i]
         codiff_eval[1][i, :] .=
-            inv_sqrt_point .* (
+            sign .* inv_sqrt_point .* (
                 .-view(fem_evals[2][idx_du][1], i, :) .* dsqrt_g_du[i] ./ (sqrt_g[i] .^ 2)  # - α¹ * (d/dx(sqrt(g)))/(sqrt(g)^2)
                 .+
                 view(fem_evals[3][idx_duu][1], i, :) .* inv_sqrt_point  # ∂u α¹ * 1 / sqrt(g)
@@ -231,12 +237,13 @@ function _evaluate_codifferential(
     fem_evals, form_basis_indices = _evaluate_form_in_canonical_coordinates(
         form_space, element_id, xi, 1
     )
+    T = eltype(fem_evals[1][1][1][1])
     n_coderivative_form_components = 1
     n_basis_functions = length(form_basis_indices[1])
     n_evaluation_points = Points.get_num_points(xi)
     # Preallocate memory for output array
     codiff_eval = [
-        zeros(Float64, n_evaluation_points, n_basis_functions) for
+        zeros(T, n_evaluation_points, n_basis_functions) for
         _ in 1:n_coderivative_form_components
     ]
     # Compute the metric terms, including derivative of the metric.
@@ -246,26 +253,30 @@ function _evaluate_codifferential(
     # Compute the coderivative.
     # α^1 = α¹ du + α² dv
     # d*α¹ = β⁰
+    # sign: (-1)^{n(k+1)+1}, n = manifold_dim, k = form_rank. 1-forms -> always -1.
+    sign = -one(T)
     idx_du = FunctionSpaces.get_derivative_idx((1, 0))
     idx_dv = FunctionSpaces.get_derivative_idx((0, 1))
     for i in axes(codiff_eval[1], 1)
         codiff_eval[1][i, :] .=
-            view(fem_evals[2][idx_du][1], i, :) .* inv_g[i][1, 1] .+  # ∂u α¹ * g¹¹
-            view(fem_evals[1][1][1], i, :) .* dinv_g_du[i][1, 1] .+  # α¹ * ∂u g¹¹
-            view(fem_evals[2][idx_du][2], i, :) .* inv_g[i][1, 2] .+  # ∂u α² * g¹²
-            view(fem_evals[1][1][2], i, :) .* dinv_g_du[i][1, 2] .+  # α² * ∂u g¹²
-            view(fem_evals[2][idx_dv][1], i, :) .* inv_g[i][2, 1] .+  # ∂v α¹ * g²¹
-            view(fem_evals[1][1][1], i, :) .* dinv_g_dv[i][2, 1] .+  # α¹ * ∂v g²¹
-            view(fem_evals[2][idx_dv][2], i, :) .* inv_g[i][2, 2] .+  # ∂v α² * g²²
-            view(fem_evals[1][1][2], i, :) .* dinv_g_dv[i][2, 2] .+  # α² * ∂v g²²
-            (1.0 / sqrt_g[i]) .* (
-                .+view(fem_evals[1][1][1], i, :) .* inv_g[i][1, 1] .* dsqrt_g_du[i]  # α¹ * g¹¹ * ∂u sqrt(g)
-                .+
-                view(fem_evals[1][1][2], i, :) .* inv_g[i][1, 2] .* dsqrt_g_du[i]  # α² * g¹² * ∂u sqrt(g)
-                .+
-                view(fem_evals[1][1][1], i, :) .* inv_g[i][2, 1] .* dsqrt_g_dv[i]  # α¹ * g²¹ * ∂v sqrt(g)
-                .+
-                view(fem_evals[1][1][2], i, :) .* inv_g[i][2, 2] .* dsqrt_g_dv[i]  # α² * g²² * ∂v sqrt(g)
+            sign .* (
+                view(fem_evals[2][idx_du][1], i, :) .* inv_g[i][1, 1] .+  # ∂u α¹ * g¹¹
+                view(fem_evals[1][1][1], i, :) .* dinv_g_du[i][1, 1] .+  # α¹ * ∂u g¹¹
+                view(fem_evals[2][idx_du][2], i, :) .* inv_g[i][1, 2] .+  # ∂u α² * g¹²
+                view(fem_evals[1][1][2], i, :) .* dinv_g_du[i][1, 2] .+  # α² * ∂u g¹²
+                view(fem_evals[2][idx_dv][1], i, :) .* inv_g[i][2, 1] .+  # ∂v α¹ * g²¹
+                view(fem_evals[1][1][1], i, :) .* dinv_g_dv[i][2, 1] .+  # α¹ * ∂v g²¹
+                view(fem_evals[2][idx_dv][2], i, :) .* inv_g[i][2, 2] .+  # ∂v α² * g²²
+                view(fem_evals[1][1][2], i, :) .* dinv_g_dv[i][2, 2] .+  # α² * ∂v g²²
+                (1.0 / sqrt_g[i]) .* (
+                    .+view(fem_evals[1][1][1], i, :) .* inv_g[i][1, 1] .* dsqrt_g_du[i]  # α¹ * g¹¹ * ∂u sqrt(g)
+                    .+
+                    view(fem_evals[1][1][2], i, :) .* inv_g[i][1, 2] .* dsqrt_g_du[i]  # α² * g¹² * ∂u sqrt(g)
+                    .+
+                    view(fem_evals[1][1][1], i, :) .* inv_g[i][2, 1] .* dsqrt_g_dv[i]  # α¹ * g²¹ * ∂v sqrt(g)
+                    .+
+                    view(fem_evals[1][1][2], i, :) .* inv_g[i][2, 2] .* dsqrt_g_dv[i]  # α² * g²² * ∂v sqrt(g)
+                )
             )
     end
 
@@ -275,29 +286,32 @@ end
 # Specialised version for the exterior derivative of 0-forms to 1-forms in 2D.
 # This is equivalent to the Laplacian of 0-forms.
 function _evaluate_codifferential(
-    form_space::F, element_id::Int, xi::Points.AbstractPoints{2}
-) where {FS <: FormSpace{2, 0}, F <: ExteriorDerivative{2, 1, 1, FS}}
+    form_space::ExteriorDerivative{2, 1, 1, FS}, element_id::Int, xi::Points.AbstractPoints{2}
+) where {FS <: FormSpace{2, 0}}
     # Evaluate derivatives of the basis functions. We need derivatives up to order 2. Since
     # we are evaluating the laplacian of 0-forms, the basis functions we do not have to
     # scale the derivatives.
     fem_evals, form_basis_indices = FunctionSpaces.evaluate(
         get_fe_space(form_space), element_id, xi, 2
     )
+    T = eltype(fem_evals[1][1][1][1])
     n_coderivative_form_components = 1
     n_basis_functions = length(form_basis_indices)
     n_evaluation_points = Points.get_num_points(xi)
     # Preallocate memory for output array
     codiff_eval = [
-        zeros(Float64, n_evaluation_points, n_basis_functions) for
+        zeros(T, n_evaluation_points, n_basis_functions) for
         _ in 1:n_coderivative_form_components
     ]
-    # # Compute the metric terms, including derivative of the metric.
+    # Compute the metric terms, including derivative of the metric.
     J, inv_g, g, sqrt_g, (dgdu, dgdv), (dinv_g_du, dinv_g_dv), (dsqrt_g_du, dsqrt_g_dv), Hs = Geometry.metric_derivatives(
         get_geometry(form_space), element_id, xi
     )
     # Compute the laplacian, which is the coderivative of the exterior derivative.
     # α¹ = α¹ du + α² dv
     # α¹ = d(β⁰) = ∂ᵤ β⁰ du + ∂ᵥ β⁰ dv
+    # sign: (-1)^{n(k+1)+1}, n = manifold_dim, k = form_rank. 1-forms -> always -1.
+    sign = -one(T)
     idx_du = FunctionSpaces.get_derivative_idx((1, 0))
     idx_dv = FunctionSpaces.get_derivative_idx((0, 1))
     idx_duu = FunctionSpaces.get_derivative_idx((2, 0))
@@ -305,19 +319,21 @@ function _evaluate_codifferential(
     idx_duv = FunctionSpaces.get_derivative_idx((1, 1))
     for i in 1:n_evaluation_points
         codiff_eval[1][i, :] .=
-            view(fem_evals[3][idx_duu][1], i, :) .* inv_g[i][1, 1] .+  # ∂u α¹ * g¹¹
-            view(fem_evals[2][idx_du][1], i, :) .* dinv_g_du[i][1, 1] .+  # α¹ * ∂u g¹¹
-            view(fem_evals[3][idx_duv][1], i, :) .* inv_g[i][1, 2] .+  # ∂u α² * g¹²
-            view(fem_evals[2][idx_dv][1], i, :) .* dinv_g_du[i][1, 2] .+  # α² * ∂u g¹²
-            view(fem_evals[3][idx_duv][1], i, :) .* inv_g[i][2, 1] .+  # ∂v α¹ * g²¹
-            view(fem_evals[2][idx_du][1], i, :) .* dinv_g_dv[i][2, 1] .+  # α¹ * ∂v g²¹
-            view(fem_evals[3][idx_dvv][1], i, :) .* inv_g[i][2, 2] .+  # ∂v α² * g²²
-            view(fem_evals[2][idx_dv][1], i, :) .* dinv_g_dv[i][2, 2] .+  # α² * ∂v g²²
-            (1.0 / sqrt_g[i]) .* (
-                view(fem_evals[2][idx_du][1], i, :) .* inv_g[i][1, 1] .* dsqrt_g_du[i] .+  # α¹ * g¹¹ * ∂u sqrt(g)
-                view(fem_evals[2][idx_dv][1], i, :) .* inv_g[i][1, 2] .* dsqrt_g_du[i] .+  # α² * g¹² * ∂u sqrt(g)
-                view(fem_evals[2][idx_du][1], i, :) .* inv_g[i][2, 1] .* dsqrt_g_dv[i] .+  # α¹ * g²¹ * ∂v sqrt(g)
-                view(fem_evals[2][idx_dv][1], i, :) .* inv_g[i][2, 2] .* dsqrt_g_dv[i]  # α² * g²² * ∂v sqrt(g)
+            sign .* (
+                view(fem_evals[3][idx_duu][1], i, :) .* inv_g[i][1, 1] .+  # ∂u α¹ * g¹¹
+                view(fem_evals[2][idx_du][1], i, :) .* dinv_g_du[i][1, 1] .+  # α¹ * ∂u g¹¹
+                view(fem_evals[3][idx_duv][1], i, :) .* inv_g[i][1, 2] .+  # ∂u α² * g¹²
+                view(fem_evals[2][idx_dv][1], i, :) .* dinv_g_du[i][1, 2] .+  # α² * ∂u g¹²
+                view(fem_evals[3][idx_duv][1], i, :) .* inv_g[i][2, 1] .+  # ∂v α¹ * g²¹
+                view(fem_evals[2][idx_du][1], i, :) .* dinv_g_dv[i][2, 1] .+  # α¹ * ∂v g²¹
+                view(fem_evals[3][idx_dvv][1], i, :) .* inv_g[i][2, 2] .+  # ∂v α² * g²²
+                view(fem_evals[2][idx_dv][1], i, :) .* dinv_g_dv[i][2, 2] .+  # α² * ∂v g²²
+                (1.0 / sqrt_g[i]) .* (
+                    view(fem_evals[2][idx_du][1], i, :) .* inv_g[i][1, 1] .* dsqrt_g_du[i] .+  # α¹ * g¹¹ * ∂u sqrt(g)
+                    view(fem_evals[2][idx_dv][1], i, :) .* inv_g[i][1, 2] .* dsqrt_g_du[i] .+  # α² * g¹² * ∂u sqrt(g)
+                    view(fem_evals[2][idx_du][1], i, :) .* inv_g[i][2, 1] .* dsqrt_g_dv[i] .+  # α¹ * g²¹ * ∂v sqrt(g)
+                    view(fem_evals[2][idx_dv][1], i, :) .* inv_g[i][2, 2] .* dsqrt_g_dv[i]  # α² * g²² * ∂v sqrt(g)
+                )
             )
     end
 

--- a/src/Forms/FormOperators/Codifferential.jl
+++ b/src/Forms/FormOperators/Codifferential.jl
@@ -8,11 +8,31 @@
 
 Represents the codifferential of an `AbstractForm`.
 
+The codifferential, often denoted ``d^{\\star}`` or ``\\delta``, is a differential operator
+mapping ``k``-forms to ``k-1``-forms. On manifolds without boundaries, it is the
+``L^2``-adjoint of the exterior derivative. That is,
+``(\\alpha^{k-1}, \\delta\\beta^k) = (d\\alpha^{k-1}, \\beta^k)``, where
+``(\\cdot, \\cdot)`` is an ``L^2`` inner-product.
+
+The codifferential can (formally) be defined in terms of the [ExteriorDerivative](@ref) and
+[Hodge](@ref). We then have (with ``n`` the manifold dimension and ``k`` the form rank)
+```math
+\\delta = (-1)^{n(k+1)+1} \\star d \\star\\;.
+```
+The codifferential is often used to defined the Hodge-Laplacian as
+``\\delta d + d \\delta``. Applied to zero-forms, the Hodge-Laplacian reduces to
+``\\delta d``. Note that this gives the opposite sign compared to the standard Laplacian in
+Cartesian coordinates.
+
 The `manifold_dim` of the `CoDifferential` is inherited from the input form, while the
 `form_rank` is the form rank of the input form minus 1.
 
 # Constructors
 - `CoDifferential(form::F)`: General constructor.
+
+# Aliases
+- `δ`: See [`δ`](@ref) (unicode character command `\\delta`).
+- `dstar`: See [`dstar`](@ref).
 
 # Examples
 ```jldoctest

--- a/src/Forms/FormOperators/Codifferential.jl
+++ b/src/Forms/FormOperators/Codifferential.jl
@@ -57,17 +57,19 @@ struct CoDifferential{manifold_dim, form_rank, expression_rank, F, L} <:
         F <: AbstractForm{manifold_dim, form_rank, expression_rank},
     }
         if form_rank == 0
-            throw(ArgumentError("""\
-                Tried to compute the codifferential of a zero form. The manifold \
-                dimension is $(manifold_dim) and the form rank is $(form_rank). \
-                """))
-        elseif form_rank > 1
-            throw(
-                ArgumentError("""\
-              Tried to compute the codifferential of a form with form_rank > 1. This has \
-              not been implemented yet. \
-              """)
+            return throw(
+                ArgumentError(
+                    LazyString(
+                        "Tried to compute the codifferential of a 0-form in ",
+                        manifold_dim,
+                        "D. The codifferential of a 0-form is not defined.",
+                    ),
+                ),
             )
+        elseif form_rank > 1
+            return throw(MethodError(CoDifferential, form))
+        elseif manifold_dim > 2
+            return throw(MethodError(CoDifferential, form))
         end
 
         old_label = get_label(form)
@@ -109,9 +111,11 @@ function evaluate(
 end
 
 function _evaluate_codifferential(
-    form::AbstractForm{manifold_dim}, ::Int, ::Points.AbstractPoints{manifold_dim}
+    form::AbstractForm{manifold_dim},
+    element_id::Int,
+    xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim}
-    throw(ArgumentError("Method not implement for type $(typeof(form))."))
+    return throw(MethodError(_evaluate_codifferential, (form, element_id, xi)))
 end
 
 ############################################################################################
@@ -123,20 +127,17 @@ function _evaluate_codifferential(
     element_id::Int,
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, form_rank, FS <: AbstractFormSpace{manifold_dim, form_rank}}
-    d_form_basis_eval, form_basis_indices = _evaluate_codifferential(
-        form.form_space, element_id, xi
-    )
-    # This is equal to binomial(manifold_dim, form_rank + 1).
-    n_derivative_components = size(d_form_basis_eval, 1)
-    d_form_eval = Vector{Vector{Float64}}(undef, n_derivative_components)
-    for derivative_form_component_id in eachindex(d_form_eval)
-        d_form_eval[derivative_form_component_id] =
-            d_form_basis_eval[derivative_form_component_id] *
-            form.coefficients[form_basis_indices[1]]
+    evals, indices = _evaluate_codifferential(get_form(form), element_id, xi)
+
+    T = eltype(evals[1])
+    coefficients = get_coefficients(form)
+    n_derivative_components = size(evals, 1) # == binomial(manifold_dim, form_rank + 1).
+
+    d_form_eval = Vector{Vector{T}}(undef, n_derivative_components)
+    for component_id in eachindex(d_form_eval)
+        d_form_eval[component_id] = evals[component_id] * coefficients[indices[1]]
     end
 
-    # We need to wrap form_basis_indices in [] to return a vector of vector to allow
-    # multi-indexed expressions, like wedges.
     return d_form_eval, [[1]]
 end
 
@@ -147,22 +148,17 @@ function _evaluate_codifferential(
 ) where {manifold_dim, FF <: FormField{manifold_dim, 0}}
     field = get_form(form)
     space = get_form(field)
-    d_form_basis_eval, form_basis_indices = _evaluate_codifferential(
-        d(space), element_id, xi
-    )
-    T = eltype(d_form_basis_eval[1])
+    evals, indices = _evaluate_codifferential(d(space), element_id, xi)
+
+    T = eltype(evals[1])
     coefficients = get_coefficients(field)
-    # This is equal to binomial(manifold_dim, form_rank + 1).
-    n_derivative_components = size(d_form_basis_eval, 1)
+    n_derivative_components = size(evals, 1) # == binomial(manifold_dim, form_rank + 1).
+
     d_form_eval = Vector{Vector{T}}(undef, n_derivative_components)
-    for dform_component_id in eachindex(d_form_eval)
-        d_form_eval[dform_component_id] =
-            d_form_basis_eval[dform_component_id] *
-            coefficients[form_basis_indices[1]]
+    for component_id in eachindex(d_form_eval)
+        d_form_eval[component_id] = evals[component_id] * coefficients[indices[1]]
     end
 
-    # We need to wrap form_basis_indices in [] to return a vector of vector to allow
-    # multi-indexed expressions, like wedges.
     return d_form_eval, [[1]]
 end
 
@@ -179,14 +175,11 @@ function _evaluate_codifferential(
         form_space, element_id, xi, 1
     )
     T = eltype(fem_evals[1][1][1][1])
-    n_coderivative_form_components = 1
+    # n_coderivative_form_components = 1
     n_basis_functions = length(form_basis_indices[1])
     n_evaluation_points = Points.get_num_points(xi)
     # Preallocate memory for output array
-    codiff_eval = [
-        zeros(T, n_evaluation_points, n_basis_functions) for
-        _ in 1:n_coderivative_form_components
-    ]
+    codiff_eval = [zeros(T, n_evaluation_points, n_basis_functions)]
     # Compute the metric terms, including derivative of the metric.
     J, inv_g, g, sqrt_g, (dgdu,), (dinv_g_du,), (dsqrt_g_du,), Hs = Geometry.metric_derivatives(
         get_geometry(form_space), element_id, xi
@@ -198,14 +191,17 @@ function _evaluate_codifferential(
     # sign: (-1)^{n(k+1)+1}, n = manifold_dim, k = form_rank. 1-forms -> always -1.
     sign = -one(T)
     idx_du = FunctionSpaces.get_derivative_idx((1,))
-    for i in axes(codiff_eval[1], 1)
-        inv_sqrt_point = 1.0 / sqrt_g[i]
-        codiff_eval[1][i, :] .=
-            sign .* inv_sqrt_point .* (
-                .-view(fem_evals[1][1][1], i, :) .* dsqrt_g_du[i] ./ (sqrt_g[i] .^ 2)  # - α¹ * (d/dx(sqrt(g)))/(sqrt(g)^2)
-                .+
-                view(fem_evals[2][idx_du][1], i, :) .* inv_sqrt_point  # ∂u α¹ * 1 / sqrt(g)
-            )
+    for b in axes(codiff_eval[1], 2)
+        for i in axes(codiff_eval[1], 1)
+            inv_sqrtg = one(T) / sqrt_g[i]
+            codiff_eval[1][i, b] =
+                sign *
+                inv_sqrtg *
+                (
+                    -fem_evals[1][1][1][i, b] * dsqrt_g_du[i] / (sqrt_g[i] ^ 2) +  # - α¹ * (d/dx(sqrt(g)))/(sqrt(g)^2)
+                    fem_evals[2][idx_du][1][i, b] * inv_sqrtg  # ∂u α¹ * 1 / sqrt(g)
+                )
+        end
     end
 
     return codiff_eval, form_basis_indices
@@ -221,14 +217,10 @@ function _evaluate_codifferential(
         get_fe_space(form_space), element_id, xi, 2
     )
     T = eltype(fem_evals[1][1][1][1])
-    n_coderivative_form_components = 1
     n_basis_functions = length(form_basis_indices)
     n_evaluation_points = Points.get_num_points(xi)
     # Preallocate memory for output array
-    codiff_eval = [
-        zeros(T, n_evaluation_points, n_basis_functions) for
-        _ in 1:n_coderivative_form_components
-    ]
+    codiff_eval = [zeros(T, n_evaluation_points, n_basis_functions)]
     # Compute the metric terms, including derivative of the metric.
     J, inv_g, g, sqrt_g, (dgdu,), (dinv_g_du,), (dsqrt_g_du,), Hs = Geometry.metric_derivatives(
         get_geometry(form_space), element_id, xi
@@ -242,14 +234,17 @@ function _evaluate_codifferential(
     sign = -one(T)
     idx_du = FunctionSpaces.get_derivative_idx((1,))
     idx_duu = FunctionSpaces.get_derivative_idx((2,))
-    for i in axes(codiff_eval[1], 1)
-        inv_sqrt_point = 1.0 / sqrt_g[i]
-        codiff_eval[1][i, :] .=
-            sign .* inv_sqrt_point .* (
-                .-view(fem_evals[2][idx_du][1], i, :) .* dsqrt_g_du[i] ./ (sqrt_g[i] .^ 2)  # - α¹ * (d/dx(sqrt(g)))/(sqrt(g)^2)
-                .+
-                view(fem_evals[3][idx_duu][1], i, :) .* inv_sqrt_point  # ∂u α¹ * 1 / sqrt(g)
-            )
+    for b in axes(codiff_eval[1], 2)
+        for i in axes(codiff_eval[1], 1)
+            inv_sqrtg = one(T) / sqrt_g[i]
+            codiff_eval[1][i, b] =
+                sign *
+                inv_sqrtg *
+                (
+                    -fem_evals[2][idx_du][1][i, b] * dsqrt_g_du[i] / (sqrt_g[i] ^ 2) +  # - α¹ * (d/dx(sqrt(g)))/(sqrt(g)^2)
+                    fem_evals[3][idx_duu][1][i, b] * inv_sqrtg  # ∂u α¹ * 1 / sqrt(g)
+                )
+        end
     end
 
     return codiff_eval, [form_basis_indices]
@@ -264,14 +259,10 @@ function _evaluate_codifferential(
         form_space, element_id, xi, 1
     )
     T = eltype(fem_evals[1][1][1][1])
-    n_coderivative_form_components = 1
     n_basis_functions = length(form_basis_indices[1])
     n_evaluation_points = Points.get_num_points(xi)
     # Preallocate memory for output array
-    codiff_eval = [
-        zeros(T, n_evaluation_points, n_basis_functions) for
-        _ in 1:n_coderivative_form_components
-    ]
+    codiff_eval = [zeros(T, n_evaluation_points, n_basis_functions)]
     # Compute the metric terms, including derivative of the metric.
     J, inv_g, g, sqrt_g, (dgdu, dgdv), (dinv_g_du, dinv_g_dv), (dsqrt_g_du, dsqrt_g_dv), Hs = Geometry.metric_derivatives(
         get_geometry(form_space), element_id, xi
@@ -283,27 +274,27 @@ function _evaluate_codifferential(
     sign = -one(T)
     idx_du = FunctionSpaces.get_derivative_idx((1, 0))
     idx_dv = FunctionSpaces.get_derivative_idx((0, 1))
-    for i in axes(codiff_eval[1], 1)
-        codiff_eval[1][i, :] .=
-            sign .* (
-                view(fem_evals[2][idx_du][1], i, :) .* inv_g[i][1, 1] .+  # ∂u α¹ * g¹¹
-                view(fem_evals[1][1][1], i, :) .* dinv_g_du[i][1, 1] .+  # α¹ * ∂u g¹¹
-                view(fem_evals[2][idx_du][2], i, :) .* inv_g[i][1, 2] .+  # ∂u α² * g¹²
-                view(fem_evals[1][1][2], i, :) .* dinv_g_du[i][1, 2] .+  # α² * ∂u g¹²
-                view(fem_evals[2][idx_dv][1], i, :) .* inv_g[i][2, 1] .+  # ∂v α¹ * g²¹
-                view(fem_evals[1][1][1], i, :) .* dinv_g_dv[i][2, 1] .+  # α¹ * ∂v g²¹
-                view(fem_evals[2][idx_dv][2], i, :) .* inv_g[i][2, 2] .+  # ∂v α² * g²²
-                view(fem_evals[1][1][2], i, :) .* dinv_g_dv[i][2, 2] .+  # α² * ∂v g²²
-                (1.0 / sqrt_g[i]) .* (
-                    .+view(fem_evals[1][1][1], i, :) .* inv_g[i][1, 1] .* dsqrt_g_du[i]  # α¹ * g¹¹ * ∂u sqrt(g)
-                    .+
-                    view(fem_evals[1][1][2], i, :) .* inv_g[i][1, 2] .* dsqrt_g_du[i]  # α² * g¹² * ∂u sqrt(g)
-                    .+
-                    view(fem_evals[1][1][1], i, :) .* inv_g[i][2, 1] .* dsqrt_g_dv[i]  # α¹ * g²¹ * ∂v sqrt(g)
-                    .+
-                    view(fem_evals[1][1][2], i, :) .* inv_g[i][2, 2] .* dsqrt_g_dv[i]  # α² * g²² * ∂v sqrt(g)
+    for b in axes(codiff_eval[1], 2)
+        for i in axes(codiff_eval[1], 1)
+            one_div_sqrtg = one(T) / sqrt_g[i]
+            codiff_eval[1][i, b] =
+                sign * (
+                    fem_evals[2][idx_du][1][i, b] * inv_g[i][1, 1] +  # ∂u α¹ * g¹¹
+                    fem_evals[1][1][1][i, b] * dinv_g_du[i][1, 1] +  # α¹ * ∂u g¹¹
+                    fem_evals[2][idx_du][2][i, b] * inv_g[i][1, 2] +  # ∂u α² * g¹²
+                    fem_evals[1][1][2][i, b] * dinv_g_du[i][1, 2] +  # α² * ∂u g¹²
+                    fem_evals[2][idx_dv][1][i, b] * inv_g[i][2, 1] +  # ∂v α¹ * g²¹
+                    fem_evals[1][1][1][i, b] * dinv_g_dv[i][2, 1] +  # α¹ * ∂v g²¹
+                    fem_evals[2][idx_dv][2][i, b] * inv_g[i][2, 2] +  # ∂v α² * g²²
+                    fem_evals[1][1][2][i, b] * dinv_g_dv[i][2, 2] +  # α² * ∂v g²²
+                    one_div_sqrtg * (
+                        fem_evals[1][1][1][i, b] * inv_g[i][1, 1] * dsqrt_g_du[i] +  # α¹ * g¹¹ * ∂u sqrt(g)
+                        fem_evals[1][1][2][i, b] * inv_g[i][1, 2] * dsqrt_g_du[i] +  # α² * g¹² * ∂u sqrt(g)
+                        fem_evals[1][1][1][i, b] * inv_g[i][2, 1] * dsqrt_g_dv[i] +  # α¹ * g²¹ * ∂v sqrt(g)
+                        fem_evals[1][1][2][i, b] * inv_g[i][2, 2] * dsqrt_g_dv[i]  # α² * g²² * ∂v sqrt(g)
+                    )
                 )
-            )
+        end
     end
 
     return codiff_eval, form_basis_indices
@@ -312,7 +303,9 @@ end
 # Specialised version for the exterior derivative of 0-forms to 1-forms in 2D.
 # This is equivalent to the Laplacian of 0-forms.
 function _evaluate_codifferential(
-    form_space::ExteriorDerivative{2, 1, 1, FS}, element_id::Int, xi::Points.AbstractPoints{2}
+    form_space::ExteriorDerivative{2, 1, 1, FS},
+    element_id::Int,
+    xi::Points.AbstractPoints{2},
 ) where {FS <: FormSpace{2, 0}}
     # Evaluate derivatives of the basis functions. We need derivatives up to order 2. Since
     # we are evaluating the laplacian of 0-forms, the basis functions we do not have to
@@ -321,14 +314,10 @@ function _evaluate_codifferential(
         get_fe_space(form_space), element_id, xi, 2
     )
     T = eltype(fem_evals[1][1][1][1])
-    n_coderivative_form_components = 1
     n_basis_functions = length(form_basis_indices)
     n_evaluation_points = Points.get_num_points(xi)
     # Preallocate memory for output array
-    codiff_eval = [
-        zeros(T, n_evaluation_points, n_basis_functions) for
-        _ in 1:n_coderivative_form_components
-    ]
+    codiff_eval = [zeros(T, n_evaluation_points, n_basis_functions)]
     # Compute the metric terms, including derivative of the metric.
     J, inv_g, g, sqrt_g, (dgdu, dgdv), (dinv_g_du, dinv_g_dv), (dsqrt_g_du, dsqrt_g_dv), Hs = Geometry.metric_derivatives(
         get_geometry(form_space), element_id, xi
@@ -343,24 +332,27 @@ function _evaluate_codifferential(
     idx_duu = FunctionSpaces.get_derivative_idx((2, 0))
     idx_dvv = FunctionSpaces.get_derivative_idx((0, 2))
     idx_duv = FunctionSpaces.get_derivative_idx((1, 1))
-    for i in 1:n_evaluation_points
-        codiff_eval[1][i, :] .=
-            sign .* (
-                view(fem_evals[3][idx_duu][1], i, :) .* inv_g[i][1, 1] .+  # ∂u α¹ * g¹¹
-                view(fem_evals[2][idx_du][1], i, :) .* dinv_g_du[i][1, 1] .+  # α¹ * ∂u g¹¹
-                view(fem_evals[3][idx_duv][1], i, :) .* inv_g[i][1, 2] .+  # ∂u α² * g¹²
-                view(fem_evals[2][idx_dv][1], i, :) .* dinv_g_du[i][1, 2] .+  # α² * ∂u g¹²
-                view(fem_evals[3][idx_duv][1], i, :) .* inv_g[i][2, 1] .+  # ∂v α¹ * g²¹
-                view(fem_evals[2][idx_du][1], i, :) .* dinv_g_dv[i][2, 1] .+  # α¹ * ∂v g²¹
-                view(fem_evals[3][idx_dvv][1], i, :) .* inv_g[i][2, 2] .+  # ∂v α² * g²²
-                view(fem_evals[2][idx_dv][1], i, :) .* dinv_g_dv[i][2, 2] .+  # α² * ∂v g²²
-                (1.0 / sqrt_g[i]) .* (
-                    view(fem_evals[2][idx_du][1], i, :) .* inv_g[i][1, 1] .* dsqrt_g_du[i] .+  # α¹ * g¹¹ * ∂u sqrt(g)
-                    view(fem_evals[2][idx_dv][1], i, :) .* inv_g[i][1, 2] .* dsqrt_g_du[i] .+  # α² * g¹² * ∂u sqrt(g)
-                    view(fem_evals[2][idx_du][1], i, :) .* inv_g[i][2, 1] .* dsqrt_g_dv[i] .+  # α¹ * g²¹ * ∂v sqrt(g)
-                    view(fem_evals[2][idx_dv][1], i, :) .* inv_g[i][2, 2] .* dsqrt_g_dv[i]  # α² * g²² * ∂v sqrt(g)
+    for b in axes(codiff_eval[1], 2)
+        for i in 1:n_evaluation_points
+            one_div_sqrtg = one(T) / sqrt_g[i]
+            codiff_eval[1][i, b] =
+                sign * (
+                    fem_evals[3][idx_duu][1][i, b] * inv_g[i][1, 1] +  # ∂u α¹ * g¹¹
+                    fem_evals[2][idx_du][1][i, b] * dinv_g_du[i][1, 1] +  # α¹ * ∂u g¹¹
+                    fem_evals[3][idx_duv][1][i, b] * inv_g[i][1, 2] +  # ∂u α² * g¹²
+                    fem_evals[2][idx_dv][1][i, b] * dinv_g_du[i][1, 2] +  # α² * ∂u g¹²
+                    fem_evals[3][idx_duv][1][i, b] * inv_g[i][2, 1] +  # ∂v α¹ * g²¹
+                    fem_evals[2][idx_du][1][i, b] * dinv_g_dv[i][2, 1] +  # α¹ * ∂v g²¹
+                    fem_evals[3][idx_dvv][1][i, b] * inv_g[i][2, 2] +  # ∂v α² * g²²
+                    fem_evals[2][idx_dv][1][i, b] * dinv_g_dv[i][2, 2] +  # α² * ∂v g²²
+                    one_div_sqrtg * (
+                        fem_evals[2][idx_du][1][i, b] * inv_g[i][1, 1] * dsqrt_g_du[i] +  # α¹ * g¹¹ * ∂u sqrt(g)
+                        fem_evals[2][idx_dv][1][i, b] * inv_g[i][1, 2] * dsqrt_g_du[i] +  # α² * g¹² * ∂u sqrt(g)
+                        fem_evals[2][idx_du][1][i, b] * inv_g[i][2, 1] * dsqrt_g_dv[i] +  # α¹ * g²¹ * ∂v sqrt(g)
+                        fem_evals[2][idx_dv][1][i, b] * inv_g[i][2, 2] * dsqrt_g_dv[i]  # α² * g²² * ∂v sqrt(g)
+                    )
                 )
-            )
+        end
     end
 
     return codiff_eval, [form_basis_indices]

--- a/src/Forms/FormOperators/Codifferential.jl
+++ b/src/Forms/FormOperators/Codifferential.jl
@@ -140,6 +140,32 @@ function _evaluate_codifferential(
     return d_form_eval, [[1]]
 end
 
+function _evaluate_codifferential(
+    form::ExteriorDerivative{manifold_dim, 1, 0, FF},
+    element_id::Int,
+    xi::Points.AbstractPoints{manifold_dim},
+) where {manifold_dim, FF <: FormField{manifold_dim, 0}}
+    field = get_form(form)
+    space = get_form(field)
+    d_form_basis_eval, form_basis_indices = _evaluate_codifferential(
+        d(space), element_id, xi
+    )
+    T = eltype(d_form_basis_eval[1])
+    coefficients = get_coefficients(field)
+    # This is equal to binomial(manifold_dim, form_rank + 1).
+    n_derivative_components = size(d_form_basis_eval, 1)
+    d_form_eval = Vector{Vector{T}}(undef, n_derivative_components)
+    for dform_component_id in eachindex(d_form_eval)
+        d_form_eval[dform_component_id] =
+            d_form_basis_eval[dform_component_id] *
+            coefficients[form_basis_indices[1]]
+    end
+
+    # We need to wrap form_basis_indices in [] to return a vector of vector to allow
+    # multi-indexed expressions, like wedges.
+    return d_form_eval, [[1]]
+end
+
 ############################################################################################
 #                                        Form Space                                        #
 ############################################################################################

--- a/test/Forms/FormOperators/CodifferentialTests.jl
+++ b/test/Forms/FormOperators/CodifferentialTests.jl
@@ -1,0 +1,304 @@
+module CodifferentialTests
+
+using Mantis
+using Test
+
+import LaTeXStrings
+
+# Constructor, property, and getters and setters tests -------------------------------------
+function basic_tests(form, answers)
+    @test Forms.get_manifold_dim(form) == answers[1]
+    @test Forms.get_form_rank(form) == answers[2]
+    @test Forms.get_expression_rank(form) == answers[3]
+    @test Forms.get_label(form) == answers[4]
+    @test Forms.get_form(form) === answers[5]
+    @test Forms.get_form_space_tree(form) === answers[6]
+
+    @test Forms.get_geometry(form) == answers[7]
+    @test Forms.get_num_elements(form) == answers[8]
+
+    @test Forms.get_estimated_nnz_per_elem(form) == answers[9]
+    @test Forms.get_max_local_dim(form) == answers[10]
+    @test Forms.get_fe_space(form) === answers[11]
+    @test Forms.get_num_basis(form) == answers[12]
+    @test Forms.get_num_basis(form, 1) == answers[13]
+
+    return nothing
+end
+
+############################################################################################
+#                                         Cartesian geometry                               #
+############################################################################################
+
+# 1D ---------------------------------------------------------------------------------------
+breakpoints_1D = LinRange(0.0, 1.0, 4)
+geometry_1D = Geometry.CartesianGeometry(breakpoints_1D)
+canonical_qrule_1D = Quadrature.tensor_product_rule((8,), Quadrature.gauss_legendre)
+dΩ_1D = Mantis.Quadrature.StandardQuadrature(
+    canonical_qrule_1D, Geometry.get_num_elements(geometry_1D)
+)
+
+B54_1D = FunctionSpaces.BSplineSpace(geometry_1D, 5, 4)
+B65_1D = FunctionSpaces.BSplineSpace(geometry_1D, 6, 5)
+
+zero_form_space_1D = Forms.FormSpace(0, B54_1D, "B54-0-1D")
+one_form_space_1D = Forms.FormSpace(1, B54_1D, "B54-1-1D")
+
+@test_throws ArgumentError Forms.CoDifferential(zero_form_space_1D)
+
+delta_one_form_space_1D = Forms.CoDifferential(one_form_space_1D)
+@test isa(delta_one_form_space_1D, Forms.CoDifferential{1, 0, 1})
+
+basic_tests(
+    delta_one_form_space_1D,
+    (
+        1,
+        0,
+        1,
+        "\$\\delta\$(B54-1-1D)",
+        one_form_space_1D,
+        (one_form_space_1D,),
+        geometry_1D,
+        3,
+        6,
+        6,
+        B54_1D,
+        8,
+        6,
+    ),
+)
+
+# Exact solution to the Biharmonic problem
+function exact_sol_func_1D(xx::Matrix{Float64})
+    xs = xx[:, 1]
+    return [[x^4 for x in xs]]
+end
+function exact_dsol_func_1D(xx::Matrix{Float64})
+    xs = xx[:, 1]
+    return [[4*x^3 for x in xs]]
+end
+function exact_ddsol_func_1D(xx::Matrix{Float64})
+    xs = xx[:, 1]
+    return [[-12*x^2 for x in xs]]
+end
+function exact_dddsol_func_1D(xx::Matrix{Float64}) # grad laplacian
+    xs = xx[:, 1]
+    return [[-24*x for x in xs]]
+end
+function forcing_function_1D(xx::Matrix{Float64})
+    xs = xx[:, 1]
+    return [[24 for x in xs]]
+end
+
+sol_1D = Forms.AnalyticalFormField(0, exact_sol_func_1D, geometry_1D, "sol")
+dsol_1D = Forms.AnalyticalFormField(1, exact_dsol_func_1D, geometry_1D, "dsol")
+δdsol_1D = Forms.AnalyticalFormField(0, exact_ddsol_func_1D, geometry_1D, "δdsol_2D")
+dδdsol_1D = Forms.AnalyticalFormField(1, exact_dddsol_func_1D, geometry_1D, "dδdsol_2D")
+δdδdsol_1D = Forms.AnalyticalFormField(0, forcing_function_1D, geometry_1D, "δdδdsol_2D")
+
+# Project the exact polynomial solution. The representation should be exact.
+sol_1D_h = Assemblers.solve_L2_projection(zero_form_space_1D, sol_1D, dΩ_1D)
+dsol_1D_h = Forms.ExteriorDerivative(sol_1D_h)
+δdsol_1D_h = Forms.CoDifferential(dsol_1D_h)
+# Also start from the laplacian, because we cannot directly compute the 4-th derivative.
+δdsol_1D_hp = Assemblers.solve_L2_projection(zero_form_space_1D, δdsol_1D, dΩ_1D)
+dδdsol_1D_h = Forms.ExteriorDerivative(δdsol_1D_hp)
+δdδdsol_1D_h = Forms.CoDifferential(dδdsol_1D_h)
+# We repeat this starting from the 1-forms, since the CoDifferential is specialised when
+# computing a Laplacian.
+dsol_1D_hp = Assemblers.solve_L2_projection(one_form_space_1D, dsol_1D, dΩ_1D)
+δdsol_1D_h2 = Forms.CoDifferential(dsol_1D_hp)
+# Also start from the laplacian, because we cannot directly compute the 4-th derivative.
+dδdsol_1D_hp = Assemblers.solve_L2_projection(one_form_space_1D, dδdsol_1D, dΩ_1D)
+δdδdsol_1D_h2 = Forms.CoDifferential(dδdsol_1D_hp)
+
+test_δdsol_1D_h = true
+test_δdδdsol_1D_h = true
+test_δdsol_1D_h2 = true
+test_δdδdsol_1D_h2 = true
+xi_1d = Quadrature.get_nodes(Quadrature.get_canonical_quadrature_rule(dΩ_1D))
+for element_id in 1:Geometry.get_num_elements(geometry_1D)
+    values, _ = Forms.evaluate(δdsol_1D_h, element_id, xi_1d)
+    values_e, _ = Forms.evaluate(δdsol_1D, element_id, xi_1d)
+
+    values2, _ = Forms.evaluate(δdδdsol_1D_h, element_id, xi_1d)
+    values2_e, _ = Forms.evaluate(δdδdsol_1D, element_id, xi_1d)
+
+    values3, _ = Forms.evaluate(δdsol_1D_h2, element_id, xi_1d)
+    values3_e, _ = Forms.evaluate(δdsol_1D, element_id, xi_1d)
+
+    values4, _ = Forms.evaluate(δdδdsol_1D_h2, element_id, xi_1d)
+    values4_e, _ = Forms.evaluate(δdδdsol_1D, element_id, xi_1d)
+
+    for point in eachindex(values[1], values2[1], values3[1], values4[1])
+        if !isapprox(values[1][point], values_e[1][point]; rtol=1e-10, atol=1e-10)
+            global test_δdsol_1D_h = false
+        end
+        if !isapprox(values2[1][point], values2_e[1][point]; rtol=1e-10, atol=1e-10)
+            global test_δdδdsol_1D_h = false
+        end
+        if !isapprox(values3[1][point], values3_e[1][point]; rtol=1e-10, atol=1e-10)
+            global test_δdsol_1D_h2 = false
+        end
+        if !isapprox(values4[1][point], values4_e[1][point]; rtol=1e-10, atol=1e-10)
+            global test_δdδdsol_1D_h2 = false
+        end
+    end
+end
+@test test_δdsol_1D_h
+@test test_δdδdsol_1D_h
+@test test_δdsol_1D_h2
+@test test_δdδdsol_1D_h2
+
+# 2D ---------------------------------------------------------------------------------------
+TP5454_2D = FunctionSpaces.TensorProductSpace((B54_1D, B54_1D))
+TP5465_2D = FunctionSpaces.TensorProductSpace((B54_1D, B65_1D))
+DS_2D = FunctionSpaces.DirectSumSpace((TP5454_2D, TP5465_2D))
+geometry_2D = FunctionSpaces.get_geometry(TP5465_2D)
+canonical_qrule_2D = Quadrature.tensor_product_rule((7, 7), Quadrature.gauss_lobatto)
+dΩ_2D = Mantis.Quadrature.StandardQuadrature(
+    canonical_qrule_2D, Geometry.get_num_elements(geometry_2D)
+)
+
+zero_form_space_2D = Forms.FormSpace(0, TP5454_2D, "TP5454-0-2D")
+one_form_space_2D = Forms.FormSpace(1, DS_2D, "DS-1-2D")
+two_form_space_2D = Forms.FormSpace(2, TP5465_2D, "TP5465-2-2D")
+
+@test_throws ArgumentError Forms.CoDifferential(zero_form_space_2D)
+@test_throws MethodError Forms.CoDifferential(two_form_space_2D)
+
+delta_one_form_space_2D = Forms.CoDifferential(one_form_space_2D)
+@test isa(delta_one_form_space_2D, Forms.CoDifferential{2, 0, 1})
+
+basic_tests(
+    delta_one_form_space_2D,
+    (
+        2,
+        0,
+        1,
+        "\$\\delta\$(DS-1-2D)",
+        one_form_space_2D,
+        (one_form_space_2D,),
+        geometry_2D,
+        9,
+        78,
+        78,
+        DS_2D,
+        136,
+        78,
+    ),
+)
+
+# Exact solution to the Biharmonic problem
+function exact_sol_func_2D(xx::Matrix{Float64})
+    xs = xx[:, 1]
+    ys = xx[:, 2]
+    return [[x^4*y^4 for (x, y) in zip(xs, ys)]]
+end
+function exact_dsol_func_2D(xx::Matrix{Float64})
+    xs = xx[:, 1]
+    ys = xx[:, 2]
+    return [[4*x^3*y^4 for (x, y) in zip(xs, ys)], [4*x^4*y^3 for (x, y) in zip(xs, ys)]]
+end
+function exact_ddsol_func_2D(xx::Matrix{Float64})
+    xs = xx[:, 1]
+    ys = xx[:, 2]
+    return [[-12*x^4*y^2 - 12*x^2*y^4 for (x, y) in zip(xs, ys)]]
+end
+function exact_dddsol_func_2D(xx::Matrix{Float64}) # grad laplacian
+    xs = xx[:, 1]
+    ys = xx[:, 2]
+    return [
+        [-24*x*y^2*(2*x^2 + y^2) for (x, y) in zip(xs, ys)],
+        [-24*x^2*y*(x^2 + 2*y^2) for (x, y) in zip(xs, ys)],
+    ]
+end
+function forcing_function_2D(xx::Matrix{Float64})
+    xs = xx[:, 1]
+    ys = xx[:, 2]
+    return [[24*x^4 + 288*x^2*y^2 + 24*y^4 for (x, y) in zip(xs, ys)]]
+end
+
+sol_2D = Forms.AnalyticalFormField(0, exact_sol_func_2D, geometry_2D, "sol")
+dsol_2D = Forms.AnalyticalFormField(1, exact_dsol_func_2D, geometry_2D, "dsol")
+δdsol_2D = Forms.AnalyticalFormField(0, exact_ddsol_func_2D, geometry_2D, "δdsol_2D")
+dδdsol_2D = Forms.AnalyticalFormField(1, exact_dddsol_func_2D, geometry_2D, "dδdsol_2D")
+δdδdsol_2D = Forms.AnalyticalFormField(0, forcing_function_2D, geometry_2D, "δdδdsol_2D")
+
+# Project the exact polynomial solution. The representation should be exact.
+sol_2D_h = Assemblers.solve_L2_projection(zero_form_space_2D, sol_2D, dΩ_2D)
+dsol_2D_h = Forms.ExteriorDerivative(sol_2D_h)
+δdsol_2D_h = Forms.CoDifferential(dsol_2D_h)
+# Also start from the laplacian, because we cannot directly compute the 4-th derivative.
+δdsol_2D_hp = Assemblers.solve_L2_projection(zero_form_space_2D, δdsol_2D, dΩ_2D)
+dδdsol_2D_h = Forms.ExteriorDerivative(δdsol_2D_hp)
+δdδdsol_2D_h = Forms.CoDifferential(dδdsol_2D_h)
+# We repeat this starting from the 1-forms, since the CoDifferential is specialised when
+# computing a Laplacian.
+dsol_2D_hp = Assemblers.solve_L2_projection(one_form_space_2D, dsol_2D, dΩ_2D)
+δdsol_2D_h2 = Forms.CoDifferential(dsol_2D_hp)
+# Also start from the laplacian, because we cannot directly compute the 4-th derivative.
+dδdsol_2D_hp = Assemblers.solve_L2_projection(one_form_space_2D, dδdsol_2D, dΩ_2D)
+δdδdsol_2D_h2 = Forms.CoDifferential(dδdsol_2D_hp)
+
+test_δdsol_2D_h = true
+test_δdδdsol_2D_h = true
+test_δdsol_2D_h2 = true
+test_δdδdsol_2D_h2 = true
+xi_2d = Quadrature.get_nodes(Quadrature.get_canonical_quadrature_rule(dΩ_2D))
+for element_id in 1:Geometry.get_num_elements(geometry_2D)
+    values, _ = Forms.evaluate(δdsol_2D_h, element_id, xi_2d)
+    values_e, _ = Forms.evaluate(δdsol_2D, element_id, xi_2d)
+
+    values2, _ = Forms.evaluate(δdδdsol_2D_h, element_id, xi_2d)
+    values2_e, _ = Forms.evaluate(δdδdsol_2D, element_id, xi_2d)
+
+    values3, _ = Forms.evaluate(δdsol_2D_h2, element_id, xi_2d)
+    values3_e, _ = Forms.evaluate(δdsol_2D, element_id, xi_2d)
+
+    values4, _ = Forms.evaluate(δdδdsol_2D_h2, element_id, xi_2d)
+    values4_e, _ = Forms.evaluate(δdδdsol_2D, element_id, xi_2d)
+
+    for point in eachindex(values3[1])
+        if !isapprox(values[1][point], values_e[1][point]; rtol=1e-10, atol=1e-10)
+            global test_δdsol_2D_h = false
+        end
+        if !isapprox(values2[1][point], values2_e[1][point]; rtol=1e-10, atol=1e-9)
+            global test_δdδdsol_2D_h = false
+        end
+        if !isapprox(values3[1][point], values3_e[1][point]; rtol=1e-10, atol=1e-10)
+            global test_δdsol_2D_h2 = false
+        end
+        if !isapprox(values4[1][point], values4_e[1][point]; rtol=1e-10, atol=1e-10)
+            global test_δdδdsol_2D_h2 = false
+        end
+    end
+end
+@test test_δdsol_2D_h
+@test test_δdδdsol_2D_h
+@test test_δdsol_2D_h2
+@test test_δdδdsol_2D_h2
+
+@test_throws MethodError Forms._evaluate_codifferential(two_form_space_2D, 1, xi_2d)
+
+# 3D ---------------------------------------------------------------------------------------
+TP545454_3D = FunctionSpaces.TensorProductSpace((B54_1D, B54_1D, B54_1D))
+TP546554_3D = FunctionSpaces.TensorProductSpace((B54_1D, B65_1D, B54_1D))
+DS_3D = FunctionSpaces.DirectSumSpace((TP546554_3D, TP545454_3D, TP546554_3D))
+geometry_3D = FunctionSpaces.get_geometry(TP546554_3D)
+canonical_qrule_3D = Quadrature.tensor_product_rule((8, 8, 8), Quadrature.gauss_legendre)
+dΩ_3D = Mantis.Quadrature.StandardQuadrature(
+    canonical_qrule_3D, Geometry.get_num_elements(geometry_3D)
+)
+
+zero_form_space_3D = Forms.FormSpace(0, TP545454_3D, "TP545454-0-3D")
+one_form_space_3D = Forms.FormSpace(1, DS_3D, "DS-1-3D")
+two_form_space_3D = Forms.FormSpace(2, DS_3D, "DS-2-3D")
+three_form_space_3D = Forms.FormSpace(3, TP546554_3D, "TP546554-3-3D")
+
+@test_throws ArgumentError Forms.CoDifferential(zero_form_space_3D)
+@test_throws MethodError Forms.CoDifferential(one_form_space_3D)
+@test_throws MethodError Forms.CoDifferential(two_form_space_3D)
+@test_throws MethodError Forms.CoDifferential(three_form_space_3D)
+
+end

--- a/test/Forms/FormOperators/runtests.jl
+++ b/test/Forms/FormOperators/runtests.jl
@@ -5,6 +5,9 @@ using Test
 @testset "Algebraic.jl" verbose = true begin
     include("Algebraic.jl")
 end
+@testset "Codifferential" verbose = true begin
+    include("CodifferentialTests.jl")
+end
 @testset "Hodge" verbose = true begin
     include("HodgeTests.jl")
 end

--- a/test/Geometry/MetricTests.jl
+++ b/test/Geometry/MetricTests.jl
@@ -36,15 +36,15 @@ for element_idx in 1:Geometry.get_num_elements(cartesian_geometry_cart_1_1)
     )
     for point in eachindex(g)
         if !isapprox(g[point][1], g_ref_cart_1_1[1]; rtol=rtol)
-            g_test_11 = false
+            global g_test_11 = false
         end
         if !isapprox(inv_g[point][1], inv_g_ref_cart_1_1[1]; rtol=rtol)
-            inv_g_test_11 = false
+            global inv_g_test_11 = false
         end
     end
 
     if any(.!isapprox.(sqrt_g, det_g_ref_cart_1_1; rtol=rtol))
-        sqrt_test_11 = false
+        global sqrt_test_11 = false
     end
 end
 @test g_test_11
@@ -86,15 +86,15 @@ for element_idx in 1:Geometry.get_num_elements(cartesian_geometry_cart_2_2)
 
     for point in eachindex(g)
         if !all(isapprox.(g[point], g_ref_cart_2_2; rtol=rtol))
-            g_test_22 = false
+            global g_test_22 = false
         end
         if !all(isapprox.(inv_g[point], inv_g_ref_cart_2_2; rtol=rtol))
-            inv_g_test_22 = false
+            global inv_g_test_22 = false
         end
     end
 
     if any(.!isapprox.(sqrt_g, det_g_ref_cart_2_2; rtol=rtol))
-        sqrt_test_22 = false
+        global sqrt_test_22 = false
     end
 end
 @test g_test_22
@@ -131,19 +131,19 @@ for element_idx in 1:Geometry.get_num_elements(cartesian_geometry_cart_2_2_inh)
     inv_g, g, sqrt_g = Geometry.inv_metric(
         cartesian_geometry_cart_2_2_inh, element_idx, xi_cart_2_2
     )
-    g_test = true
-    inv_g_test = true
+    global g_test = true
+    global inv_g_test = true
     for point in eachindex(g)
         if !all(isapprox.(g[point], g_ref_cart_2_2_inh[element_idx]; rtol=rtol))
-            g_test_22_inh = false
+            global g_test_22_inh = false
         end
         if !all(isapprox.(inv_g[point], inv_g_ref_cart_2_2_inh[element_idx]; rtol=rtol))
-            inv_g_test_22_inh = false
+            global inv_g_test_22_inh = false
         end
     end
 
     if any(.!isapprox.(sqrt_g, det_g_ref_cart_2_2_inh[element_idx]; rtol=rtol))
-        sqrt_test_22_inh = false
+        global sqrt_test_22_inh = false
     end
 end
 @test g_test_22_inh
@@ -184,7 +184,7 @@ for (k, IJ) in enumerate(CartesianIndices((4, 4)))
                 rtol=1e-14,
             ),
         )
-            inv_g_test_geo23 = false
+            global inv_g_test_geo23 = false
         end
         if !all(
             isapprox.(
@@ -193,7 +193,7 @@ for (k, IJ) in enumerate(CartesianIndices((4, 4)))
                 rtol=1e-14,
             ),
         )
-            g_test_geo23 = false
+            global g_test_geo23 = false
         end
     end
     if !all(
@@ -206,7 +206,7 @@ for (k, IJ) in enumerate(CartesianIndices((4, 4)))
                 rtol=1e-14,
             ),
         )
-        sqrt_test_geo23 = false
+        global sqrt_test_geo23 = false
     end
 end
 @test g_test_geo23
@@ -265,37 +265,37 @@ dinvg1_test_geo23ext = true
 dinvg2_test_geo23ext = true
 for p in eachindex(xi)
     if !all(isapprox.(J[p], Jans(xi[p]...), rtol=1e-14))
-        J_test_geo23ext = false
+        global J_test_geo23ext = false
     end
     if !all(isapprox.(g[p], gans(xi[p]...), rtol=1e-14))
-        g_test_geo23ext = false
+        global g_test_geo23ext = false
     end
     if !all(isapprox.(sqrt_g[p], sqrtgans(xi[p]...), rtol=1e-14))
-        sqrt_test_geo23ext = false
+        global sqrt_test_geo23ext = false
     end
     if !all(isapprox.(inv_g[p], ginvans(xi[p]...), rtol=1e-14))
-        inv_g_test_geo23ext = false
+        global inv_g_test_geo23ext = false
     end
     if !all(isapprox.(Hs[p][1], Hans(xi[p]...)[1], rtol=1e-14))
-        H1_test_geo23ext = false
+        global H1_test_geo23ext = false
     end
     if !all(isapprox.(Hs[p][2], Hans(xi[p]...)[2], rtol=1e-14))
-        H2_test_geo23ext = false
+        global H2_test_geo23ext = false
     end
     if !all(isapprox.(Hs[p][3], Hans(xi[p]...)[3], rtol=1e-14))
-        H3_test_geo23ext = false
+        global H3_test_geo23ext = false
     end
     if !all(isapprox.(dgdxs[1][p], dgduans(xi[p]...), rtol=1e-14))
-        dgdx1_test_geo23ext = false
+        global dgdx1_test_geo23ext = false
     end
     if !all(isapprox.(dgdxs[2][p], dgdvans(xi[p]...), rtol=1e-14))
-        dgdx2_test_geo23ext = false
+        global dgdx2_test_geo23ext = false
     end
     if !all(isapprox.(dinv_g_dxs[1][p], dginvgduans(xi[p]...), rtol=1e-12))
-        dinvg1_test_geo23ext = false
+        global dinvg1_test_geo23ext = false
     end
     if !all(isapprox.(dinv_g_dxs[2][p], dginvgdvans(xi[p]...), rtol=1e-12))
-        dinvg2_test_geo23ext = false
+        global dinvg2_test_geo23ext = false
     end
 end
 @test J_test_geo23ext
@@ -355,37 +355,37 @@ for (k, IJ) in enumerate(CartesianIndices((3, 4)))
     for p in eachindex(xi)
         u, v = uv[p, :]
         if !all(isapprox.(J[p], Jans_geo232(u, v), rtol=1e-12))
-            J_test_geo23ext2 = false
+            global J_test_geo23ext2 = false
         end
         if !all(isapprox.(g[p], gans_geo232(u, v), rtol=1e-14))
-            g_test_geo23ext2 = false
+            global g_test_geo23ext2 = false
         end
         if !all(isapprox.(sqrt_g[p], sqrtgans_geo232(u, v), rtol=1e-14))
-            sqrt_test_geo23ext2 = false
+            global sqrt_test_geo23ext2 = false
         end
         if !all(isapprox.(inv_g[p], ginvans_geo232(u, v), rtol=1e-14))
-            inv_g_test_geo23ext2 = false
+            global inv_g_test_geo23ext2 = false
         end
         if !all(isapprox.(Hs[p][1], Hans_geo232(u, v)[1], rtol=1e-14))
-            H1_test_geo23ext2 = false
+            global H1_test_geo23ext2 = false
         end
         if !all(isapprox.(Hs[p][2], Hans_geo232(u, v)[2], rtol=1e-14))
-            H2_test_geo23ext2 = false
+            global H2_test_geo23ext2 = false
         end
         if !all(isapprox.(Hs[p][3], Hans_geo232(u, v)[3], rtol=1e-14))
-            H3_test_geo23ext2 = false
+            global H3_test_geo23ext2 = false
         end
         if !all(isapprox.(dgdxs[1][p], dgduans_geo232(u, v), rtol=1e-14))
-            dgdx1_test_geo23ext2 = false
+            global dgdx1_test_geo23ext2 = false
         end
         if !all(isapprox.(dgdxs[2][p], dgdvans_geo232(u, v), rtol=1e-14))
-            dgdx2_test_geo23ext2 = false
+            global dgdx2_test_geo23ext2 = false
         end
         if !all(isapprox.(dinv_g_dxs[1][p], dginvgduans_geo232(u, v), rtol=1e-12))
-            dinvg1_test_geo23ext2 = false
+            global dinvg1_test_geo23ext2 = false
         end
         if !all(isapprox.(dinv_g_dxs[2][p], dginvgdvans_geo232(u, v), rtol=1e-12))
-            dinvg2_test_geo23ext2 = false
+            global dinvg2_test_geo23ext2 = false
         end
     end
 end
@@ -456,38 +456,38 @@ for (k, IJ) in enumerate(CartesianIndices((1, 1)))
     for p in eachindex(xi_exp12)
         u, v = uv[p, :]
         if !all(isapprox.(J[p], Jans_exp12(u, v), rtol=1e-14, atol=1e-14))
-            J_test_exp12 = false
+            global J_test_exp12 = false
         end
         if !all(isapprox.(g[p], gans_exp12(u, v), rtol=1e-14, atol=1e-14))
-            g_test_exp12 = false
+            global g_test_exp12 = false
         end
         if !all(isapprox.(sqrt_g[p], sqrtgans_exp12(u, v), rtol=1e-14, atol=1e-14))
-            sqrt_test_exp12 = false
+            global sqrt_test_exp12 = false
         end
         if !all(isapprox.(inv_g[p], ginvans_exp12(u, v), rtol=1e-14, atol=1e-14))
-            inv_g_test_exp12 = false
+            global inv_g_test_exp12 = false
         end
         if !all(isapprox.(Hs[p][1], Hans_exp12(u, v)[1], rtol=1e-14, atol=1e-14))
-            H1_test_exp12 = false
+            global H1_test_exp12 = false
         end
         if !all(isapprox.(Hs[p][2], Hans_exp12(u, v)[2], rtol=1e-14, atol=1e-14))
-            H2_test_exp12 = false
+            global H2_test_exp12 = false
         end
         if !all(isapprox.(dgdxs[1][p], dgduans_exp12(u, v), rtol=1e-14, atol=1e-14))
-            dgdx1_test_exp12 = false
+            global dgdx1_test_exp12 = false
         end
         if !all(isapprox.(dgdxs[2][p], dgdvans_exp12(u, v), rtol=1e-14, atol=1e-14))
-            dgdx2_test_exp12 = false
+            global dgdx2_test_exp12 = false
         end
         if !all(
             isapprox.(dinv_g_dxs[1][p], dginvgduans_exp12(u, v), rtol=1e-14, atol=1e-14)
         )
-            dinvg1_test_exp12 = false
+            global dinvg1_test_exp12 = false
         end
         if !all(
             isapprox.(dinv_g_dxs[2][p], dginvgdvans_exp12(u, v), rtol=1e-14, atol=1e-14)
         )
-            dinvg2_test_exp12 = false
+            global dinvg2_test_exp12 = false
         end
     end
 end
@@ -533,34 +533,34 @@ dinvg1_test_cb = true
 dinvg2_test_cb = true
 for p in eachindex(xi)
     if !all(isapprox.(J[p], Jans_cart_box(xi[p]...), rtol=1e-14))
-        J_test_cb = false
+        global J_test_cb = false
     end
     if !all(isapprox.(g[p], gans_cart_box(xi[p]...), rtol=1e-14))
-        g_test_cb = false
+        global g_test_cb = false
     end
     if !all(isapprox.(sqrt_g[p], sqrtgans_cart_box(xi[p]...), rtol=1e-14))
-        sqrt_test_cb = false
+        global sqrt_test_cb = false
     end
     if !all(isapprox.(inv_g[p], ginvans_cart_box(xi[p]...), rtol=1e-14))
-        inv_g_test_cb = false
+        global inv_g_test_cb = false
     end
     if !all(isapprox.(Hs[p][1], Hans_cart_box(xi[p]...)[1], rtol=1e-14))
-        H1_test_cb = false
+        global H1_test_cb = false
     end
     if !all(isapprox.(Hs[p][2], Hans_cart_box(xi[p]...)[2], rtol=1e-14))
-        H2_test_cb = false
+        global H2_test_cb = false
     end
     if !all(isapprox.(dgdxs[1][p], dgduans_cart_box(xi[p]...), rtol=1e-14))
-        dgdx1_test_cb = false
+        global dgdx1_test_cb = false
     end
     if !all(isapprox.(dgdxs[2][p], dgdvans_cart_box(xi[p]...), rtol=1e-14))
-        dgdx2_test_cb = false
+        global dgdx2_test_cb = false
     end
     if !all(isapprox.(dinv_g_dxs[1][p], dginvgduans_cart_box(xi[p]...), rtol=1e-12))
-        dinvg1_test_cb = false
+        global dinvg1_test_cb = false
     end
     if !all(isapprox.(dinv_g_dxs[2][p], dginvgdvans_cart_box(xi[p]...), rtol=1e-12))
-        dinvg2_test_cb = false
+        global dinvg2_test_cb = false
     end
 end
 @test J_test_cb
@@ -612,16 +612,16 @@ for (k, IJ) in enumerate(CartesianIndices((3, 4)))
         u = (2.0 / (r - l)) * uv[p, 1] - 2.0 * l / (r - l) - 1.0
         v = (2.0 / (t - b)) * uv[p, 2] - 2.0 * b / (t - b) - 1.0
         if !all(isapprox.(J[p], Jans_curv(u, v), rtol=1e-12))
-            J_test_cg = false
+            global J_test_cg = false
         end
         if !all(isapprox.(g[p], gans_curv(u, v), rtol=1e-12))
-            g_test_cg = false
+            global g_test_cg = false
         end
         if !all(isapprox.(sqrt_g[p], sqrtgans_curv(u, v), rtol=1e-12))
-            sqrt_test_cg = false
+            global sqrt_test_cg = false
         end
         if !all(isapprox.(inv_g[p], invgans_curv(u, v), rtol=1e-12))
-            inv_g_test_cg = false
+            global inv_g_test_cg = false
         end
     end
 end
@@ -666,34 +666,34 @@ dinvg1_test_tpcb = true
 dinvg2_test_tpcb = true
 for p in eachindex(xi)
     if !all(isapprox.(J[p], Jans_tp_cart_box(xi[p]...), rtol=1e-14))
-        J_test_tpcb = false
+        global J_test_tpcb = false
     end
     if !all(isapprox.(g[p], gans_tp_cart_box(xi[p]...), rtol=1e-14))
-        g_test_tpcb = false
+        global g_test_tpcb = false
     end
     if !all(isapprox.(sqrt_g[p], sqrtgans_tp_cart_box(xi[p]...), rtol=1e-14))
-        sqrt_test_tpcb = false
+        global sqrt_test_tpcb = false
     end
     if !all(isapprox.(inv_g[p], ginvans_tp_cart_box(xi[p]...), rtol=1e-14))
-        inv_g_test_tpcb = false
+        global inv_g_test_tpcb = false
     end
     if !all(isapprox.(Hs[p][1], Hans_tp_cart_box(xi[p]...)[1], rtol=1e-14))
-        H1_test_tpcb = false
+        global H1_test_tpcb = false
     end
     if !all(isapprox.(Hs[p][2], Hans_tp_cart_box(xi[p]...)[2], rtol=1e-14))
-        H2_test_tpcb = false
+        global H2_test_tpcb = false
     end
     if !all(isapprox.(dgdxs[1][p], dgduans_tp_cart_box(xi[p]...), rtol=1e-14))
-        dgdx1_test_tpcb = false
+        global dgdx1_test_tpcb = false
     end
     if !all(isapprox.(dgdxs[2][p], dgdvans_tp_cart_box(xi[p]...), rtol=1e-14))
-        dgdx2_test_tpcb = false
+        global dgdx2_test_tpcb = false
     end
     if !all(isapprox.(dinv_g_dxs[1][p], dginvgduans_tp_cart_box(xi[p]...), rtol=1e-12))
-        dinvg1_test_tpcb = false
+        global dinvg1_test_tpcb = false
     end
     if !all(isapprox.(dinv_g_dxs[2][p], dginvgdvans_tp_cart_box(xi[p]...), rtol=1e-12))
-        dinvg2_test_tpcb = false
+        global dinvg2_test_tpcb = false
     end
 end
 @test J_test_tpcb
@@ -770,37 +770,37 @@ for (k, IJ) in enumerate(CartesianIndices((n_theta, n_z)))
     for p in eachindex(xi_cyl)
         u, v = uv[p, :]
         if !all(isapprox.(J[p], Jans_tp_cyl(u, v), rtol=1e-14))
-            J_test_tpcyl = false
+            global J_test_tpcyl = false
         end
         if !all(isapprox.(g[p], gans_tp_cyl(u, v), rtol=1e-14))
-            g_test_tpcyl = false
+            global g_test_tpcyl = false
         end
         if !all(isapprox.(sqrt_g[p], sqrtgans_tp_cyl(u, v), rtol=1e-14))
-            sqrt_test_tpcyl = false
+            global sqrt_test_tpcyl = false
         end
         if !all(isapprox.(inv_g[p], ginvans_tp_cyl(u, v), rtol=1e-14))
-            inv_g_test_tpcyl = false
+            global inv_g_test_tpcyl = false
         end
         if !all(isapprox.(Hs[p][1], Hans_tp_cyl(u, v)[1], rtol=1e-14))
-            H1_test_tpcyl = false
+            global H1_test_tpcyl = false
         end
         if !all(isapprox.(Hs[p][2], Hans_tp_cyl(u, v)[2], rtol=1e-14))
-            H2_test_tpcyl = false
+            global H2_test_tpcyl = false
         end
         if !all(isapprox.(Hs[p][3], Hans_tp_cyl(u, v)[3], rtol=1e-14))
-            H3_test_tpcyl = false
+            global H3_test_tpcyl = false
         end
         if !all(isapprox.(dgdxs[1][p], dgduans_tp_cyl(u, v), atol=1e-14))
-            dgdx1_test_tpcyl = false
+            global dgdx1_test_tpcyl = false
         end
         if !all(isapprox.(dgdxs[2][p], dgdvans_tp_cyl(u, v), atol=1e-14))
-            dgdx2_test_tpcyl = false
+            global dgdx2_test_tpcyl = false
         end
         if !all(isapprox.(dinv_g_dxs[1][p], dginvgduans_tp_cyl(u, v), atol=1e-14))
-            dinvg1_test_tpcyl = false
+            global dinvg1_test_tpcyl = false
         end
         if !all(isapprox.(dinv_g_dxs[2][p], dginvgdvans_tp_cyl(u, v), atol=1e-14))
-            dinvg2_test_tpcyl = false
+            global dinvg2_test_tpcyl = false
         end
     end
 end
@@ -936,65 +936,65 @@ for (k, IJK) in enumerate(CartesianIndices((n_r, n_theta_cyl, n_z_cyl)))
     for p in eachindex(xi_solid_cyl)
         r, theta, z = uvw[p, 1], uvw[p, 2], uvw[p, 3]
         if !all(isapprox.(J[p], Jans_solid_cyl(r, theta, z), rtol=1e-14))
-            J_test_scyl = false
+            global J_test_scyl = false
         end
         if !all(isapprox.(g[p], gans_solid_cyl(r, theta, z), rtol=1e-14, atol=1e-14))
-            g_test_scyl = false
+            global g_test_scyl = false
         end
         if !all(isapprox.(sqrt_g[p], sqrtgans_solid_cyl(r, theta, z), rtol=1e-14))
-            sqrt_test_scyl = false
+            global sqrt_test_scyl = false
         end
         if !all(
             isapprox.(inv_g[p], ginvans_solid_cyl(r, theta, z), rtol=1e-14, atol=1e-14)
         )
-            inv_g_test_scyl = false
+            global inv_g_test_scyl = false
         end
         if !all(
             isapprox.(Hs[p][1], Hans_solid_cyl(r, theta, z)[1], rtol=1e-14, atol=1e-14)
         )
-            H1_test_scyl = false
+            global H1_test_scyl = false
         end
         if !all(
             isapprox.(Hs[p][2], Hans_solid_cyl(r, theta, z)[2], rtol=1e-14, atol=1e-14)
         )
-            H2_test_scyl = false
+            global H2_test_scyl = false
         end
         if !all(
             isapprox.(Hs[p][3], Hans_solid_cyl(r, theta, z)[3], rtol=1e-14, atol=1e-14)
         )
-            H3_test_scyl = false
+            global H3_test_scyl = false
         end
         if !all(
             isapprox.(dgdxs[1][p], dgduans_solid_cyl(r, theta, z), rtol=1e-14, atol=1e-14)
         )
-            dgdx1_test_scyl = false
+            global dgdx1_test_scyl = false
         end
         if !all(
             isapprox.(dgdxs[2][p], dgdvans_solid_cyl(r, theta, z), rtol=1e-14, atol=1e-14)
         )
-            dgdx2_test_scyl = false
+            global dgdx2_test_scyl = false
         end
         if !all(
             isapprox.(dgdxs[3][p], dgdwans_solid_cyl(r, theta, z), rtol=1e-14, atol=1e-14)
         )
-            dgdx3_test_scyl = false
+            global dgdx3_test_scyl = false
         end
         if !all(
             isapprox.(
                 dinv_g_dxs[1][p], dginvgduans_solid_cyl(r, theta, z), rtol=1e-12, atol=1e-12
             )
         )
-            dinvg1_test_scyl = false
+            global dinvg1_test_scyl = false
         end
         if !all(
             isapprox.(dinv_g_dxs[2][p], dginvgdvans_solid_cyl(r, theta, z), atol=1e-12)
         )
-            dinvg2_test_scyl = false
+            global dinvg2_test_scyl = false
         end
         if !all(
             isapprox.(dinv_g_dxs[3][p], dginvgdwans_solid_cyl(r, theta, z), atol=1e-12)
         )
-            dinvg3_test_scyl = false
+            global dinvg3_test_scyl = false
         end
     end
 end


### PR DESCRIPTION
Some updates to the codiferential:
- fixes #395 .
- fixes a currently undetected bug in the 1D Laplacian.
- Adds the Laplacian on FormFields (it was already possible on spaces, but not handled on FormFields).
- Adds tests for the codifferential.
    - The tests format was based on those for the metric. When using this, I noticed that they were missing a global declaration, which is why I also updated the metric tests. This missing global meant that, if a test was failing, the local variable was changed but not the global one. The result was that failing tests were not noticable.
- Updated the doc(string) accordingly.