### PR TITLE
chore: add ai configurations

### DIFF
--- a/.ai/check.sh
+++ b/.ai/check.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)" # Mantis top-level directory.
+
+AI_DIR="$ROOT/.ai"
+GITHUB_DIR="$ROOT/.github"
+CLAUDE_DIR="$ROOT/.claude"
+
+echo "Checking AI configurations... "
+
+
+############################################################################################
+#                                     Main instructions                                    #
+############################################################################################
+
+diff "$AI_DIR/instructions.md" "$GITHUB_DIR/copilot-instructions.md"
+diff "$AI_DIR/instructions.md" "$ROOT/CLAUDE.md"
+
+############################################################################################
+#                                         Skills                                           #
+############################################################################################
+
+# Check modified skills
+for skill in "$AI_DIR"/skills/*.md; do
+    name="$(basename "$skill" .md)"
+    for agent in "$GITHUB_DIR" "$CLAUDE_DIR"; do
+        diff "$skill" "$agent/skills/$name/SKILL.md"
+    done
+done
+
+# Check for stale skills
+for dir in "$GITHUB_DIR" "$CLAUDE_DIR"; do
+    for skilldir in "$dir"/skills/*; do
+        [ -d "$skilldir" ] || continue
+
+        name="$(basename "$skilldir")"
+
+        if [[ ! -f "$AI_DIR/skills/$name.md" ]]; then
+            echo "The skill \`$skilldir\` does not exist in \`.ai/skills\`."
+            echo "Please remove it."
+            exit 1
+        fi
+    done
+done
+
+echo "Done!"

--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -1,0 +1,83 @@
+# Mantis.jl
+
+Julia package for high-order, structure-preserving finite element methods, built on the
+Finite Element Exterior Calculus (FEEC) framework. Supports piecewise-polynomial,
+non-polynomial, and adaptively-refinable (hierarchical B-spline) finite element spaces,
+among others.
+
+## Build & test Supports Julia 1.10 (LTS) through pre-release (CI runs lts, 1, pre).
+
+```
+bash
+julia --project=. -e 'using Pkg; Pkg.instantiate()'          # resolve deps
+julia --project=. -e 'using Pkg; Pkg.test()'                  # full suite
+julia --project=. -e 'include("test/Geometry/runtests.jl")'   # one module
+julia --project=. -e 'include("test/Assemblers/GlobalAssemblersTests.jl")'  # one file
+```
+
+Test files use plain import Mantis / top-level @tests (no @testset inside each file);
+@testset wrapping happens in each module's test/<Module>/runtests.jl, which is in turn
+included from test/runtests.jl. Mirror src/<Module> structure when adding tests, and
+register new files in the module's runtests.jl.
+JET type-inference tests (test/Inference) only run on Julia >= 1.12, non-prerelease, via
+their own nested project — skipped otherwise.
+
+Docs: julia --project=docs docs/make.jl.
+
+Example pages under docs/src/Examples are generated from examples/src/\*.jl via Literate.jl
+— edit the .jl source, not the generated .md.
+
+`jlfmt` is used to enforce consistent formatting.
+
+## Architecture src/Mantis.jl includes each submodule in dependency
+
+order and re-exports selected symbols. Modules depend roughly on those before them:
+GeneralHelpers -> Mesh -> Points -> Hierarchy -> Geometry -> FunctionSpaces -> Quadrature ->
+Forms -> Analysis -> Assemblers -> Plot
+
+Each module's <ModuleName>.jl defines the module, abstract types, exports, and top-level
+fallback methods (throw(MethodError(...)) documenting the interface concrete subtypes must
+implement), then includes the rest of the module at the bottom — read it first when
+exploring a module.
+
+- **Mesh**: topology-only connectivity, no geometry.
+- **Points**: point sets used for evaluation (e.g. CartesianPoints).
+- **Hierarchy**: bookkeeping for hierarchically-refined (adaptive) structures.
+- **Geometry**: AbstractGeometry{manifold_dim, image_dim, num_patches} maps the canonical
+  domain [0,1]^manifold_dim to physical space. Evaluation happens in the canonical domain,
+  not physical space — this distinction carries through Forms and Assemblers too.
+- **FunctionSpaces**: AbstractFESpace and concrete FE spaces (e.g. B-splines).
+- **Quadrature**: element-level and global quadrature rules. -
+  **Forms**: the FEEC layer. AbstractForm{manifold_dim, form_rank, expression_rank} is
+  central — expression_rank 0 = field (no basis), 1 = space (has a basis), 2 = two-basis
+  expression (e.g. from wedge products). Operators (d, ★, ♯, ∧, ∫, dstar/δ) build expression
+  trees rather than eagerly computing values; evaluate then walks the tree.
+- **Analysis**: error computation (e.g. L2 error).
+- **Assemblers**: turns Forms expressions into global sparse matrices/vectors
+  (GlobalAssemblers.jl + per-problem WeakFormulations).
+- **Time Integrators**: Use for solving time-dependent problems. Uses a GLM framework.
+- **Plot**: writes VTK output; Makie plotting lives in the weak-dependency extension
+  ext/MakieExt.jl. exports/Exports.jl and exports/Forms.jl are auxiliary re-exports of the
+  curated public API (marked "auto-generated") — keep in sync manually if you add/rename
+  public Forms exports.
+
+## Conventions
+
+- **Style**: [Blue Style](https://github.com/JuliaDiff/BlueStyle) with the modifications in
+  .JuliaFormatter.toml (no import->using conversion, short function defs stay short,
+  markdown/docstring formatting disabled, docs/ excluded).
+- **Docstrings**: public functions/types get # Arguments, # Returns (when arguments are not
+  clear), and where relevant # Exceptions sections, matching existing src/ style. Add #
+  Examples with a jldoctest block when it aids understanding.
+- **Commit messages** are enforced by .github/scripts/commit-msg.sh / CommitMessage.yml CI
+  (Conventional Commits): <type>: <text> (<type>!: <text> for breaking changes, revert:
+  <type>: <text> for reverts). Allowed types: bench, chore, ci, doc, feat, fix, perf,
+  refactor, style, test, revert, merge. Title <= 50 chars; first word of <text> must be
+  lower-case, imperative/future tense (not -ed/-s/-ing), e.g. feat: add new cool geometry.
+  Keep commits single-purpose — see docs/src/Support/Contributing.md (e.g. perf: commits
+  should quantify improvement with something like @allocations).
+- **Public-but-undocumented exports** use Julia's public keyword (guarded by VERSION >=
+  v"1.11.0-DEV.469" for Julia 1.10 compatibility) instead of export, e.g. abstract types in
+  Forms.jl.
+- **Weak dependencies**: go through a package extension in ext/, declared via
+  [weakdeps]/[extensions] in Project.toml, not a hard dependency.

--- a/.ai/skills/docexamples.md
+++ b/.ai/skills/docexamples.md
@@ -1,0 +1,266 @@
+---
+name: Mantis Example Documentation
+description: Write and maintain example documentation pages that demonstrate how to use Mantis.jl through complete, executable examples, following the style used throughout `docs/src/Examples/`.
+---
+
+# Mantis.jl Example Documentation
+
+This skill describes how to write or update example pages under:
+
+```
+docs/src/Examples/
+```
+
+Examples are intended to teach users how to solve problems using Mantis, not to document
+individual APIs.
+
+Each example should demonstrate a complete workflow that users can adapt to their own
+problems.
+
+---
+
+# Purpose
+
+An example should answer questions such as:
+
+- How do I use this functionality?
+- What is the typical workflow?
+- Which abstractions work together?
+- What result should I expect?
+
+Examples should be practical, self-contained, and easy to adapt.
+
+---
+
+# Source Files
+
+Documentation pages are generated from
+
+```
+examples/src/*.jl
+```
+
+using Literate.jl.
+
+**Always edit the `.jl` source file**, not the generated Markdown page.
+
+Ensure that both the code and the accompanying comments are suitable for Literate.jl.
+
+---
+
+# Intended Audience
+
+Assume readers:
+
+- are familiar with Julia,
+- have basic knowledge of finite element methods,
+- are learning how to use Mantis.
+
+Explain Mantis-specific concepts, but avoid explaining general Julia syntax.
+
+---
+
+# Structure
+
+A typical example should contain:
+
+1. Introduction
+2. Problem description
+3. Geometry construction
+4. Function space definition
+5. Weak formulation or computation
+6. Results
+7. Discussion
+
+Not every example requires every section, but the progression should feel natural.
+
+Whenever possible, build on previous examples to avoid repeating code.
+
+---
+
+# Introduce the Problem
+
+Begin by describing:
+
+- the mathematical problem,
+- the objective of the example,
+- the important Mantis features being demonstrated.
+
+Keep the introduction concise.
+
+---
+
+# Build the Example Incrementally
+
+Construct the example in logical steps.
+
+For example:
+
+- define the geometry,
+- define function spaces,
+- construct forms,
+- assemble the problem,
+- solve,
+- analyze or visualize the results.
+
+Avoid presenting a large block of code without explanation.
+
+---
+
+# Explain Design Decisions
+
+Describe *why* each step is performed.
+
+For example:
+
+- why a particular geometry is chosen,
+- why a certain function space is appropriate,
+- why a specific operator is used.
+
+Help readers understand the reasoning behind the workflow.
+
+---
+
+# Focus on Public APIs
+
+Examples should use the public Mantis interface.
+
+Avoid relying on:
+
+- internal helper functions,
+- undocumented interfaces,
+- implementation details.
+
+Examples should remain valid as the implementation evolves.
+
+---
+
+# Keep Examples Realistic
+
+Use examples that resemble actual workflows.
+
+Prefer:
+
+- standard geometries,
+- commonly used function spaces,
+- realistic boundary conditions,
+- representative numerical problems.
+
+Avoid contrived examples that only demonstrate syntax.
+
+---
+
+# Keep Examples Concise
+
+Include enough code to illustrate the workflow, but avoid unnecessary complexity.
+
+If an example becomes too long, consider splitting it into multiple examples.
+
+Each example should focus on one primary concept.
+
+---
+
+# Explain the Mathematics
+
+Briefly describe the mathematical formulation when it improves understanding.
+
+For example:
+
+- the governing equations,
+- weak formulations,
+- differential operators,
+- finite element spaces.
+
+Keep mathematical discussions concise and directly relevant to the example.
+
+---
+
+# Results
+
+Conclude by explaining:
+
+- what was computed,
+- what users should observe,
+- how to interpret the output.
+
+When appropriate, discuss expected numerical behavior or convergence properties.
+
+---
+
+# Visualizations
+
+Include plots or VTK output only when they help explain the result.
+
+Visualizations should support the narrative, not replace it.
+
+Ensure generated figures are reproducible.
+
+---
+
+# Cross References
+
+Link to related documentation where appropriate.
+
+Examples include:
+
+- module documentation,
+- tutorials,
+- API documentation,
+- related examples.
+
+Avoid duplicating explanations that already exist elsewhere.
+
+---
+
+# Maintain Examples
+
+Whenever the implementation changes:
+
+- update the example,
+- update explanatory text,
+- update expected output,
+- remove obsolete code.
+
+Examples should always execute successfully.
+
+---
+
+# Writing Style
+
+Write in clear, concise English.
+
+Use comments to explain concepts rather than individual Julia statements.
+
+Prefer explaining the workflow over explaining syntax.
+
+---
+
+# Example Checklist
+
+Before opening a PR, verify that:
+
+- the example is implemented in `examples/src/`
+- the example follows the style of existing examples
+- the workflow is easy to follow
+- only public APIs are used
+- explanations focus on concepts rather than syntax
+- mathematical terminology is accurate
+- the example executes successfully
+- generated documentation renders correctly with Literate.jl
+- visualizations, if included, are reproducible
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- edit the generated Markdown files
+- rely on undocumented or internal APIs
+- include large unexplained code blocks
+- explain basic Julia syntax
+- mix multiple unrelated concepts into a single example
+- leave outdated output or figures after implementation changes
+
+Prefer examples that teach users how to solve realistic problems using Mantis rather than
+examples that merely demonstrate individual functions.

--- a/.ai/skills/docmodules.md
+++ b/.ai/skills/docmodules.md
@@ -1,0 +1,265 @@
+---
+name: Mantis Module Documentation
+description: Write and maintain module documentation pages that explain the mathematical concepts, architecture, and public interfaces of a Mantis.jl module, following the style used in `docs/src/Design/Modules/`.
+---
+
+# Mantis.jl Module Documentation
+
+This skill describes how to write or update module documentation pages under
+
+```
+docs/src/Design/Modules/
+```
+
+These pages are intended to explain the design of a module to users and contributors, rather
+than documenting individual APIs.
+
+Use existing pages, such as `docs/src/Design/Modules/Forms.md`, as the primary style
+reference.
+
+---
+
+# Purpose
+
+A module page should answer questions such as:
+
+- What problem does this module solve?
+- What mathematical concepts does it implement?
+- What role does it play within Mantis?
+- How does it interact with other modules?
+- What are its primary public abstractions?
+- How should users think about using it?
+
+The emphasis is on **concepts and design**, not implementation details.
+
+---
+
+# Intended Audience
+
+Assume readers:
+
+- are familiar with Julia,
+- have some background in finite element methods,
+- may be unfamiliar with the internal architecture of Mantis.
+
+Explain mathematical concepts when they are central to understanding the module, but avoid
+turning the page into a textbook.
+
+---
+
+# Structure
+
+Follow the structure used by existing module pages.
+
+A typical page contains:
+
+1. Overview
+2. Core concepts
+3. Main abstractions
+4. Relationships to other modules
+5. Examples
+6. References (when appropriate)
+
+Not every page requires every section, but the overall organization should remain consistent
+across modules.
+
+---
+
+# Overview
+
+Begin with a concise overview describing:
+
+- the module's responsibility,
+- where it fits within the overall architecture,
+- what kinds of functionality it provides.
+
+Avoid discussing implementation files or internal organization.
+
+Focus on the conceptual role of the module.
+
+---
+
+# Explain the Mathematics
+
+Many Mantis modules represent mathematical abstractions.
+
+Describe:
+
+- the mathematical objects represented,
+- the notation used throughout the library,
+- important invariants,
+- the relationship between mathematical concepts and their implementation.
+
+For example:
+
+- differential forms
+- pullbacks
+- Hodge operators
+- finite element spaces
+- hierarchical refinement
+
+Use precise mathematical terminology.
+
+---
+
+# Explain the Design
+
+Describe the design decisions behind the module.
+
+For example:
+
+- why symbolic expressions are used,
+- why evaluation is lazy,
+- why canonical coordinates are preferred,
+- how abstraction boundaries are maintained.
+
+Help readers understand *why* the module is designed the way it is.
+
+---
+
+# Introduce Public Abstractions
+
+Present the important public types and interfaces.
+
+Explain:
+
+- what they represent,
+- when they should be used,
+- how they relate to one another.
+
+Do not duplicate API docstrings. Instead, extensively embed the docstrings into the
+documentation page, creating a cohesive narrative.
+
+---
+
+# Describe Module Relationships
+
+Explain how the module interacts with the rest of Mantis.
+
+Examples include:
+
+- Geometry provides mappings used by Forms.
+- FunctionSpaces provide basis functions consumed by Forms.
+- Assemblers evaluate symbolic expressions built by Forms.
+
+Help readers understand the flow of information through the library.
+
+---
+
+# Use Examples
+
+Prefer small conceptual examples over exhaustive tutorials.
+
+Examples should illustrate:
+
+- typical workflows,
+- important abstractions,
+- common usage patterns.
+
+Avoid large blocks of implementation code.
+
+---
+
+# Maintain Conceptual Level
+
+Keep the documentation focused on design.
+
+Prefer explaining:
+
+- why something exists,
+- what abstraction it provides,
+- how it fits into the library.
+
+Avoid describing:
+
+- internal helper functions,
+- implementation details,
+- private data structures,
+- optimization techniques unless they motivate the design.
+
+---
+
+# Cross References
+
+Link to related documentation where appropriate.
+
+Examples include:
+
+- other module pages,
+- tutorials,
+- examples,
+- API documentation.
+
+Use cross references to help readers navigate the documentation rather than duplicating
+content.
+
+---
+
+# Mathematical Notation
+
+When introducing notation:
+
+- define symbols before using them,
+- use consistent notation throughout the page,
+- match notation used elsewhere in the documentation.
+
+Prefer mathematical clarity over excessive formalism.
+
+---
+
+# Diagrams
+
+When appropriate, include simple diagrams illustrating:
+
+- module relationships,
+- data flow,
+- mathematical structures,
+- abstraction layers.
+
+Diagrams should clarify the design rather than decorate the page.
+
+---
+
+# Keep Documentation Current
+
+Whenever the module changes:
+
+- update the conceptual description,
+- update examples,
+- update descriptions of public abstractions,
+- update relationships to other modules.
+
+Documentation should evolve together with the implementation.
+
+---
+
+# Documentation Checklist
+
+Before opening a PR, verify that:
+
+- the page follows the style of existing module documentation (especially
+  `docs/src/Design/Modules/Forms.md`)
+- the module's purpose is clearly explained
+- the mathematical concepts are described accurately
+- the main abstractions are introduced
+- relationships to other modules are explained
+- examples are concise and illustrative
+- implementation details are minimized
+- terminology is consistent with the rest of the documentation
+- cross references are updated where appropriate
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- duplicate API docstrings
+- document individual methods in detail
+- explain the implementation file layout
+- include unnecessary implementation details
+- introduce notation without defining it
+- turn the page into a complete mathematical reference
+
+Prefer documentation that explains the *design philosophy* and *conceptual model* of the
+module over documentation that mirrors the source code.

--- a/.ai/skills/docstrings.md
+++ b/.ai/skills/docstrings.md
@@ -1,0 +1,274 @@
+---
+name: Mantis Docstrings
+description: Write clear, consistent, and informative docstrings for Mantis.jl that follow the project's documentation style and accurately describe the public API.
+---
+
+# Mantis.jl Docstrings
+
+This skill describes how to write docstrings for Mantis.jl.
+
+Public APIs should be documented clearly enough that users can understand how to use them
+without reading the implementation.
+
+Docstrings are part of the public interface and should evolve alongside the code.
+
+---
+
+# What Should Be Documented
+
+Document all public:
+
+- functions
+- methods with user-facing behavior
+- types
+- macros
+- constants when appropriate
+
+Internal helper functions generally do not require docstrings unless they implement
+important algorithms or are likely to be reused.
+
+---
+
+# Follow Existing Style
+
+Match the style already used throughout `src/`.
+
+Do not introduce a new documentation format.
+
+Public docstrings should use section headings where appropriate:
+
+- `# Arguments` (when not obvious from the name)
+- `# Returns` (when not obvious from the name)
+- `# Exceptions`
+- `# Examples` (whenever possible)
+
+Only include sections that add value. Avoid empty or trivial sections.
+
+---
+
+# Function Docstrings
+
+Begin with a concise summary describing what the function does.
+
+Prefer describing the operation rather than the implementation.
+
+Prefer:
+
+> Compute the pullback of a differential form onto the reference domain.
+
+Avoid:
+
+> This function loops over the basis functions and applies pullback transformations.
+
+Implementation details belong in comments, not the public documentation.
+
+---
+
+# Arguments
+
+Include an `# Arguments` section whenever the function accepts non-obvious parameters.
+
+For each argument, describe:
+
+- its purpose
+- expected type or interface (when not obvious)
+- any assumptions or restrictions
+
+Explain the _meaning_ of an argument, not merely its Julia type.
+
+Prever:
+
+```
+- `geometry`: Geometry used to map the canonical element to physical space.
+```
+
+Avoid:
+
+```
+- `geometry`: An `AbstractGeometry`.
+```
+
+---
+
+# Returns
+
+Include a `# Returns` section whenever the return value is not immediately obvious.
+
+Describe:
+
+- what is returned
+- important guarantees
+- ownership or mutability when relevant
+
+Focus on the semantic meaning of the result rather than its exact implementation type unless
+that type is important to users.
+
+---
+
+# Exceptions
+
+Include a `# Exceptions` section when the function intentionally throws errors under
+documented conditions.
+
+Describe:
+
+- when an exception occurs
+- why it occurs
+
+---
+
+# Examples
+
+Include `# Examples` when they improve understanding (should be often).
+
+Use `jldoctest` blocks.
+
+Examples should:
+
+- be minimal
+- be complete
+- execute successfully
+- demonstrate typical usage
+
+Prefer realistic examples over artificial ones.
+
+---
+
+# Type Docstrings
+
+Describe:
+
+- what the type represents
+- its role within Mantis
+- important invariants
+- when users should use it
+
+Avoid documenting every field unless users are expected to construct the type directly.
+
+Explain the abstraction before the representation.
+
+---
+
+# Mathematical Concepts
+
+Mantis is based on FEEC and differential geometry.
+
+When documenting mathematical objects:
+
+- use correct mathematical terminology
+- define symbols when necessary
+- distinguish between canonical and physical domains
+- distinguish symbolic expressions from evaluated quantities
+
+Assume readers have some numerical PDE background, but avoid unnecessary jargon.
+
+---
+
+# Generic Interfaces
+
+Abstract interfaces should document:
+
+- the purpose of the interface
+- required methods
+- expected behavior
+- semantic contracts
+
+Concrete implementations should document only behavior that differs from or extends the
+interface documentation.
+
+Avoid duplicating documentation across implementations.
+
+---
+
+# Keep Documentation Focused
+
+Describe:
+
+- what the API does
+- why it exists
+- when it should be used
+
+Avoid lengthy implementation discussions.
+
+If implementation details are important for maintainers, place them in comments rather than
+docstrings.
+
+---
+
+# Maintain Accuracy
+
+Whenever changing behavior:
+
+- update the corresponding docstring
+- update examples
+- update documented exceptions
+- update return value descriptions if necessary
+
+Outdated documentation is often more harmful than missing documentation.
+
+---
+
+# Cross References
+
+When appropriate, reference related functionality using Julia's documentation conventions.
+
+Examples include:
+
+- related operators
+- complementary types
+- alternative constructors
+
+Use cross references to help users discover the API rather than repeating documentation.
+
+---
+
+# Writing Style
+
+Write in clear, concise English.
+
+Prefer:
+
+- active voice
+- complete sentences
+- consistent terminology
+- precise mathematical language
+
+Avoid:
+
+- unnecessary verbosity
+- implementation-specific language
+- ambiguous wording
+- unexplained abbreviations
+
+Use the same terminology consistently throughout the codebase.
+
+---
+
+# Documentation Checklist
+
+Before opening a PR, verify that:
+
+- every new public API has a docstring
+- docstrings follow the existing project style
+- `# Arguments`, `# Returns`, `# Exceptions`, and `# Examples` sections are included where
+  appropriate
+- examples are valid `jldoctest`s when provided
+- mathematical terminology is accurate
+- documentation matches the implementation
+- related documentation is updated when behavior changes
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- document the implementation instead of the interface
+- repeat obvious type information without explanation
+- leave stale examples after refactoring
+- duplicate identical documentation across multiple methods
+- omit documentation for new public APIs
+- include speculative or future behavior
+
+Prefer documentation that explains the purpose and semantics of an API over documentation
+that merely describes its syntax.

--- a/.ai/skills/feature.md
+++ b/.ai/skills/feature.md
@@ -1,0 +1,282 @@
+---
+name: Mantis Feature Development
+description: Implement new functionality in the Mantis.jl finite element library while preserving FEEC abstractions, module boundaries, and project conventions.
+---
+
+# Mantis.jl Feature Development
+
+This skill describes how to correctly implement new functionality in Mantis.jl.
+
+## Core Principles
+
+Mantis is organized as a layered FEEC library.
+
+Every new feature should preserve the existing abstraction hierarchy.
+
+Never bypass existing abstractions simply because something is easier to implement.
+
+Whenever possible, implement functionality by extending existing interfaces instead of
+introducing parallel implementations.
+
+---
+
+# Module Dependency Order
+
+Modules have a strict dependency order.
+
+```
+GeneralHelpers
+    ↓
+Mesh
+    ↓
+Points
+    ↓
+Hierarchy
+    ↓
+Geometry
+    ↓
+FunctionSpaces
+    ↓
+Quadrature
+    ↓
+Forms
+    ↓
+Analysis
+    ↓
+Assemblers
+    ↓
+TimeIntegrators
+    ↓
+Plot
+```
+
+A module may depend on modules above it.
+
+Avoid introducing dependencies in the opposite direction.
+
+---
+
+# Before Implementing
+
+First identify which layer owns the feature.
+
+Typical ownership:
+
+- mesh topology → Mesh
+- physical mappings → Geometry
+- finite element spaces → FunctionSpaces
+- symbolic FEEC operators → Forms
+- numerical integration → Quadrature
+- global matrix assembly → Assemblers
+- postprocessing → Analysis
+- visualization → Plot
+
+Avoid implementing functionality in a higher layer when it naturally belongs in a lower one.
+
+---
+
+# Module Structure
+
+Each module follows the same pattern.
+
+```
+ModuleName.jl
+
+module ModuleName
+
+exports
+
+abstract types
+
+fallback interface methods
+
+include("...")
+
+end
+```
+
+When adding new interfaces:
+
+1. add the abstract interface
+2. provide documented fallback methods throwing `MethodError`
+3. implement concrete types in separate files
+4. include those files from the module
+
+Do not place large implementations directly inside `ModuleName.jl`.
+
+---
+
+# Geometry
+
+Geometry maps
+
+```
+[0,1]^n
+    →
+physical space
+```
+
+Evaluation always occurs on the canonical domain.
+
+Do not evaluate basis functions directly in physical coordinates.
+
+Coordinate transforms belong inside Geometry.
+
+Assemblers and Forms should remain geometry-independent.
+
+---
+
+# Forms
+
+Forms are symbolic expression trees.
+
+Operators such as
+
+- d
+- ★
+- δ
+- ∧
+- ∫
+- ♯
+
+construct expressions.
+
+They do **not** perform numerical evaluation.
+
+Evaluation happens exclusively through `evaluate`.
+
+When implementing a new operator:
+
+- preserve lazy evaluation
+- create new expression nodes
+- extend `evaluate`
+- avoid eager computation
+
+---
+
+# Function Spaces
+
+New finite element spaces should extend `AbstractFESpace` and the corresponding documented
+abstract methods.
+
+Reuse existing interfaces whenever possible.
+
+---
+
+# Assemblers
+
+Assemblers convert symbolic Forms into sparse matrices.
+
+Weak formulations should build symbolic expressions.
+
+Avoid inserting numerical kernels directly into weak formulations.
+
+If new assembly logic is required:
+
+- extend the assembler interface
+- preserve sparse assembly
+- reuse existing quadrature infrastructure
+
+---
+
+# Public API
+
+When adding public functionality use `export` or `public` as appropriate
+
+Keep exported APIs minimal.
+
+---
+
+# Documentation
+
+Public APIs require docstrings.
+
+Use the project style:
+
+- Arguments (when not obvious from the name)
+- Returns (when not obvious from the name)
+- Examples (when useful)
+
+Follow existing documentation style instead of inventing new conventions.
+
+---
+
+# Tests
+
+Every feature should include tests.
+
+Mirror the source layout.
+
+Example:
+
+```
+src/Geometry/NewGeometry.jl
+
+↓
+
+test/Geometry/NewGeometryTests.jl
+```
+
+Register new test files in the corresponding
+
+```
+test/<Module>/runtests.jl
+```
+
+Test files contain top-level `@test`s.
+
+Do not wrap them in additional `@testset`s.
+
+---
+
+# Extensions
+
+Optional functionality belongs in package extensions.
+
+Current example:
+
+```
+ext/MakieExt.jl
+```
+
+Do not introduce hard dependencies for optional features.
+
+---
+
+# Style
+
+Follow BlueStyle with the repository's formatter configuration.
+
+Match surrounding code.
+
+Prefer extending existing APIs over introducing new naming patterns.
+
+---
+
+# Implementation Checklist
+
+Before opening a PR verify that:
+
+- feature lives in the correct module
+- abstraction boundaries are preserved
+- module dependency order is respected
+- lazy evaluation is preserved (Forms)
+- new public APIs are documented
+- exports are updated
+- tests are added
+- module `runtests.jl` registers the new tests
+- Julia 1.10 compatibility is preserved
+- optional dependencies use package extensions
+
+---
+
+# Things to Avoid
+
+Do not
+
+- evaluate symbolic Forms eagerly
+- couple Assemblers to specific form or finite element spaces
+- introduce circular module dependencies
+- perform geometry computations outside Geometry
+- duplicate existing interfaces
+- add optional packages as hard dependencies

--- a/.ai/skills/refactoring.md
+++ b/.ai/skills/refactoring.md
@@ -1,0 +1,256 @@
+---
+name: Mantis Refactoring
+description: Refactor Mantis.jl code while preserving FEEC abstractions, module boundaries, API stability, and numerical correctness.
+---
+
+# Mantis.jl Refactoring
+
+This skill describes how to safely refactor existing code in Mantis.jl.
+
+The primary objective of a refactor is to improve the implementation **without changing
+observable behaviour**.
+
+Observable behaviour includes:
+
+- numerical results
+- public APIs
+- supported Julia versions
+- performance characteristics (unless intentionally improved)
+- documentation semantics
+
+When in doubt, prefer smaller, incremental refactors over large rewrites.
+
+---
+
+# Understand Before Changing
+
+Before modifying code, identify:
+
+- which module owns the functionality
+- whether the code is part of the public API
+- whether it implements an interface used elsewhere
+- whether it is performance critical
+
+Read the module's top-level `<Module>.jl` file first to understand the intended abstractions
+before changing implementation files.
+
+Never refactor code that you do not yet understand.
+
+---
+
+# Preserve Module Boundaries
+
+Mantis follows a layered architecture.
+
+```
+GeneralHelpers
+    ↓
+Mesh
+    ↓
+Points
+    ↓
+Hierarchy
+    ↓
+Geometry
+    ↓
+FunctionSpaces
+    ↓
+Quadrature
+    ↓
+Forms
+    ↓
+Analysis
+    ↓
+Assemblers
+    ↓
+TimeIntegrators
+    ↓
+Plot
+```
+
+Do not introduce dependencies that violate this ordering.
+
+If functionality naturally belongs in a lower layer, move it there rather than duplicating
+it in higher layers.
+
+---
+
+# Preserve Existing Abstractions
+
+Prefer strengthening existing abstractions over introducing new ones.
+
+When similar implementations exist:
+
+- extract common functionality
+- reuse existing interfaces
+- eliminate duplication
+
+Avoid introducing parallel interfaces that solve the same problem.
+
+If multiple concrete types implement nearly identical logic, consider moving shared
+behaviour into common helper functions or abstract interface methods.
+
+---
+
+# Preserve FEEC Semantics
+
+The FEEC abstractions are fundamental to Mantis.
+
+In particular:
+
+- Forms represent symbolic expression trees.
+- Operators build expressions.
+- Evaluation occurs through `evaluate`.
+- Assemblers consume symbolic expressions.
+- Geometry handles mappings between canonical and physical domains.
+
+Do not blur these responsibilities during refactoring.
+
+Avoid introducing shortcuts that bypass symbolic representations.
+
+---
+
+# Preserve Public APIs
+
+Refactoring should not require downstream users to modify their code.
+
+Avoid:
+
+- renaming exported symbols
+- changing method signatures
+- changing return types
+- changing documented behaviour
+
+If a breaking change is unavoidable, isolate it into a dedicated change rather than
+combining it with unrelated refactoring.
+
+---
+
+# Reduce Duplication Carefully
+
+When removing duplicated code:
+
+- verify that implementations are truly equivalent
+- preserve specialized behaviour
+- avoid over-generalization
+
+A small amount of duplication is preferable to an abstraction that obscures the mathematics
+or FEEC concepts.
+
+---
+
+# Improve Readability
+
+Refactoring should make code easier to understand.
+
+Common improvements include:
+
+- extracting helper functions
+- improving function names
+- reducing nesting
+- separating independent responsibilities
+- simplifying dispatch
+
+Avoid introducing additional layers of abstraction unless they clearly improve
+maintainability.
+
+---
+
+# Preserve Performance
+
+Many parts of Mantis execute inside assembly loops.
+
+When refactoring performance-critical code:
+
+- avoid unnecessary allocations
+- preserve type stability
+- avoid introducing dynamic dispatch
+- keep hot paths simple
+
+Prefer measuring performance before and after significant refactors.
+
+Do not assume cleaner code is automatically faster.
+
+---
+
+# Preserve Generic Programming
+
+Mantis relies heavily on Julia's multiple dispatch.
+
+Prefer extending existing generic interfaces rather than introducing type checks or
+conditional logic.
+
+Avoid replacing dispatch with manual branching based on concrete types.
+
+---
+
+# Documentation
+
+If public code is moved or reorganized:
+
+- keep docstrings attached to the public API
+- update examples if needed
+- ensure exported symbols remain documented
+
+Internal helper functions generally do not require extensive documentation unless they
+implement non-trivial algorithms.
+
+---
+
+# Tests
+
+Every refactor should preserve existing test coverage.
+
+If behaviour is unchanged:
+
+- existing tests should continue to pass without modification
+
+If code becomes easier to test:
+
+- consider adding focused regression tests
+- preserve mirror structure between `src/` and `test/`
+
+Never remove tests solely because the implementation changed.
+
+---
+
+# Optional Dependencies
+
+Do not convert weak dependencies into hard dependencies.
+
+Functionality related to optional packages should remain inside package extensions under
+`ext/`.
+
+---
+
+# Refactoring Checklist
+
+Before opening a PR, verify that:
+
+- no public APIs changed unintentionally
+- module dependency order is preserved
+- FEEC abstractions remain intact
+- symbolic evaluation remains lazy
+- geometry responsibilities remain in Geometry
+- duplicated logic has been reduced appropriately
+- performance-critical code remains type-stable
+- existing tests pass
+- new regression tests are added where appropriate
+- documentation remains accurate
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- rewrite working code without a clear objective
+- introduce circular module dependencies
+- replace dispatch with manual type checks
+- move geometry logic into Assemblers or Forms
+- eagerly evaluate symbolic expressions
+- over-generalize small pieces of duplicated code
+- combine behavioural changes with large refactors
+- sacrifice numerical clarity for clever abstractions
+
+Prefer refactors that are incremental, well-scoped, and easy to review.

--- a/.ai/skills/tests.md
+++ b/.ai/skills/tests.md
@@ -1,0 +1,306 @@
+---
+name: Mantis Testing
+description: Write and maintain tests for Mantis.jl that verify correctness, numerical accuracy, API behavior, and regression safety while following the project's testing conventions.
+---
+
+# Mantis.jl Testing
+
+This skill describes how to write tests for Mantis.jl.
+
+Tests should verify **observable behaviour**, not implementation details.
+
+Prefer testing through the public interface whenever possible.
+
+---
+
+# Testing Philosophy
+
+A good test should:
+
+- verify mathematical correctness
+- verify numerical correctness
+- catch regressions
+- remain readable
+- be deterministic
+- be independent of execution order
+
+Avoid tests that depend on implementation details unless those details are part of a
+documented interface.
+
+---
+
+# Test Organization
+
+Mirror the source tree.
+
+Example:
+
+```
+src/
+    Geometry/
+        TensorProductGeometry.jl
+
+↓
+
+test/
+    Geometry/
+        TensorProductGeometryTests.jl
+```
+
+Every new test file must be registered inside the module's
+
+```
+test/<Module>/runtests.jl
+```
+
+which is then included from
+
+```
+test/runtests.jl
+```
+
+Do **not** wrap individual test files inside additional `@testset`s.
+
+Each test file should contain top-level `@test`s, as the enclosing `@testset` is provided by
+the module's `runtests.jl`.
+
+---
+
+# What to Test
+
+When adding new functionality, consider testing:
+
+## Public API
+
+Verify that public functions:
+
+- accept expected inputs
+- return expected outputs
+- throw expected exceptions
+- preserve documented behaviour
+
+---
+
+## Mathematical Properties
+
+Whenever possible, test mathematical identities rather than individual implementation steps.
+
+Examples include:
+
+- exact polynomial reproduction
+- commuting diagrams
+- exactness of complexes
+- partition of unity
+- interpolation properties
+- symmetry
+- conservation laws
+
+---
+
+## Numerical Accuracy
+
+For numerical algorithms, compare against:
+
+- analytical solutions
+- manufactured solutions
+- reference values
+- previously validated implementations
+
+Use tolerances appropriate for floating-point arithmetic.
+
+Avoid exact equality unless mathematically guaranteed.
+
+---
+
+## Edge Cases
+
+Consider testing:
+
+- empty inputs
+- degenerate meshes
+- boundary elements
+- single-element meshes
+- high polynomial orders
+- low polynomial orders
+- invalid arguments
+
+Ensure errors are informative and intentional.
+
+---
+
+## Regression Tests
+
+When fixing a bug:
+
+1. write a test that reproduces the bug
+2. verify it fails before the fix
+3. verify it passes afterwards
+
+Keep the regression test even after the bug is fixed.
+
+---
+
+# Forms
+
+Since Forms are symbolic expression trees, test both:
+
+- symbolic construction
+- numerical evaluation
+
+For example, verify that operators construct the expected expressions and that `evaluate`
+produces the correct numerical values.
+
+Avoid testing internal tree layouts unless they are part of the public API.
+
+---
+
+# Geometry
+
+Geometry tests should verify:
+
+- mappings from canonical to physical coordinates
+- Jacobians
+- inverse mappings (when applicable)
+- orientations
+- boundary mappings
+
+Prefer analytical geometries with known exact results.
+
+---
+
+# Function Spaces
+
+Test:
+
+- basis evaluation
+- interpolation
+- continuity
+- partition of unity
+- derivatives
+- degree-specific behaviour
+
+Whenever possible, compare against exact polynomial values.
+
+---
+
+# Quadrature
+
+Verify:
+
+- exact integration of polynomials or other spaces up to the expected degree
+- correct handling of weights
+- correct handling of mapped geometries
+
+---
+
+# Assemblers
+
+Assembly tests should verify:
+
+- correct matrix sizes
+- sparsity structure
+- symmetry (when expected)
+- consistency with analytical weak forms
+
+For larger systems, compare assembled operators against known reference solutions or
+invariants rather than individual entries.
+
+---
+
+# Floating-Point Comparisons
+
+Use tolerances appropriate to the computation.
+
+Prefer
+
+```
+@test isapprox(...)
+```
+
+over exact equality for floating-point results.
+
+Choose tolerances based on expected numerical error rather than arbitrary values.
+
+---
+
+# Determinism
+
+Tests should produce identical results across runs.
+
+Avoid dependence on:
+
+- random number generation (unless seeded)
+- execution order
+- iteration order of unordered collections
+- machine-specific behaviour
+
+---
+
+# Performance
+
+Performance tests generally do not belong in the standard test suite.
+
+If verifying a performance improvement:
+
+- use dedicated benchmarks
+- measure allocations when appropriate
+- avoid fragile timing-based assertions
+
+---
+
+# Inference Tests
+
+JET inference tests live under
+
+```
+test/Inference
+```
+
+They use a separate project and are only executed on supported Julia versions.
+
+Do not place ordinary correctness tests there.
+
+---
+
+# Documentation Examples
+
+If adding a `jldoctest` example:
+
+- ensure it executes successfully
+- keep it minimal
+- avoid unnecessary complexity
+
+Documentation examples should remain synchronized with the implementation.
+
+---
+
+# Test Checklist
+
+Before opening a PR, verify that:
+
+- new functionality has corresponding tests
+- tests mirror the source tree
+- new test files are registered in `runtests.jl`
+- public APIs are tested
+- edge cases are covered where appropriate
+- floating-point comparisons use appropriate tolerances
+- regression tests are added for bug fixes
+- tests are deterministic
+- the full test suite passes on supported Julia versions
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- test private implementation details unnecessarily
+- duplicate existing tests without increasing coverage
+- rely on execution order
+- hard-code floating-point values without justification
+- use unnecessarily loose tolerances
+- remove regression tests after a bug is fixed
+- write brittle tests that fail after harmless refactoring
+
+Prefer tests that validate mathematical correctness and user-visible behaviour over tests
+that mirror the implementation.

--- a/.ai/sync.sh
+++ b/.ai/sync.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)" # Mantis top-level directory.
+
+AI_DIR="$ROOT/.ai"
+GITHUB_DIR="$ROOT/.github"
+CLAUDE_DIR="$ROOT/.claude"
+
+echo "Syncing AI configurations... "
+
+
+############################################################################################
+#                                     Main instructions                                    #
+############################################################################################
+
+mkdir -p "$GITHUB_DIR"
+mkdir -p "$CLAUDE_DIR"
+
+# Create read-only copies
+install -m 644 "$AI_DIR/instructions.md" "$GITHUB_DIR/copilot-instructions.md"
+install -m 644 "$AI_DIR/instructions.md" "$ROOT/CLAUDE.md"
+
+############################################################################################
+#                                         Skills                                           #
+############################################################################################
+
+# Copy skills
+mkdir -p "$GITHUB_DIR/skills"
+mkdir -p "$CLAUDE_DIR/skills"
+for skill in "$AI_DIR"/skills/*.md; do
+    name="$(basename "$skill" .md)"
+    for agent in "$GITHUB_DIR" "$CLAUDE_DIR"; do
+        mkdir -p "$agent/skills/$name"
+        install -m 644 "$skill" "$agent/skills/$name/SKILL.md"
+    done
+done
+
+# Remove stale skills
+for dir in "$GITHUB_DIR" "$CLAUDE_DIR"; do
+    for skilldir in "$dir"/skills/*; do
+        [ -d "$skilldir" ] || continue
+
+        name="$(basename "$skilldir")"
+
+        if [[ ! -f "$AI_DIR/skills/$name.md" ]]; then
+            rm -r "$skilldir"
+        fi
+    done
+done
+
+echo "Done!"

--- a/.claude/skills/docexamples/SKILL.md
+++ b/.claude/skills/docexamples/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: Mantis Example Documentation
+description: Write and maintain example documentation pages that demonstrate how to use Mantis.jl through complete, executable examples, following the style used throughout `docs/src/Examples/`.
+---
+
+# Mantis.jl Example Documentation
+
+This skill describes how to write or update example pages under:
+
+```
+docs/src/Examples/
+```
+
+Examples are intended to teach users how to solve problems using Mantis, not to document
+individual APIs.
+
+Each example should demonstrate a complete workflow that users can adapt to their own
+problems.
+
+---
+
+# Purpose
+
+An example should answer questions such as:
+
+- How do I use this functionality?
+- What is the typical workflow?
+- Which abstractions work together?
+- What result should I expect?
+
+Examples should be practical, self-contained, and easy to adapt.
+
+---
+
+# Source Files
+
+Documentation pages are generated from
+
+```
+examples/src/*.jl
+```
+
+using Literate.jl.
+
+**Always edit the `.jl` source file**, not the generated Markdown page.
+
+Ensure that both the code and the accompanying comments are suitable for Literate.jl.
+
+---
+
+# Intended Audience
+
+Assume readers:
+
+- are familiar with Julia,
+- have basic knowledge of finite element methods,
+- are learning how to use Mantis.
+
+Explain Mantis-specific concepts, but avoid explaining general Julia syntax.
+
+---
+
+# Structure
+
+A typical example should contain:
+
+1. Introduction
+2. Problem description
+3. Geometry construction
+4. Function space definition
+5. Weak formulation or computation
+6. Results
+7. Discussion
+
+Not every example requires every section, but the progression should feel natural.
+
+Whenever possible, build on previous examples to avoid repeating code.
+
+---
+
+# Introduce the Problem
+
+Begin by describing:
+
+- the mathematical problem,
+- the objective of the example,
+- the important Mantis features being demonstrated.
+
+Keep the introduction concise.
+
+---
+
+# Build the Example Incrementally
+
+Construct the example in logical steps.
+
+For example:
+
+- define the geometry,
+- define function spaces,
+- construct forms,
+- assemble the problem,
+- solve,
+- analyze or visualize the results.
+
+Avoid presenting a large block of code without explanation.
+
+---
+
+# Explain Design Decisions
+
+Describe *why* each step is performed.
+
+For example:
+
+- why a particular geometry is chosen,
+- why a certain function space is appropriate,
+- why a specific operator is used.
+
+Help readers understand the reasoning behind the workflow.
+
+---
+
+# Focus on Public APIs
+
+Examples should use the public Mantis interface.
+
+Avoid relying on:
+
+- internal helper functions,
+- undocumented interfaces,
+- implementation details.
+
+Examples should remain valid as the implementation evolves.
+
+---
+
+# Keep Examples Realistic
+
+Use examples that resemble actual workflows.
+
+Prefer:
+
+- standard geometries,
+- commonly used function spaces,
+- realistic boundary conditions,
+- representative numerical problems.
+
+Avoid contrived examples that only demonstrate syntax.
+
+---
+
+# Keep Examples Concise
+
+Include enough code to illustrate the workflow, but avoid unnecessary complexity.
+
+If an example becomes too long, consider splitting it into multiple examples.
+
+Each example should focus on one primary concept.
+
+---
+
+# Explain the Mathematics
+
+Briefly describe the mathematical formulation when it improves understanding.
+
+For example:
+
+- the governing equations,
+- weak formulations,
+- differential operators,
+- finite element spaces.
+
+Keep mathematical discussions concise and directly relevant to the example.
+
+---
+
+# Results
+
+Conclude by explaining:
+
+- what was computed,
+- what users should observe,
+- how to interpret the output.
+
+When appropriate, discuss expected numerical behavior or convergence properties.
+
+---
+
+# Visualizations
+
+Include plots or VTK output only when they help explain the result.
+
+Visualizations should support the narrative, not replace it.
+
+Ensure generated figures are reproducible.
+
+---
+
+# Cross References
+
+Link to related documentation where appropriate.
+
+Examples include:
+
+- module documentation,
+- tutorials,
+- API documentation,
+- related examples.
+
+Avoid duplicating explanations that already exist elsewhere.
+
+---
+
+# Maintain Examples
+
+Whenever the implementation changes:
+
+- update the example,
+- update explanatory text,
+- update expected output,
+- remove obsolete code.
+
+Examples should always execute successfully.
+
+---
+
+# Writing Style
+
+Write in clear, concise English.
+
+Use comments to explain concepts rather than individual Julia statements.
+
+Prefer explaining the workflow over explaining syntax.
+
+---
+
+# Example Checklist
+
+Before opening a PR, verify that:
+
+- the example is implemented in `examples/src/`
+- the example follows the style of existing examples
+- the workflow is easy to follow
+- only public APIs are used
+- explanations focus on concepts rather than syntax
+- mathematical terminology is accurate
+- the example executes successfully
+- generated documentation renders correctly with Literate.jl
+- visualizations, if included, are reproducible
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- edit the generated Markdown files
+- rely on undocumented or internal APIs
+- include large unexplained code blocks
+- explain basic Julia syntax
+- mix multiple unrelated concepts into a single example
+- leave outdated output or figures after implementation changes
+
+Prefer examples that teach users how to solve realistic problems using Mantis rather than
+examples that merely demonstrate individual functions.

--- a/.claude/skills/docmodules/SKILL.md
+++ b/.claude/skills/docmodules/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: Mantis Module Documentation
+description: Write and maintain module documentation pages that explain the mathematical concepts, architecture, and public interfaces of a Mantis.jl module, following the style used in `docs/src/Design/Modules/`.
+---
+
+# Mantis.jl Module Documentation
+
+This skill describes how to write or update module documentation pages under
+
+```
+docs/src/Design/Modules/
+```
+
+These pages are intended to explain the design of a module to users and contributors, rather
+than documenting individual APIs.
+
+Use existing pages, such as `docs/src/Design/Modules/Forms.md`, as the primary style
+reference.
+
+---
+
+# Purpose
+
+A module page should answer questions such as:
+
+- What problem does this module solve?
+- What mathematical concepts does it implement?
+- What role does it play within Mantis?
+- How does it interact with other modules?
+- What are its primary public abstractions?
+- How should users think about using it?
+
+The emphasis is on **concepts and design**, not implementation details.
+
+---
+
+# Intended Audience
+
+Assume readers:
+
+- are familiar with Julia,
+- have some background in finite element methods,
+- may be unfamiliar with the internal architecture of Mantis.
+
+Explain mathematical concepts when they are central to understanding the module, but avoid
+turning the page into a textbook.
+
+---
+
+# Structure
+
+Follow the structure used by existing module pages.
+
+A typical page contains:
+
+1. Overview
+2. Core concepts
+3. Main abstractions
+4. Relationships to other modules
+5. Examples
+6. References (when appropriate)
+
+Not every page requires every section, but the overall organization should remain consistent
+across modules.
+
+---
+
+# Overview
+
+Begin with a concise overview describing:
+
+- the module's responsibility,
+- where it fits within the overall architecture,
+- what kinds of functionality it provides.
+
+Avoid discussing implementation files or internal organization.
+
+Focus on the conceptual role of the module.
+
+---
+
+# Explain the Mathematics
+
+Many Mantis modules represent mathematical abstractions.
+
+Describe:
+
+- the mathematical objects represented,
+- the notation used throughout the library,
+- important invariants,
+- the relationship between mathematical concepts and their implementation.
+
+For example:
+
+- differential forms
+- pullbacks
+- Hodge operators
+- finite element spaces
+- hierarchical refinement
+
+Use precise mathematical terminology.
+
+---
+
+# Explain the Design
+
+Describe the design decisions behind the module.
+
+For example:
+
+- why symbolic expressions are used,
+- why evaluation is lazy,
+- why canonical coordinates are preferred,
+- how abstraction boundaries are maintained.
+
+Help readers understand *why* the module is designed the way it is.
+
+---
+
+# Introduce Public Abstractions
+
+Present the important public types and interfaces.
+
+Explain:
+
+- what they represent,
+- when they should be used,
+- how they relate to one another.
+
+Do not duplicate API docstrings. Instead, extensively embed the docstrings into the
+documentation page, creating a cohesive narrative.
+
+---
+
+# Describe Module Relationships
+
+Explain how the module interacts with the rest of Mantis.
+
+Examples include:
+
+- Geometry provides mappings used by Forms.
+- FunctionSpaces provide basis functions consumed by Forms.
+- Assemblers evaluate symbolic expressions built by Forms.
+
+Help readers understand the flow of information through the library.
+
+---
+
+# Use Examples
+
+Prefer small conceptual examples over exhaustive tutorials.
+
+Examples should illustrate:
+
+- typical workflows,
+- important abstractions,
+- common usage patterns.
+
+Avoid large blocks of implementation code.
+
+---
+
+# Maintain Conceptual Level
+
+Keep the documentation focused on design.
+
+Prefer explaining:
+
+- why something exists,
+- what abstraction it provides,
+- how it fits into the library.
+
+Avoid describing:
+
+- internal helper functions,
+- implementation details,
+- private data structures,
+- optimization techniques unless they motivate the design.
+
+---
+
+# Cross References
+
+Link to related documentation where appropriate.
+
+Examples include:
+
+- other module pages,
+- tutorials,
+- examples,
+- API documentation.
+
+Use cross references to help readers navigate the documentation rather than duplicating
+content.
+
+---
+
+# Mathematical Notation
+
+When introducing notation:
+
+- define symbols before using them,
+- use consistent notation throughout the page,
+- match notation used elsewhere in the documentation.
+
+Prefer mathematical clarity over excessive formalism.
+
+---
+
+# Diagrams
+
+When appropriate, include simple diagrams illustrating:
+
+- module relationships,
+- data flow,
+- mathematical structures,
+- abstraction layers.
+
+Diagrams should clarify the design rather than decorate the page.
+
+---
+
+# Keep Documentation Current
+
+Whenever the module changes:
+
+- update the conceptual description,
+- update examples,
+- update descriptions of public abstractions,
+- update relationships to other modules.
+
+Documentation should evolve together with the implementation.
+
+---
+
+# Documentation Checklist
+
+Before opening a PR, verify that:
+
+- the page follows the style of existing module documentation (especially
+  `docs/src/Design/Modules/Forms.md`)
+- the module's purpose is clearly explained
+- the mathematical concepts are described accurately
+- the main abstractions are introduced
+- relationships to other modules are explained
+- examples are concise and illustrative
+- implementation details are minimized
+- terminology is consistent with the rest of the documentation
+- cross references are updated where appropriate
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- duplicate API docstrings
+- document individual methods in detail
+- explain the implementation file layout
+- include unnecessary implementation details
+- introduce notation without defining it
+- turn the page into a complete mathematical reference
+
+Prefer documentation that explains the *design philosophy* and *conceptual model* of the
+module over documentation that mirrors the source code.

--- a/.claude/skills/docmodules/SKILL.md
+++ b/.claude/skills/docmodules/SKILL.md
@@ -1,265 +1,302 @@
 ---
 name: Mantis Module Documentation
-description: Write and maintain module documentation pages that explain the mathematical concepts, architecture, and public interfaces of a Mantis.jl module, following the style used in `docs/src/Design/Modules/`.
+description: Write or update a module design page under `docs/src/Design/Modules/` for a Mantis.jl module — explaining its purpose, mathematical concepts, public abstractions, and relationships to other modules. Use this whenever the user asks to document a module, write or improve a module page, fill in a stub or `@autodocs` placeholder, describe what a module does or how it fits into Mantis, or refresh module docs after a refactor. Reach for it even when they only say something like "document Quadrature" or "the Geometry docs are out of date" without naming the docs directory.
 ---
 
 # Mantis.jl Module Documentation
 
-This skill describes how to write or update module documentation pages under
+Module pages under `docs/src/Design/Modules/` explain **what a module represents and why its
+abstractions exist**. They sit between the theory pages and the API reference: a reader who
+knows FEM but not Mantis should come away with the module's mental model.
+
+This is not an API dump. Docstrings are *woven into* a narrative, not listed. If the page
+reads like a table of contents for the source tree, it has failed.
+
+`docs/src/Design/Modules/Forms.md` is the canonical style reference; `Points.md` is the
+cleanest short example of the same style. Read at least one before writing.
+
+## Before writing
+
+Documentation that drifts from the code is worse than none, so start from the source:
+
+1. **Read the module.** The types, their parameters, and the existing docstrings. Type
+   parameters usually *are* the mental model — `AbstractForm{manifold_dim, form_rank,
+   expression_rank}` tells you what a form is in Mantis.
+2. **Inventory what must be covered.** `makedocs` is configured with `modules=[...]`, which
+   makes Documenter **fail the build if any docstring from the module is missing from the
+   docs**. List the module's public names and plan for each to land in some `@docs` block.
+   This is why unwritten pages use `@autodocs` — it satisfies the check trivially. Replacing
+   such a stub means accounting for everything it was silently covering.
+3. **Check the existing page.** Several are stubs (`Quadrature.md`, `Mesh.md`,
+   `FunctionSpaces.md`); a few are substantial. Keep whatever is already accurate.
+4. **Find the neighbours.** Which modules does it depend on, and which depend on it? Skim
+   their pages so cross-references and terminology line up.
+
+Infer the module and depth from the request; ask only when genuinely ambiguous.
+
+## Page anatomy
+
+A page sets the module for docstring lookup, then a title carrying the page anchor
+`Doc<Module>Module`, then the module's own docstring:
+
+````markdown
+```@meta
+CurrentModule = Mantis.Points
+```
+# [Points](@id DocPointsModule)
+
+```@docs
+Points
+```
+
+## Overview
+...
+````
+
+A page may switch `CurrentModule` partway through — `TensorProducts.md` starts at `Mantis`
+to document the module itself, then narrows — so do that when you need names from two scopes.
+
+Section headings carry anchors named `<Module><Topic>` in CamelCase: `PointsAbstract`,
+`PointsConcrete`, `FormsCreation`, `TensorProductsRequirement`. Add an anchor to any section
+another page will want to link to; sections nobody links to don't need one.
+
+Typical section flow, adapted to the module rather than applied mechanically:
+
+1. **Overview** — the problem the module solves and its role in Mantis
+2. **Core concepts** — the mathematics, only as deep as the design requires
+3. **Main abstractions** — the public types, in the order a reader meets them
+4. **Relationships to other modules** — what flows in and out
+5. **Examples** — short and conceptual
+6. **References** — when the module implements published work
+
+`Points.md` follows almost exactly this. `Forms.md` instead organises around *creating* forms
+and then *operating on* them, because that is how users actually think about forms. Follow
+the module's own logic rather than forcing the list.
+
+## Writing the narrative
+
+**Lead with the problem, not the type.** `Points.md` opens by explaining that evaluation
+happens in the canonical domain ``[0, 1]^n`` and that the module exists to keep the meaning
+of "a point" consistent across the library. Only then does `AbstractPoints` appear. A reader
+who understands the problem can half-predict the abstraction, which is what makes it stick.
+
+**Weave docstrings into prose.** Introduce what a type is for, include it, then connect it to
+what comes next:
+
+````markdown
+All point sets in Mantis are subtypes of `AbstractPoints`:
+
+```@docs
+AbstractPoints
+```
+
+The module requires every concrete subtype to implement `get_num_points`:
+
+```@docs
+get_num_points
+```
+
+From this, other methods can be automatically derived, without needing manual
+implementation:
+
+```@docs
+get_manifold_dim
+get_input_points
+```
+````
+
+Group related names into one block when a single sentence introduces them all; give a name
+its own block when it deserves its own introduction. Never restate what the docstring already
+says — if you catch yourself paraphrasing one you just included, cut the prose (or fix the
+docstring).
+
+Each docstring may appear in **exactly one** `@docs` block across the whole documentation, or
+the build errors on a duplicate. When a name belongs to another module's page, link instead:
+``[`FunctionSpaces.AbstractFESpace`](@ref)``.
+
+**Explain design choices where they illuminate the abstraction.** Why forms evaluate in
+canonical coordinates and pull back; why `PointSet` stores coordinates dimension-wise, so
+tensor-product routines can take a whole dimension in one access without allocating; why
+`TensorProducts` centralises index bookkeeping instead of letting each module reinvent it.
+These are the sentences readers remember. A choice with no user-visible consequence is
+implementation detail — leave it out.
+
+**Mark internals explicitly** when a reader genuinely benefits from knowing them, using the
+established admonition:
+
+````markdown
+### [Internals: How a `FormSpace` is evaluated](@id FormsInternalEvaluateFormSpace)
+!!! note "Internal behaviour"
+    We explain how a `FormSpace` is evaluated. However, this is considered an
+    implementational detail.
+````
+
+Use it sparingly, for behaviour that shapes how users reason about results — not as licence
+for a tour of private helpers.
+
+## Mathematics and notation
+
+Define notation before using it, and match what the theory pages and neighbouring module
+pages already use: ``n`` for manifold dimension, ``m`` for embedding dimension, ``\Omega^0
+:= [0, 1]^n`` for the canonical domain, ``\Lambda^k_h`` for discrete form spaces, ``\Phi``
+for geometry mappings.
+
+Inline math uses double backticks (``` ``[0, 1]^n`` ```); displayed math uses ` ```math `
+blocks. Include only the mathematics the design rests on. `Geometry.md` develops the
+tensor-product geometry and its Jacobian in full because the module's entire structure
+follows from it — that depth is earned, not a default.
+
+## Examples
+
+Prefer one short `@repl` session showing the abstraction doing its job. Name the session so
+several blocks can share state:
+
+````markdown
+```@repl CreatingFormSpaces
+using Mantis
+B = FunctionSpaces.create_bspline_space((0.0, 0.0), (1.0, 1.0), (4, 4), (3, 3), (2, 2))
+```
+we can use this function space to create two different spaces: one for a ``0``-form
+``\Lambda^0_h`` and one for a ``2``-form ``\Lambda^2_h``.
+```@repl CreatingFormSpaces
+Λ⁰ₕ = Forms.FormSpace(0, B, "0-form")
+Λ²ₕ = Forms.FormSpace(2, B, "2-form")
+```
+````
+
+`@repl` blocks **execute during the build**, so every line must run against the current API.
+Verify them instead of writing plausible-looking code. Full workflows belong in
+`docs/src/Examples/` — link there rather than reproducing them.
+
+## Cross-references and citations
+
+- Module page: `[Geometry](@ref DocGeometryModule)`, or `[Quadrature](@ref)` when the page
+  title alone resolves
+- Section: `[Operations on Forms](@ref FormsOperations)`
+- API name: ``[`FunctionSpaces.AbstractFESpace`](@ref)``
+- Theory page: `[differential form theory page](@ref TheoryForms)`
+- Literature: `[Arnold2010](@cite)` or `[Bezanson2017, Bezanson2018](@cite)`, with keys in
+  `docs/src/refs.bib`
+
+Link rather than duplicate: when your page needs a concept another page owns, one sentence
+plus a reference beats a paragraph of restatement.
+
+A "Relationships to Other Modules" section works well as a short bulleted list, each entry
+naming what is given or taken:
+
+````markdown
+- **[Geometry](@ref DocGeometryModule)**: evaluates geometries by mapping points in the
+  canonical domain to a set of points on a given element.
+- [Quadrature](@ref): quadrature rules store their nodes as `AbstractPoints`.
+````
+
+Add a diagram only when the architecture or data flow is genuinely hard to follow in prose.
+
+## Registering and verifying the page
+
+A new page is invisible until listed in `docs/make.jl`, in the `Modules` entry of `Design`
+(alphabetical) and — if the module isn't there yet — in `makedocs(modules=[...])`. Both are
+easy to forget and both fail confusingly.
+
+Then build, because every failure mode here is a build-time one:
+
+```bash
+julia --project=docs -e 'using Pkg; Pkg.instantiate(); include("docs/make.jl")'
+```
+
+Watch for docstrings from the module that no block includes, the same docstring included
+twice, unresolved `@ref` targets, and `@repl` blocks that error. If the build breaks for
+reasons unrelated to your page, say so plainly rather than reporting the page as verified.
+
+The block and anchor tables at the end of this page have the exact syntax when you need it.
+
+## What to avoid
+
+- Organising sections around source files, or mentioning file layout at all
+- Listing docstrings with no connecting prose, or paraphrasing docstrings you just included
+- Documenting private helpers, internal data structures, or method-by-method behaviour
+- Mathematical development beyond what the design needs
+- Notation introduced without definition, or diverging from the rest of the docs
+- Restating what a tutorial, example, or theory page already owns
+
+## Final check
+
+- Follows `Forms.md` / `Points.md`: `@meta` header, `Doc<Module>Module` anchor, module
+  docstring, narrative with woven `@docs` blocks
+- Purpose and mathematical concepts are clear to someone new to Mantis
+- Every public name of the module appears in exactly one `@docs` block somewhere in the docs
+- Relationships to other modules are explained and cross-referenced
+- Examples are short, conceptual, and actually run
+- Terminology and notation match the surrounding documentation
+- Page is registered in `docs/make.jl` and the docs build
+
+## Documenter reference
+
+### Blocks
+
+| Block | Purpose | Notes |
+|---|---|---|
+| ` ```@meta ` | Set `CurrentModule` for unqualified docstring lookup | First block on the page; may be repeated to switch scope mid-page |
+| ` ```@docs ` | Include named docstrings | One name per line. Each docstring may appear only once in the whole doc set |
+| ` ```@autodocs ` | Include every docstring of a module | What unwritten stub pages use; replace with narrative `@docs` blocks |
+| ` ```@repl <name> ` | Executed REPL session, output shown | Runs at build time. Named sessions share state across blocks |
+| ` ```math ` | Displayed equation | Inline math uses double backticks instead |
+| `!!! note "..."` | Admonition | The established one is `!!! note "Internal behaviour"` |
+
+Disambiguating an overloaded method inside a `@docs` block needs the full signature:
 
 ```
-docs/src/Design/Modules/
+evaluate(::AbstractForm{manifold_dim}, ::Int, ::Points.AbstractPoints{manifold_dim}) where {manifold_dim}
 ```
 
-These pages are intended to explain the design of a module to users and contributors, rather
-than documenting individual APIs.
+Callable structs (functors) can trip Documenter's docstring check — see the comment in
+`docs/make.jl`; the workaround is to attach the docstring to the type definition.
 
-Use existing pages, such as `docs/src/Design/Modules/Forms.md`, as the primary style
-reference.
+### Anchors
 
----
+| Kind | Pattern | Examples |
+|---|---|---|
+| Module page title | `Doc<Module>Module` | `DocPointsModule`, `DocGeometryModule`, `DocTensorProductsModule` |
+| Section within a page | `<Module><Topic>` | `PointsAbstract`, `PointsConcrete`, `FormsCreation`, `TensorProductsRequirement` |
+| Theory pages | descriptive | `TheoryForms`, `FEEC`, `ExtCoeffs` |
 
-# Purpose
+`Assemblers.md` declares `DocAssemblyModule`, not `DocAssemblersModule`. Match whatever a
+page already declares rather than "correcting" it — other pages link to it.
 
-A module page should answer questions such as:
+### Page skeleton
 
-- What problem does this module solve?
-- What mathematical concepts does it implement?
-- What role does it play within Mantis?
-- How does it interact with other modules?
-- What are its primary public abstractions?
-- How should users think about using it?
+````markdown
+```@meta
+CurrentModule = Mantis.<Module>
+```
+# [<Module>](@id Doc<Module>Module)
 
-The emphasis is on **concepts and design**, not implementation details.
+```@docs
+<Module>
+```
 
----
+## Overview
 
-# Intended Audience
+<The problem the module solves and its role in Mantis. Define any notation the page relies
+on, such as the canonical domain.>
 
-Assume readers:
+## [<Core concept>](@id <Module>Concepts)
 
-- are familiar with Julia,
-- have some background in finite element methods,
-- may be unfamiliar with the internal architecture of Mantis.
+<The mathematics, to the depth the design requires.>
 
-Explain mathematical concepts when they are central to understanding the module, but avoid
-turning the page into a textbook.
+## [<Main abstraction>](@id <Module>Abstract)
 
----
+<Introduce the type, include it, then relate it to what follows.>
 
-# Structure
+```@docs
+Abstract<Thing>
+```
 
-Follow the structure used by existing module pages.
+## [Relationships to Other Modules](@id <Module>Relationships)
 
-A typical page contains:
+- **[<Other module>](@ref Doc<Other>Module)**: <what flows between them>
 
-1. Overview
-2. Core concepts
-3. Main abstractions
-4. Relationships to other modules
-5. Examples
-6. References (when appropriate)
+## References
 
-Not every page requires every section, but the overall organization should remain consistent
-across modules.
-
----
-
-# Overview
-
-Begin with a concise overview describing:
-
-- the module's responsibility,
-- where it fits within the overall architecture,
-- what kinds of functionality it provides.
-
-Avoid discussing implementation files or internal organization.
-
-Focus on the conceptual role of the module.
-
----
-
-# Explain the Mathematics
-
-Many Mantis modules represent mathematical abstractions.
-
-Describe:
-
-- the mathematical objects represented,
-- the notation used throughout the library,
-- important invariants,
-- the relationship between mathematical concepts and their implementation.
-
-For example:
-
-- differential forms
-- pullbacks
-- Hodge operators
-- finite element spaces
-- hierarchical refinement
-
-Use precise mathematical terminology.
-
----
-
-# Explain the Design
-
-Describe the design decisions behind the module.
-
-For example:
-
-- why symbolic expressions are used,
-- why evaluation is lazy,
-- why canonical coordinates are preferred,
-- how abstraction boundaries are maintained.
-
-Help readers understand *why* the module is designed the way it is.
-
----
-
-# Introduce Public Abstractions
-
-Present the important public types and interfaces.
-
-Explain:
-
-- what they represent,
-- when they should be used,
-- how they relate to one another.
-
-Do not duplicate API docstrings. Instead, extensively embed the docstrings into the
-documentation page, creating a cohesive narrative.
-
----
-
-# Describe Module Relationships
-
-Explain how the module interacts with the rest of Mantis.
-
-Examples include:
-
-- Geometry provides mappings used by Forms.
-- FunctionSpaces provide basis functions consumed by Forms.
-- Assemblers evaluate symbolic expressions built by Forms.
-
-Help readers understand the flow of information through the library.
-
----
-
-# Use Examples
-
-Prefer small conceptual examples over exhaustive tutorials.
-
-Examples should illustrate:
-
-- typical workflows,
-- important abstractions,
-- common usage patterns.
-
-Avoid large blocks of implementation code.
-
----
-
-# Maintain Conceptual Level
-
-Keep the documentation focused on design.
-
-Prefer explaining:
-
-- why something exists,
-- what abstraction it provides,
-- how it fits into the library.
-
-Avoid describing:
-
-- internal helper functions,
-- implementation details,
-- private data structures,
-- optimization techniques unless they motivate the design.
-
----
-
-# Cross References
-
-Link to related documentation where appropriate.
-
-Examples include:
-
-- other module pages,
-- tutorials,
-- examples,
-- API documentation.
-
-Use cross references to help readers navigate the documentation rather than duplicating
-content.
-
----
-
-# Mathematical Notation
-
-When introducing notation:
-
-- define symbols before using them,
-- use consistent notation throughout the page,
-- match notation used elsewhere in the documentation.
-
-Prefer mathematical clarity over excessive formalism.
-
----
-
-# Diagrams
-
-When appropriate, include simple diagrams illustrating:
-
-- module relationships,
-- data flow,
-- mathematical structures,
-- abstraction layers.
-
-Diagrams should clarify the design rather than decorate the page.
-
----
-
-# Keep Documentation Current
-
-Whenever the module changes:
-
-- update the conceptual description,
-- update examples,
-- update descriptions of public abstractions,
-- update relationships to other modules.
-
-Documentation should evolve together with the implementation.
-
----
-
-# Documentation Checklist
-
-Before opening a PR, verify that:
-
-- the page follows the style of existing module documentation (especially
-  `docs/src/Design/Modules/Forms.md`)
-- the module's purpose is clearly explained
-- the mathematical concepts are described accurately
-- the main abstractions are introduced
-- relationships to other modules are explained
-- examples are concise and illustrative
-- implementation details are minimized
-- terminology is consistent with the rest of the documentation
-- cross references are updated where appropriate
-
----
-
-# Things to Avoid
-
-Do not:
-
-- duplicate API docstrings
-- document individual methods in detail
-- explain the implementation file layout
-- include unnecessary implementation details
-- introduce notation without defining it
-- turn the page into a complete mathematical reference
-
-Prefer documentation that explains the *design philosophy* and *conceptual model* of the
-module over documentation that mirrors the source code.
+<Only when the module implements published work: [Key](@cite).>
+````

--- a/.claude/skills/docstrings/SKILL.md
+++ b/.claude/skills/docstrings/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: Mantis Docstrings
+description: Write clear, consistent, and informative docstrings for Mantis.jl that follow the project's documentation style and accurately describe the public API.
+---
+
+# Mantis.jl Docstrings
+
+This skill describes how to write docstrings for Mantis.jl.
+
+Public APIs should be documented clearly enough that users can understand how to use them
+without reading the implementation.
+
+Docstrings are part of the public interface and should evolve alongside the code.
+
+---
+
+# What Should Be Documented
+
+Document all public:
+
+- functions
+- methods with user-facing behavior
+- types
+- macros
+- constants when appropriate
+
+Internal helper functions generally do not require docstrings unless they implement
+important algorithms or are likely to be reused.
+
+---
+
+# Follow Existing Style
+
+Match the style already used throughout `src/`.
+
+Do not introduce a new documentation format.
+
+Public docstrings should use section headings where appropriate:
+
+- `# Arguments` (when not obvious from the name)
+- `# Returns` (when not obvious from the name)
+- `# Exceptions`
+- `# Examples` (whenever possible)
+
+Only include sections that add value. Avoid empty or trivial sections.
+
+---
+
+# Function Docstrings
+
+Begin with a concise summary describing what the function does.
+
+Prefer describing the operation rather than the implementation.
+
+Prefer:
+
+> Compute the pullback of a differential form onto the reference domain.
+
+Avoid:
+
+> This function loops over the basis functions and applies pullback transformations.
+
+Implementation details belong in comments, not the public documentation.
+
+---
+
+# Arguments
+
+Include an `# Arguments` section whenever the function accepts non-obvious parameters.
+
+For each argument, describe:
+
+- its purpose
+- expected type or interface (when not obvious)
+- any assumptions or restrictions
+
+Explain the _meaning_ of an argument, not merely its Julia type.
+
+Prever:
+
+```
+- `geometry`: Geometry used to map the canonical element to physical space.
+```
+
+Avoid:
+
+```
+- `geometry`: An `AbstractGeometry`.
+```
+
+---
+
+# Returns
+
+Include a `# Returns` section whenever the return value is not immediately obvious.
+
+Describe:
+
+- what is returned
+- important guarantees
+- ownership or mutability when relevant
+
+Focus on the semantic meaning of the result rather than its exact implementation type unless
+that type is important to users.
+
+---
+
+# Exceptions
+
+Include a `# Exceptions` section when the function intentionally throws errors under
+documented conditions.
+
+Describe:
+
+- when an exception occurs
+- why it occurs
+
+---
+
+# Examples
+
+Include `# Examples` when they improve understanding (should be often).
+
+Use `jldoctest` blocks.
+
+Examples should:
+
+- be minimal
+- be complete
+- execute successfully
+- demonstrate typical usage
+
+Prefer realistic examples over artificial ones.
+
+---
+
+# Type Docstrings
+
+Describe:
+
+- what the type represents
+- its role within Mantis
+- important invariants
+- when users should use it
+
+Avoid documenting every field unless users are expected to construct the type directly.
+
+Explain the abstraction before the representation.
+
+---
+
+# Mathematical Concepts
+
+Mantis is based on FEEC and differential geometry.
+
+When documenting mathematical objects:
+
+- use correct mathematical terminology
+- define symbols when necessary
+- distinguish between canonical and physical domains
+- distinguish symbolic expressions from evaluated quantities
+
+Assume readers have some numerical PDE background, but avoid unnecessary jargon.
+
+---
+
+# Generic Interfaces
+
+Abstract interfaces should document:
+
+- the purpose of the interface
+- required methods
+- expected behavior
+- semantic contracts
+
+Concrete implementations should document only behavior that differs from or extends the
+interface documentation.
+
+Avoid duplicating documentation across implementations.
+
+---
+
+# Keep Documentation Focused
+
+Describe:
+
+- what the API does
+- why it exists
+- when it should be used
+
+Avoid lengthy implementation discussions.
+
+If implementation details are important for maintainers, place them in comments rather than
+docstrings.
+
+---
+
+# Maintain Accuracy
+
+Whenever changing behavior:
+
+- update the corresponding docstring
+- update examples
+- update documented exceptions
+- update return value descriptions if necessary
+
+Outdated documentation is often more harmful than missing documentation.
+
+---
+
+# Cross References
+
+When appropriate, reference related functionality using Julia's documentation conventions.
+
+Examples include:
+
+- related operators
+- complementary types
+- alternative constructors
+
+Use cross references to help users discover the API rather than repeating documentation.
+
+---
+
+# Writing Style
+
+Write in clear, concise English.
+
+Prefer:
+
+- active voice
+- complete sentences
+- consistent terminology
+- precise mathematical language
+
+Avoid:
+
+- unnecessary verbosity
+- implementation-specific language
+- ambiguous wording
+- unexplained abbreviations
+
+Use the same terminology consistently throughout the codebase.
+
+---
+
+# Documentation Checklist
+
+Before opening a PR, verify that:
+
+- every new public API has a docstring
+- docstrings follow the existing project style
+- `# Arguments`, `# Returns`, `# Exceptions`, and `# Examples` sections are included where
+  appropriate
+- examples are valid `jldoctest`s when provided
+- mathematical terminology is accurate
+- documentation matches the implementation
+- related documentation is updated when behavior changes
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- document the implementation instead of the interface
+- repeat obvious type information without explanation
+- leave stale examples after refactoring
+- duplicate identical documentation across multiple methods
+- omit documentation for new public APIs
+- include speculative or future behavior
+
+Prefer documentation that explains the purpose and semantics of an API over documentation
+that merely describes its syntax.

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: Mantis Feature Development
+description: Implement new functionality in the Mantis.jl finite element library while preserving FEEC abstractions, module boundaries, and project conventions.
+---
+
+# Mantis.jl Feature Development
+
+This skill describes how to correctly implement new functionality in Mantis.jl.
+
+## Core Principles
+
+Mantis is organized as a layered FEEC library.
+
+Every new feature should preserve the existing abstraction hierarchy.
+
+Never bypass existing abstractions simply because something is easier to implement.
+
+Whenever possible, implement functionality by extending existing interfaces instead of
+introducing parallel implementations.
+
+---
+
+# Module Dependency Order
+
+Modules have a strict dependency order.
+
+```
+GeneralHelpers
+    ↓
+Mesh
+    ↓
+Points
+    ↓
+Hierarchy
+    ↓
+Geometry
+    ↓
+FunctionSpaces
+    ↓
+Quadrature
+    ↓
+Forms
+    ↓
+Analysis
+    ↓
+Assemblers
+    ↓
+TimeIntegrators
+    ↓
+Plot
+```
+
+A module may depend on modules above it.
+
+Avoid introducing dependencies in the opposite direction.
+
+---
+
+# Before Implementing
+
+First identify which layer owns the feature.
+
+Typical ownership:
+
+- mesh topology → Mesh
+- physical mappings → Geometry
+- finite element spaces → FunctionSpaces
+- symbolic FEEC operators → Forms
+- numerical integration → Quadrature
+- global matrix assembly → Assemblers
+- postprocessing → Analysis
+- visualization → Plot
+
+Avoid implementing functionality in a higher layer when it naturally belongs in a lower one.
+
+---
+
+# Module Structure
+
+Each module follows the same pattern.
+
+```
+ModuleName.jl
+
+module ModuleName
+
+exports
+
+abstract types
+
+fallback interface methods
+
+include("...")
+
+end
+```
+
+When adding new interfaces:
+
+1. add the abstract interface
+2. provide documented fallback methods throwing `MethodError`
+3. implement concrete types in separate files
+4. include those files from the module
+
+Do not place large implementations directly inside `ModuleName.jl`.
+
+---
+
+# Geometry
+
+Geometry maps
+
+```
+[0,1]^n
+    →
+physical space
+```
+
+Evaluation always occurs on the canonical domain.
+
+Do not evaluate basis functions directly in physical coordinates.
+
+Coordinate transforms belong inside Geometry.
+
+Assemblers and Forms should remain geometry-independent.
+
+---
+
+# Forms
+
+Forms are symbolic expression trees.
+
+Operators such as
+
+- d
+- ★
+- δ
+- ∧
+- ∫
+- ♯
+
+construct expressions.
+
+They do **not** perform numerical evaluation.
+
+Evaluation happens exclusively through `evaluate`.
+
+When implementing a new operator:
+
+- preserve lazy evaluation
+- create new expression nodes
+- extend `evaluate`
+- avoid eager computation
+
+---
+
+# Function Spaces
+
+New finite element spaces should extend `AbstractFESpace` and the corresponding documented
+abstract methods.
+
+Reuse existing interfaces whenever possible.
+
+---
+
+# Assemblers
+
+Assemblers convert symbolic Forms into sparse matrices.
+
+Weak formulations should build symbolic expressions.
+
+Avoid inserting numerical kernels directly into weak formulations.
+
+If new assembly logic is required:
+
+- extend the assembler interface
+- preserve sparse assembly
+- reuse existing quadrature infrastructure
+
+---
+
+# Public API
+
+When adding public functionality use `export` or `public` as appropriate
+
+Keep exported APIs minimal.
+
+---
+
+# Documentation
+
+Public APIs require docstrings.
+
+Use the project style:
+
+- Arguments (when not obvious from the name)
+- Returns (when not obvious from the name)
+- Examples (when useful)
+
+Follow existing documentation style instead of inventing new conventions.
+
+---
+
+# Tests
+
+Every feature should include tests.
+
+Mirror the source layout.
+
+Example:
+
+```
+src/Geometry/NewGeometry.jl
+
+↓
+
+test/Geometry/NewGeometryTests.jl
+```
+
+Register new test files in the corresponding
+
+```
+test/<Module>/runtests.jl
+```
+
+Test files contain top-level `@test`s.
+
+Do not wrap them in additional `@testset`s.
+
+---
+
+# Extensions
+
+Optional functionality belongs in package extensions.
+
+Current example:
+
+```
+ext/MakieExt.jl
+```
+
+Do not introduce hard dependencies for optional features.
+
+---
+
+# Style
+
+Follow BlueStyle with the repository's formatter configuration.
+
+Match surrounding code.
+
+Prefer extending existing APIs over introducing new naming patterns.
+
+---
+
+# Implementation Checklist
+
+Before opening a PR verify that:
+
+- feature lives in the correct module
+- abstraction boundaries are preserved
+- module dependency order is respected
+- lazy evaluation is preserved (Forms)
+- new public APIs are documented
+- exports are updated
+- tests are added
+- module `runtests.jl` registers the new tests
+- Julia 1.10 compatibility is preserved
+- optional dependencies use package extensions
+
+---
+
+# Things to Avoid
+
+Do not
+
+- evaluate symbolic Forms eagerly
+- couple Assemblers to specific form or finite element spaces
+- introduce circular module dependencies
+- perform geometry computations outside Geometry
+- duplicate existing interfaces
+- add optional packages as hard dependencies

--- a/.claude/skills/refactoring/SKILL.md
+++ b/.claude/skills/refactoring/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: Mantis Refactoring
+description: Refactor Mantis.jl code while preserving FEEC abstractions, module boundaries, API stability, and numerical correctness.
+---
+
+# Mantis.jl Refactoring
+
+This skill describes how to safely refactor existing code in Mantis.jl.
+
+The primary objective of a refactor is to improve the implementation **without changing
+observable behaviour**.
+
+Observable behaviour includes:
+
+- numerical results
+- public APIs
+- supported Julia versions
+- performance characteristics (unless intentionally improved)
+- documentation semantics
+
+When in doubt, prefer smaller, incremental refactors over large rewrites.
+
+---
+
+# Understand Before Changing
+
+Before modifying code, identify:
+
+- which module owns the functionality
+- whether the code is part of the public API
+- whether it implements an interface used elsewhere
+- whether it is performance critical
+
+Read the module's top-level `<Module>.jl` file first to understand the intended abstractions
+before changing implementation files.
+
+Never refactor code that you do not yet understand.
+
+---
+
+# Preserve Module Boundaries
+
+Mantis follows a layered architecture.
+
+```
+GeneralHelpers
+    ↓
+Mesh
+    ↓
+Points
+    ↓
+Hierarchy
+    ↓
+Geometry
+    ↓
+FunctionSpaces
+    ↓
+Quadrature
+    ↓
+Forms
+    ↓
+Analysis
+    ↓
+Assemblers
+    ↓
+TimeIntegrators
+    ↓
+Plot
+```
+
+Do not introduce dependencies that violate this ordering.
+
+If functionality naturally belongs in a lower layer, move it there rather than duplicating
+it in higher layers.
+
+---
+
+# Preserve Existing Abstractions
+
+Prefer strengthening existing abstractions over introducing new ones.
+
+When similar implementations exist:
+
+- extract common functionality
+- reuse existing interfaces
+- eliminate duplication
+
+Avoid introducing parallel interfaces that solve the same problem.
+
+If multiple concrete types implement nearly identical logic, consider moving shared
+behaviour into common helper functions or abstract interface methods.
+
+---
+
+# Preserve FEEC Semantics
+
+The FEEC abstractions are fundamental to Mantis.
+
+In particular:
+
+- Forms represent symbolic expression trees.
+- Operators build expressions.
+- Evaluation occurs through `evaluate`.
+- Assemblers consume symbolic expressions.
+- Geometry handles mappings between canonical and physical domains.
+
+Do not blur these responsibilities during refactoring.
+
+Avoid introducing shortcuts that bypass symbolic representations.
+
+---
+
+# Preserve Public APIs
+
+Refactoring should not require downstream users to modify their code.
+
+Avoid:
+
+- renaming exported symbols
+- changing method signatures
+- changing return types
+- changing documented behaviour
+
+If a breaking change is unavoidable, isolate it into a dedicated change rather than
+combining it with unrelated refactoring.
+
+---
+
+# Reduce Duplication Carefully
+
+When removing duplicated code:
+
+- verify that implementations are truly equivalent
+- preserve specialized behaviour
+- avoid over-generalization
+
+A small amount of duplication is preferable to an abstraction that obscures the mathematics
+or FEEC concepts.
+
+---
+
+# Improve Readability
+
+Refactoring should make code easier to understand.
+
+Common improvements include:
+
+- extracting helper functions
+- improving function names
+- reducing nesting
+- separating independent responsibilities
+- simplifying dispatch
+
+Avoid introducing additional layers of abstraction unless they clearly improve
+maintainability.
+
+---
+
+# Preserve Performance
+
+Many parts of Mantis execute inside assembly loops.
+
+When refactoring performance-critical code:
+
+- avoid unnecessary allocations
+- preserve type stability
+- avoid introducing dynamic dispatch
+- keep hot paths simple
+
+Prefer measuring performance before and after significant refactors.
+
+Do not assume cleaner code is automatically faster.
+
+---
+
+# Preserve Generic Programming
+
+Mantis relies heavily on Julia's multiple dispatch.
+
+Prefer extending existing generic interfaces rather than introducing type checks or
+conditional logic.
+
+Avoid replacing dispatch with manual branching based on concrete types.
+
+---
+
+# Documentation
+
+If public code is moved or reorganized:
+
+- keep docstrings attached to the public API
+- update examples if needed
+- ensure exported symbols remain documented
+
+Internal helper functions generally do not require extensive documentation unless they
+implement non-trivial algorithms.
+
+---
+
+# Tests
+
+Every refactor should preserve existing test coverage.
+
+If behaviour is unchanged:
+
+- existing tests should continue to pass without modification
+
+If code becomes easier to test:
+
+- consider adding focused regression tests
+- preserve mirror structure between `src/` and `test/`
+
+Never remove tests solely because the implementation changed.
+
+---
+
+# Optional Dependencies
+
+Do not convert weak dependencies into hard dependencies.
+
+Functionality related to optional packages should remain inside package extensions under
+`ext/`.
+
+---
+
+# Refactoring Checklist
+
+Before opening a PR, verify that:
+
+- no public APIs changed unintentionally
+- module dependency order is preserved
+- FEEC abstractions remain intact
+- symbolic evaluation remains lazy
+- geometry responsibilities remain in Geometry
+- duplicated logic has been reduced appropriately
+- performance-critical code remains type-stable
+- existing tests pass
+- new regression tests are added where appropriate
+- documentation remains accurate
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- rewrite working code without a clear objective
+- introduce circular module dependencies
+- replace dispatch with manual type checks
+- move geometry logic into Assemblers or Forms
+- eagerly evaluate symbolic expressions
+- over-generalize small pieces of duplicated code
+- combine behavioural changes with large refactors
+- sacrifice numerical clarity for clever abstractions
+
+Prefer refactors that are incremental, well-scoped, and easy to review.

--- a/.claude/skills/tests/SKILL.md
+++ b/.claude/skills/tests/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: Mantis Testing
+description: Write and maintain tests for Mantis.jl that verify correctness, numerical accuracy, API behavior, and regression safety while following the project's testing conventions.
+---
+
+# Mantis.jl Testing
+
+This skill describes how to write tests for Mantis.jl.
+
+Tests should verify **observable behaviour**, not implementation details.
+
+Prefer testing through the public interface whenever possible.
+
+---
+
+# Testing Philosophy
+
+A good test should:
+
+- verify mathematical correctness
+- verify numerical correctness
+- catch regressions
+- remain readable
+- be deterministic
+- be independent of execution order
+
+Avoid tests that depend on implementation details unless those details are part of a
+documented interface.
+
+---
+
+# Test Organization
+
+Mirror the source tree.
+
+Example:
+
+```
+src/
+    Geometry/
+        TensorProductGeometry.jl
+
+↓
+
+test/
+    Geometry/
+        TensorProductGeometryTests.jl
+```
+
+Every new test file must be registered inside the module's
+
+```
+test/<Module>/runtests.jl
+```
+
+which is then included from
+
+```
+test/runtests.jl
+```
+
+Do **not** wrap individual test files inside additional `@testset`s.
+
+Each test file should contain top-level `@test`s, as the enclosing `@testset` is provided by
+the module's `runtests.jl`.
+
+---
+
+# What to Test
+
+When adding new functionality, consider testing:
+
+## Public API
+
+Verify that public functions:
+
+- accept expected inputs
+- return expected outputs
+- throw expected exceptions
+- preserve documented behaviour
+
+---
+
+## Mathematical Properties
+
+Whenever possible, test mathematical identities rather than individual implementation steps.
+
+Examples include:
+
+- exact polynomial reproduction
+- commuting diagrams
+- exactness of complexes
+- partition of unity
+- interpolation properties
+- symmetry
+- conservation laws
+
+---
+
+## Numerical Accuracy
+
+For numerical algorithms, compare against:
+
+- analytical solutions
+- manufactured solutions
+- reference values
+- previously validated implementations
+
+Use tolerances appropriate for floating-point arithmetic.
+
+Avoid exact equality unless mathematically guaranteed.
+
+---
+
+## Edge Cases
+
+Consider testing:
+
+- empty inputs
+- degenerate meshes
+- boundary elements
+- single-element meshes
+- high polynomial orders
+- low polynomial orders
+- invalid arguments
+
+Ensure errors are informative and intentional.
+
+---
+
+## Regression Tests
+
+When fixing a bug:
+
+1. write a test that reproduces the bug
+2. verify it fails before the fix
+3. verify it passes afterwards
+
+Keep the regression test even after the bug is fixed.
+
+---
+
+# Forms
+
+Since Forms are symbolic expression trees, test both:
+
+- symbolic construction
+- numerical evaluation
+
+For example, verify that operators construct the expected expressions and that `evaluate`
+produces the correct numerical values.
+
+Avoid testing internal tree layouts unless they are part of the public API.
+
+---
+
+# Geometry
+
+Geometry tests should verify:
+
+- mappings from canonical to physical coordinates
+- Jacobians
+- inverse mappings (when applicable)
+- orientations
+- boundary mappings
+
+Prefer analytical geometries with known exact results.
+
+---
+
+# Function Spaces
+
+Test:
+
+- basis evaluation
+- interpolation
+- continuity
+- partition of unity
+- derivatives
+- degree-specific behaviour
+
+Whenever possible, compare against exact polynomial values.
+
+---
+
+# Quadrature
+
+Verify:
+
+- exact integration of polynomials or other spaces up to the expected degree
+- correct handling of weights
+- correct handling of mapped geometries
+
+---
+
+# Assemblers
+
+Assembly tests should verify:
+
+- correct matrix sizes
+- sparsity structure
+- symmetry (when expected)
+- consistency with analytical weak forms
+
+For larger systems, compare assembled operators against known reference solutions or
+invariants rather than individual entries.
+
+---
+
+# Floating-Point Comparisons
+
+Use tolerances appropriate to the computation.
+
+Prefer
+
+```
+@test isapprox(...)
+```
+
+over exact equality for floating-point results.
+
+Choose tolerances based on expected numerical error rather than arbitrary values.
+
+---
+
+# Determinism
+
+Tests should produce identical results across runs.
+
+Avoid dependence on:
+
+- random number generation (unless seeded)
+- execution order
+- iteration order of unordered collections
+- machine-specific behaviour
+
+---
+
+# Performance
+
+Performance tests generally do not belong in the standard test suite.
+
+If verifying a performance improvement:
+
+- use dedicated benchmarks
+- measure allocations when appropriate
+- avoid fragile timing-based assertions
+
+---
+
+# Inference Tests
+
+JET inference tests live under
+
+```
+test/Inference
+```
+
+They use a separate project and are only executed on supported Julia versions.
+
+Do not place ordinary correctness tests there.
+
+---
+
+# Documentation Examples
+
+If adding a `jldoctest` example:
+
+- ensure it executes successfully
+- keep it minimal
+- avoid unnecessary complexity
+
+Documentation examples should remain synchronized with the implementation.
+
+---
+
+# Test Checklist
+
+Before opening a PR, verify that:
+
+- new functionality has corresponding tests
+- tests mirror the source tree
+- new test files are registered in `runtests.jl`
+- public APIs are tested
+- edge cases are covered where appropriate
+- floating-point comparisons use appropriate tolerances
+- regression tests are added for bug fixes
+- tests are deterministic
+- the full test suite passes on supported Julia versions
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- test private implementation details unnecessarily
+- duplicate existing tests without increasing coverage
+- rely on execution order
+- hard-code floating-point values without justification
+- use unnecessarily loose tolerances
+- remove regression tests after a bug is fixed
+- write brittle tests that fail after harmless refactoring
+
+Prefer tests that validate mathematical correctness and user-visible behaviour over tests
+that mirror the implementation.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,83 @@
+# Mantis.jl
+
+Julia package for high-order, structure-preserving finite element methods, built on the
+Finite Element Exterior Calculus (FEEC) framework. Supports piecewise-polynomial,
+non-polynomial, and adaptively-refinable (hierarchical B-spline) finite element spaces,
+among others.
+
+## Build & test Supports Julia 1.10 (LTS) through pre-release (CI runs lts, 1, pre).
+
+```
+bash
+julia --project=. -e 'using Pkg; Pkg.instantiate()'          # resolve deps
+julia --project=. -e 'using Pkg; Pkg.test()'                  # full suite
+julia --project=. -e 'include("test/Geometry/runtests.jl")'   # one module
+julia --project=. -e 'include("test/Assemblers/GlobalAssemblersTests.jl")'  # one file
+```
+
+Test files use plain import Mantis / top-level @tests (no @testset inside each file);
+@testset wrapping happens in each module's test/<Module>/runtests.jl, which is in turn
+included from test/runtests.jl. Mirror src/<Module> structure when adding tests, and
+register new files in the module's runtests.jl.
+JET type-inference tests (test/Inference) only run on Julia >= 1.12, non-prerelease, via
+their own nested project — skipped otherwise.
+
+Docs: julia --project=docs docs/make.jl.
+
+Example pages under docs/src/Examples are generated from examples/src/\*.jl via Literate.jl
+— edit the .jl source, not the generated .md.
+
+`jlfmt` is used to enforce consistent formatting.
+
+## Architecture src/Mantis.jl includes each submodule in dependency
+
+order and re-exports selected symbols. Modules depend roughly on those before them:
+GeneralHelpers -> Mesh -> Points -> Hierarchy -> Geometry -> FunctionSpaces -> Quadrature ->
+Forms -> Analysis -> Assemblers -> Plot
+
+Each module's <ModuleName>.jl defines the module, abstract types, exports, and top-level
+fallback methods (throw(MethodError(...)) documenting the interface concrete subtypes must
+implement), then includes the rest of the module at the bottom — read it first when
+exploring a module.
+
+- **Mesh**: topology-only connectivity, no geometry.
+- **Points**: point sets used for evaluation (e.g. CartesianPoints).
+- **Hierarchy**: bookkeeping for hierarchically-refined (adaptive) structures.
+- **Geometry**: AbstractGeometry{manifold_dim, image_dim, num_patches} maps the canonical
+  domain [0,1]^manifold_dim to physical space. Evaluation happens in the canonical domain,
+  not physical space — this distinction carries through Forms and Assemblers too.
+- **FunctionSpaces**: AbstractFESpace and concrete FE spaces (e.g. B-splines).
+- **Quadrature**: element-level and global quadrature rules. -
+  **Forms**: the FEEC layer. AbstractForm{manifold_dim, form_rank, expression_rank} is
+  central — expression_rank 0 = field (no basis), 1 = space (has a basis), 2 = two-basis
+  expression (e.g. from wedge products). Operators (d, ★, ♯, ∧, ∫, dstar/δ) build expression
+  trees rather than eagerly computing values; evaluate then walks the tree.
+- **Analysis**: error computation (e.g. L2 error).
+- **Assemblers**: turns Forms expressions into global sparse matrices/vectors
+  (GlobalAssemblers.jl + per-problem WeakFormulations).
+- **Time Integrators**: Use for solving time-dependent problems. Uses a GLM framework.
+- **Plot**: writes VTK output; Makie plotting lives in the weak-dependency extension
+  ext/MakieExt.jl. exports/Exports.jl and exports/Forms.jl are auxiliary re-exports of the
+  curated public API (marked "auto-generated") — keep in sync manually if you add/rename
+  public Forms exports.
+
+## Conventions
+
+- **Style**: [Blue Style](https://github.com/JuliaDiff/BlueStyle) with the modifications in
+  .JuliaFormatter.toml (no import->using conversion, short function defs stay short,
+  markdown/docstring formatting disabled, docs/ excluded).
+- **Docstrings**: public functions/types get # Arguments, # Returns (when arguments are not
+  clear), and where relevant # Exceptions sections, matching existing src/ style. Add #
+  Examples with a jldoctest block when it aids understanding.
+- **Commit messages** are enforced by .github/scripts/commit-msg.sh / CommitMessage.yml CI
+  (Conventional Commits): <type>: <text> (<type>!: <text> for breaking changes, revert:
+  <type>: <text> for reverts). Allowed types: bench, chore, ci, doc, feat, fix, perf,
+  refactor, style, test, revert, merge. Title <= 50 chars; first word of <text> must be
+  lower-case, imperative/future tense (not -ed/-s/-ing), e.g. feat: add new cool geometry.
+  Keep commits single-purpose — see docs/src/Support/Contributing.md (e.g. perf: commits
+  should quantify improvement with something like @allocations).
+- **Public-but-undocumented exports** use Julia's public keyword (guarded by VERSION >=
+  v"1.11.0-DEV.469" for Julia 1.10 compatibility) instead of export, e.g. abstract types in
+  Forms.jl.
+- **Weak dependencies**: go through a package extension in ext/, declared via
+  [weakdeps]/[extensions] in Project.toml, not a hard dependency.

--- a/.github/skills/docexamples/SKILL.md
+++ b/.github/skills/docexamples/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: Mantis Example Documentation
+description: Write and maintain example documentation pages that demonstrate how to use Mantis.jl through complete, executable examples, following the style used throughout `docs/src/Examples/`.
+---
+
+# Mantis.jl Example Documentation
+
+This skill describes how to write or update example pages under:
+
+```
+docs/src/Examples/
+```
+
+Examples are intended to teach users how to solve problems using Mantis, not to document
+individual APIs.
+
+Each example should demonstrate a complete workflow that users can adapt to their own
+problems.
+
+---
+
+# Purpose
+
+An example should answer questions such as:
+
+- How do I use this functionality?
+- What is the typical workflow?
+- Which abstractions work together?
+- What result should I expect?
+
+Examples should be practical, self-contained, and easy to adapt.
+
+---
+
+# Source Files
+
+Documentation pages are generated from
+
+```
+examples/src/*.jl
+```
+
+using Literate.jl.
+
+**Always edit the `.jl` source file**, not the generated Markdown page.
+
+Ensure that both the code and the accompanying comments are suitable for Literate.jl.
+
+---
+
+# Intended Audience
+
+Assume readers:
+
+- are familiar with Julia,
+- have basic knowledge of finite element methods,
+- are learning how to use Mantis.
+
+Explain Mantis-specific concepts, but avoid explaining general Julia syntax.
+
+---
+
+# Structure
+
+A typical example should contain:
+
+1. Introduction
+2. Problem description
+3. Geometry construction
+4. Function space definition
+5. Weak formulation or computation
+6. Results
+7. Discussion
+
+Not every example requires every section, but the progression should feel natural.
+
+Whenever possible, build on previous examples to avoid repeating code.
+
+---
+
+# Introduce the Problem
+
+Begin by describing:
+
+- the mathematical problem,
+- the objective of the example,
+- the important Mantis features being demonstrated.
+
+Keep the introduction concise.
+
+---
+
+# Build the Example Incrementally
+
+Construct the example in logical steps.
+
+For example:
+
+- define the geometry,
+- define function spaces,
+- construct forms,
+- assemble the problem,
+- solve,
+- analyze or visualize the results.
+
+Avoid presenting a large block of code without explanation.
+
+---
+
+# Explain Design Decisions
+
+Describe *why* each step is performed.
+
+For example:
+
+- why a particular geometry is chosen,
+- why a certain function space is appropriate,
+- why a specific operator is used.
+
+Help readers understand the reasoning behind the workflow.
+
+---
+
+# Focus on Public APIs
+
+Examples should use the public Mantis interface.
+
+Avoid relying on:
+
+- internal helper functions,
+- undocumented interfaces,
+- implementation details.
+
+Examples should remain valid as the implementation evolves.
+
+---
+
+# Keep Examples Realistic
+
+Use examples that resemble actual workflows.
+
+Prefer:
+
+- standard geometries,
+- commonly used function spaces,
+- realistic boundary conditions,
+- representative numerical problems.
+
+Avoid contrived examples that only demonstrate syntax.
+
+---
+
+# Keep Examples Concise
+
+Include enough code to illustrate the workflow, but avoid unnecessary complexity.
+
+If an example becomes too long, consider splitting it into multiple examples.
+
+Each example should focus on one primary concept.
+
+---
+
+# Explain the Mathematics
+
+Briefly describe the mathematical formulation when it improves understanding.
+
+For example:
+
+- the governing equations,
+- weak formulations,
+- differential operators,
+- finite element spaces.
+
+Keep mathematical discussions concise and directly relevant to the example.
+
+---
+
+# Results
+
+Conclude by explaining:
+
+- what was computed,
+- what users should observe,
+- how to interpret the output.
+
+When appropriate, discuss expected numerical behavior or convergence properties.
+
+---
+
+# Visualizations
+
+Include plots or VTK output only when they help explain the result.
+
+Visualizations should support the narrative, not replace it.
+
+Ensure generated figures are reproducible.
+
+---
+
+# Cross References
+
+Link to related documentation where appropriate.
+
+Examples include:
+
+- module documentation,
+- tutorials,
+- API documentation,
+- related examples.
+
+Avoid duplicating explanations that already exist elsewhere.
+
+---
+
+# Maintain Examples
+
+Whenever the implementation changes:
+
+- update the example,
+- update explanatory text,
+- update expected output,
+- remove obsolete code.
+
+Examples should always execute successfully.
+
+---
+
+# Writing Style
+
+Write in clear, concise English.
+
+Use comments to explain concepts rather than individual Julia statements.
+
+Prefer explaining the workflow over explaining syntax.
+
+---
+
+# Example Checklist
+
+Before opening a PR, verify that:
+
+- the example is implemented in `examples/src/`
+- the example follows the style of existing examples
+- the workflow is easy to follow
+- only public APIs are used
+- explanations focus on concepts rather than syntax
+- mathematical terminology is accurate
+- the example executes successfully
+- generated documentation renders correctly with Literate.jl
+- visualizations, if included, are reproducible
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- edit the generated Markdown files
+- rely on undocumented or internal APIs
+- include large unexplained code blocks
+- explain basic Julia syntax
+- mix multiple unrelated concepts into a single example
+- leave outdated output or figures after implementation changes
+
+Prefer examples that teach users how to solve realistic problems using Mantis rather than
+examples that merely demonstrate individual functions.

--- a/.github/skills/docmodules/SKILL.md
+++ b/.github/skills/docmodules/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: Mantis Module Documentation
+description: Write and maintain module documentation pages that explain the mathematical concepts, architecture, and public interfaces of a Mantis.jl module, following the style used in `docs/src/Design/Modules/`.
+---
+
+# Mantis.jl Module Documentation
+
+This skill describes how to write or update module documentation pages under
+
+```
+docs/src/Design/Modules/
+```
+
+These pages are intended to explain the design of a module to users and contributors, rather
+than documenting individual APIs.
+
+Use existing pages, such as `docs/src/Design/Modules/Forms.md`, as the primary style
+reference.
+
+---
+
+# Purpose
+
+A module page should answer questions such as:
+
+- What problem does this module solve?
+- What mathematical concepts does it implement?
+- What role does it play within Mantis?
+- How does it interact with other modules?
+- What are its primary public abstractions?
+- How should users think about using it?
+
+The emphasis is on **concepts and design**, not implementation details.
+
+---
+
+# Intended Audience
+
+Assume readers:
+
+- are familiar with Julia,
+- have some background in finite element methods,
+- may be unfamiliar with the internal architecture of Mantis.
+
+Explain mathematical concepts when they are central to understanding the module, but avoid
+turning the page into a textbook.
+
+---
+
+# Structure
+
+Follow the structure used by existing module pages.
+
+A typical page contains:
+
+1. Overview
+2. Core concepts
+3. Main abstractions
+4. Relationships to other modules
+5. Examples
+6. References (when appropriate)
+
+Not every page requires every section, but the overall organization should remain consistent
+across modules.
+
+---
+
+# Overview
+
+Begin with a concise overview describing:
+
+- the module's responsibility,
+- where it fits within the overall architecture,
+- what kinds of functionality it provides.
+
+Avoid discussing implementation files or internal organization.
+
+Focus on the conceptual role of the module.
+
+---
+
+# Explain the Mathematics
+
+Many Mantis modules represent mathematical abstractions.
+
+Describe:
+
+- the mathematical objects represented,
+- the notation used throughout the library,
+- important invariants,
+- the relationship between mathematical concepts and their implementation.
+
+For example:
+
+- differential forms
+- pullbacks
+- Hodge operators
+- finite element spaces
+- hierarchical refinement
+
+Use precise mathematical terminology.
+
+---
+
+# Explain the Design
+
+Describe the design decisions behind the module.
+
+For example:
+
+- why symbolic expressions are used,
+- why evaluation is lazy,
+- why canonical coordinates are preferred,
+- how abstraction boundaries are maintained.
+
+Help readers understand *why* the module is designed the way it is.
+
+---
+
+# Introduce Public Abstractions
+
+Present the important public types and interfaces.
+
+Explain:
+
+- what they represent,
+- when they should be used,
+- how they relate to one another.
+
+Do not duplicate API docstrings. Instead, extensively embed the docstrings into the
+documentation page, creating a cohesive narrative.
+
+---
+
+# Describe Module Relationships
+
+Explain how the module interacts with the rest of Mantis.
+
+Examples include:
+
+- Geometry provides mappings used by Forms.
+- FunctionSpaces provide basis functions consumed by Forms.
+- Assemblers evaluate symbolic expressions built by Forms.
+
+Help readers understand the flow of information through the library.
+
+---
+
+# Use Examples
+
+Prefer small conceptual examples over exhaustive tutorials.
+
+Examples should illustrate:
+
+- typical workflows,
+- important abstractions,
+- common usage patterns.
+
+Avoid large blocks of implementation code.
+
+---
+
+# Maintain Conceptual Level
+
+Keep the documentation focused on design.
+
+Prefer explaining:
+
+- why something exists,
+- what abstraction it provides,
+- how it fits into the library.
+
+Avoid describing:
+
+- internal helper functions,
+- implementation details,
+- private data structures,
+- optimization techniques unless they motivate the design.
+
+---
+
+# Cross References
+
+Link to related documentation where appropriate.
+
+Examples include:
+
+- other module pages,
+- tutorials,
+- examples,
+- API documentation.
+
+Use cross references to help readers navigate the documentation rather than duplicating
+content.
+
+---
+
+# Mathematical Notation
+
+When introducing notation:
+
+- define symbols before using them,
+- use consistent notation throughout the page,
+- match notation used elsewhere in the documentation.
+
+Prefer mathematical clarity over excessive formalism.
+
+---
+
+# Diagrams
+
+When appropriate, include simple diagrams illustrating:
+
+- module relationships,
+- data flow,
+- mathematical structures,
+- abstraction layers.
+
+Diagrams should clarify the design rather than decorate the page.
+
+---
+
+# Keep Documentation Current
+
+Whenever the module changes:
+
+- update the conceptual description,
+- update examples,
+- update descriptions of public abstractions,
+- update relationships to other modules.
+
+Documentation should evolve together with the implementation.
+
+---
+
+# Documentation Checklist
+
+Before opening a PR, verify that:
+
+- the page follows the style of existing module documentation (especially
+  `docs/src/Design/Modules/Forms.md`)
+- the module's purpose is clearly explained
+- the mathematical concepts are described accurately
+- the main abstractions are introduced
+- relationships to other modules are explained
+- examples are concise and illustrative
+- implementation details are minimized
+- terminology is consistent with the rest of the documentation
+- cross references are updated where appropriate
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- duplicate API docstrings
+- document individual methods in detail
+- explain the implementation file layout
+- include unnecessary implementation details
+- introduce notation without defining it
+- turn the page into a complete mathematical reference
+
+Prefer documentation that explains the *design philosophy* and *conceptual model* of the
+module over documentation that mirrors the source code.

--- a/.github/skills/docstrings/SKILL.md
+++ b/.github/skills/docstrings/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: Mantis Docstrings
+description: Write clear, consistent, and informative docstrings for Mantis.jl that follow the project's documentation style and accurately describe the public API.
+---
+
+# Mantis.jl Docstrings
+
+This skill describes how to write docstrings for Mantis.jl.
+
+Public APIs should be documented clearly enough that users can understand how to use them
+without reading the implementation.
+
+Docstrings are part of the public interface and should evolve alongside the code.
+
+---
+
+# What Should Be Documented
+
+Document all public:
+
+- functions
+- methods with user-facing behavior
+- types
+- macros
+- constants when appropriate
+
+Internal helper functions generally do not require docstrings unless they implement
+important algorithms or are likely to be reused.
+
+---
+
+# Follow Existing Style
+
+Match the style already used throughout `src/`.
+
+Do not introduce a new documentation format.
+
+Public docstrings should use section headings where appropriate:
+
+- `# Arguments` (when not obvious from the name)
+- `# Returns` (when not obvious from the name)
+- `# Exceptions`
+- `# Examples` (whenever possible)
+
+Only include sections that add value. Avoid empty or trivial sections.
+
+---
+
+# Function Docstrings
+
+Begin with a concise summary describing what the function does.
+
+Prefer describing the operation rather than the implementation.
+
+Prefer:
+
+> Compute the pullback of a differential form onto the reference domain.
+
+Avoid:
+
+> This function loops over the basis functions and applies pullback transformations.
+
+Implementation details belong in comments, not the public documentation.
+
+---
+
+# Arguments
+
+Include an `# Arguments` section whenever the function accepts non-obvious parameters.
+
+For each argument, describe:
+
+- its purpose
+- expected type or interface (when not obvious)
+- any assumptions or restrictions
+
+Explain the _meaning_ of an argument, not merely its Julia type.
+
+Prever:
+
+```
+- `geometry`: Geometry used to map the canonical element to physical space.
+```
+
+Avoid:
+
+```
+- `geometry`: An `AbstractGeometry`.
+```
+
+---
+
+# Returns
+
+Include a `# Returns` section whenever the return value is not immediately obvious.
+
+Describe:
+
+- what is returned
+- important guarantees
+- ownership or mutability when relevant
+
+Focus on the semantic meaning of the result rather than its exact implementation type unless
+that type is important to users.
+
+---
+
+# Exceptions
+
+Include a `# Exceptions` section when the function intentionally throws errors under
+documented conditions.
+
+Describe:
+
+- when an exception occurs
+- why it occurs
+
+---
+
+# Examples
+
+Include `# Examples` when they improve understanding (should be often).
+
+Use `jldoctest` blocks.
+
+Examples should:
+
+- be minimal
+- be complete
+- execute successfully
+- demonstrate typical usage
+
+Prefer realistic examples over artificial ones.
+
+---
+
+# Type Docstrings
+
+Describe:
+
+- what the type represents
+- its role within Mantis
+- important invariants
+- when users should use it
+
+Avoid documenting every field unless users are expected to construct the type directly.
+
+Explain the abstraction before the representation.
+
+---
+
+# Mathematical Concepts
+
+Mantis is based on FEEC and differential geometry.
+
+When documenting mathematical objects:
+
+- use correct mathematical terminology
+- define symbols when necessary
+- distinguish between canonical and physical domains
+- distinguish symbolic expressions from evaluated quantities
+
+Assume readers have some numerical PDE background, but avoid unnecessary jargon.
+
+---
+
+# Generic Interfaces
+
+Abstract interfaces should document:
+
+- the purpose of the interface
+- required methods
+- expected behavior
+- semantic contracts
+
+Concrete implementations should document only behavior that differs from or extends the
+interface documentation.
+
+Avoid duplicating documentation across implementations.
+
+---
+
+# Keep Documentation Focused
+
+Describe:
+
+- what the API does
+- why it exists
+- when it should be used
+
+Avoid lengthy implementation discussions.
+
+If implementation details are important for maintainers, place them in comments rather than
+docstrings.
+
+---
+
+# Maintain Accuracy
+
+Whenever changing behavior:
+
+- update the corresponding docstring
+- update examples
+- update documented exceptions
+- update return value descriptions if necessary
+
+Outdated documentation is often more harmful than missing documentation.
+
+---
+
+# Cross References
+
+When appropriate, reference related functionality using Julia's documentation conventions.
+
+Examples include:
+
+- related operators
+- complementary types
+- alternative constructors
+
+Use cross references to help users discover the API rather than repeating documentation.
+
+---
+
+# Writing Style
+
+Write in clear, concise English.
+
+Prefer:
+
+- active voice
+- complete sentences
+- consistent terminology
+- precise mathematical language
+
+Avoid:
+
+- unnecessary verbosity
+- implementation-specific language
+- ambiguous wording
+- unexplained abbreviations
+
+Use the same terminology consistently throughout the codebase.
+
+---
+
+# Documentation Checklist
+
+Before opening a PR, verify that:
+
+- every new public API has a docstring
+- docstrings follow the existing project style
+- `# Arguments`, `# Returns`, `# Exceptions`, and `# Examples` sections are included where
+  appropriate
+- examples are valid `jldoctest`s when provided
+- mathematical terminology is accurate
+- documentation matches the implementation
+- related documentation is updated when behavior changes
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- document the implementation instead of the interface
+- repeat obvious type information without explanation
+- leave stale examples after refactoring
+- duplicate identical documentation across multiple methods
+- omit documentation for new public APIs
+- include speculative or future behavior
+
+Prefer documentation that explains the purpose and semantics of an API over documentation
+that merely describes its syntax.

--- a/.github/skills/feature/SKILL.md
+++ b/.github/skills/feature/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: Mantis Feature Development
+description: Implement new functionality in the Mantis.jl finite element library while preserving FEEC abstractions, module boundaries, and project conventions.
+---
+
+# Mantis.jl Feature Development
+
+This skill describes how to correctly implement new functionality in Mantis.jl.
+
+## Core Principles
+
+Mantis is organized as a layered FEEC library.
+
+Every new feature should preserve the existing abstraction hierarchy.
+
+Never bypass existing abstractions simply because something is easier to implement.
+
+Whenever possible, implement functionality by extending existing interfaces instead of
+introducing parallel implementations.
+
+---
+
+# Module Dependency Order
+
+Modules have a strict dependency order.
+
+```
+GeneralHelpers
+    ↓
+Mesh
+    ↓
+Points
+    ↓
+Hierarchy
+    ↓
+Geometry
+    ↓
+FunctionSpaces
+    ↓
+Quadrature
+    ↓
+Forms
+    ↓
+Analysis
+    ↓
+Assemblers
+    ↓
+TimeIntegrators
+    ↓
+Plot
+```
+
+A module may depend on modules above it.
+
+Avoid introducing dependencies in the opposite direction.
+
+---
+
+# Before Implementing
+
+First identify which layer owns the feature.
+
+Typical ownership:
+
+- mesh topology → Mesh
+- physical mappings → Geometry
+- finite element spaces → FunctionSpaces
+- symbolic FEEC operators → Forms
+- numerical integration → Quadrature
+- global matrix assembly → Assemblers
+- postprocessing → Analysis
+- visualization → Plot
+
+Avoid implementing functionality in a higher layer when it naturally belongs in a lower one.
+
+---
+
+# Module Structure
+
+Each module follows the same pattern.
+
+```
+ModuleName.jl
+
+module ModuleName
+
+exports
+
+abstract types
+
+fallback interface methods
+
+include("...")
+
+end
+```
+
+When adding new interfaces:
+
+1. add the abstract interface
+2. provide documented fallback methods throwing `MethodError`
+3. implement concrete types in separate files
+4. include those files from the module
+
+Do not place large implementations directly inside `ModuleName.jl`.
+
+---
+
+# Geometry
+
+Geometry maps
+
+```
+[0,1]^n
+    →
+physical space
+```
+
+Evaluation always occurs on the canonical domain.
+
+Do not evaluate basis functions directly in physical coordinates.
+
+Coordinate transforms belong inside Geometry.
+
+Assemblers and Forms should remain geometry-independent.
+
+---
+
+# Forms
+
+Forms are symbolic expression trees.
+
+Operators such as
+
+- d
+- ★
+- δ
+- ∧
+- ∫
+- ♯
+
+construct expressions.
+
+They do **not** perform numerical evaluation.
+
+Evaluation happens exclusively through `evaluate`.
+
+When implementing a new operator:
+
+- preserve lazy evaluation
+- create new expression nodes
+- extend `evaluate`
+- avoid eager computation
+
+---
+
+# Function Spaces
+
+New finite element spaces should extend `AbstractFESpace` and the corresponding documented
+abstract methods.
+
+Reuse existing interfaces whenever possible.
+
+---
+
+# Assemblers
+
+Assemblers convert symbolic Forms into sparse matrices.
+
+Weak formulations should build symbolic expressions.
+
+Avoid inserting numerical kernels directly into weak formulations.
+
+If new assembly logic is required:
+
+- extend the assembler interface
+- preserve sparse assembly
+- reuse existing quadrature infrastructure
+
+---
+
+# Public API
+
+When adding public functionality use `export` or `public` as appropriate
+
+Keep exported APIs minimal.
+
+---
+
+# Documentation
+
+Public APIs require docstrings.
+
+Use the project style:
+
+- Arguments (when not obvious from the name)
+- Returns (when not obvious from the name)
+- Examples (when useful)
+
+Follow existing documentation style instead of inventing new conventions.
+
+---
+
+# Tests
+
+Every feature should include tests.
+
+Mirror the source layout.
+
+Example:
+
+```
+src/Geometry/NewGeometry.jl
+
+↓
+
+test/Geometry/NewGeometryTests.jl
+```
+
+Register new test files in the corresponding
+
+```
+test/<Module>/runtests.jl
+```
+
+Test files contain top-level `@test`s.
+
+Do not wrap them in additional `@testset`s.
+
+---
+
+# Extensions
+
+Optional functionality belongs in package extensions.
+
+Current example:
+
+```
+ext/MakieExt.jl
+```
+
+Do not introduce hard dependencies for optional features.
+
+---
+
+# Style
+
+Follow BlueStyle with the repository's formatter configuration.
+
+Match surrounding code.
+
+Prefer extending existing APIs over introducing new naming patterns.
+
+---
+
+# Implementation Checklist
+
+Before opening a PR verify that:
+
+- feature lives in the correct module
+- abstraction boundaries are preserved
+- module dependency order is respected
+- lazy evaluation is preserved (Forms)
+- new public APIs are documented
+- exports are updated
+- tests are added
+- module `runtests.jl` registers the new tests
+- Julia 1.10 compatibility is preserved
+- optional dependencies use package extensions
+
+---
+
+# Things to Avoid
+
+Do not
+
+- evaluate symbolic Forms eagerly
+- couple Assemblers to specific form or finite element spaces
+- introduce circular module dependencies
+- perform geometry computations outside Geometry
+- duplicate existing interfaces
+- add optional packages as hard dependencies

--- a/.github/skills/refactoring/SKILL.md
+++ b/.github/skills/refactoring/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: Mantis Refactoring
+description: Refactor Mantis.jl code while preserving FEEC abstractions, module boundaries, API stability, and numerical correctness.
+---
+
+# Mantis.jl Refactoring
+
+This skill describes how to safely refactor existing code in Mantis.jl.
+
+The primary objective of a refactor is to improve the implementation **without changing
+observable behaviour**.
+
+Observable behaviour includes:
+
+- numerical results
+- public APIs
+- supported Julia versions
+- performance characteristics (unless intentionally improved)
+- documentation semantics
+
+When in doubt, prefer smaller, incremental refactors over large rewrites.
+
+---
+
+# Understand Before Changing
+
+Before modifying code, identify:
+
+- which module owns the functionality
+- whether the code is part of the public API
+- whether it implements an interface used elsewhere
+- whether it is performance critical
+
+Read the module's top-level `<Module>.jl` file first to understand the intended abstractions
+before changing implementation files.
+
+Never refactor code that you do not yet understand.
+
+---
+
+# Preserve Module Boundaries
+
+Mantis follows a layered architecture.
+
+```
+GeneralHelpers
+    ↓
+Mesh
+    ↓
+Points
+    ↓
+Hierarchy
+    ↓
+Geometry
+    ↓
+FunctionSpaces
+    ↓
+Quadrature
+    ↓
+Forms
+    ↓
+Analysis
+    ↓
+Assemblers
+    ↓
+TimeIntegrators
+    ↓
+Plot
+```
+
+Do not introduce dependencies that violate this ordering.
+
+If functionality naturally belongs in a lower layer, move it there rather than duplicating
+it in higher layers.
+
+---
+
+# Preserve Existing Abstractions
+
+Prefer strengthening existing abstractions over introducing new ones.
+
+When similar implementations exist:
+
+- extract common functionality
+- reuse existing interfaces
+- eliminate duplication
+
+Avoid introducing parallel interfaces that solve the same problem.
+
+If multiple concrete types implement nearly identical logic, consider moving shared
+behaviour into common helper functions or abstract interface methods.
+
+---
+
+# Preserve FEEC Semantics
+
+The FEEC abstractions are fundamental to Mantis.
+
+In particular:
+
+- Forms represent symbolic expression trees.
+- Operators build expressions.
+- Evaluation occurs through `evaluate`.
+- Assemblers consume symbolic expressions.
+- Geometry handles mappings between canonical and physical domains.
+
+Do not blur these responsibilities during refactoring.
+
+Avoid introducing shortcuts that bypass symbolic representations.
+
+---
+
+# Preserve Public APIs
+
+Refactoring should not require downstream users to modify their code.
+
+Avoid:
+
+- renaming exported symbols
+- changing method signatures
+- changing return types
+- changing documented behaviour
+
+If a breaking change is unavoidable, isolate it into a dedicated change rather than
+combining it with unrelated refactoring.
+
+---
+
+# Reduce Duplication Carefully
+
+When removing duplicated code:
+
+- verify that implementations are truly equivalent
+- preserve specialized behaviour
+- avoid over-generalization
+
+A small amount of duplication is preferable to an abstraction that obscures the mathematics
+or FEEC concepts.
+
+---
+
+# Improve Readability
+
+Refactoring should make code easier to understand.
+
+Common improvements include:
+
+- extracting helper functions
+- improving function names
+- reducing nesting
+- separating independent responsibilities
+- simplifying dispatch
+
+Avoid introducing additional layers of abstraction unless they clearly improve
+maintainability.
+
+---
+
+# Preserve Performance
+
+Many parts of Mantis execute inside assembly loops.
+
+When refactoring performance-critical code:
+
+- avoid unnecessary allocations
+- preserve type stability
+- avoid introducing dynamic dispatch
+- keep hot paths simple
+
+Prefer measuring performance before and after significant refactors.
+
+Do not assume cleaner code is automatically faster.
+
+---
+
+# Preserve Generic Programming
+
+Mantis relies heavily on Julia's multiple dispatch.
+
+Prefer extending existing generic interfaces rather than introducing type checks or
+conditional logic.
+
+Avoid replacing dispatch with manual branching based on concrete types.
+
+---
+
+# Documentation
+
+If public code is moved or reorganized:
+
+- keep docstrings attached to the public API
+- update examples if needed
+- ensure exported symbols remain documented
+
+Internal helper functions generally do not require extensive documentation unless they
+implement non-trivial algorithms.
+
+---
+
+# Tests
+
+Every refactor should preserve existing test coverage.
+
+If behaviour is unchanged:
+
+- existing tests should continue to pass without modification
+
+If code becomes easier to test:
+
+- consider adding focused regression tests
+- preserve mirror structure between `src/` and `test/`
+
+Never remove tests solely because the implementation changed.
+
+---
+
+# Optional Dependencies
+
+Do not convert weak dependencies into hard dependencies.
+
+Functionality related to optional packages should remain inside package extensions under
+`ext/`.
+
+---
+
+# Refactoring Checklist
+
+Before opening a PR, verify that:
+
+- no public APIs changed unintentionally
+- module dependency order is preserved
+- FEEC abstractions remain intact
+- symbolic evaluation remains lazy
+- geometry responsibilities remain in Geometry
+- duplicated logic has been reduced appropriately
+- performance-critical code remains type-stable
+- existing tests pass
+- new regression tests are added where appropriate
+- documentation remains accurate
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- rewrite working code without a clear objective
+- introduce circular module dependencies
+- replace dispatch with manual type checks
+- move geometry logic into Assemblers or Forms
+- eagerly evaluate symbolic expressions
+- over-generalize small pieces of duplicated code
+- combine behavioural changes with large refactors
+- sacrifice numerical clarity for clever abstractions
+
+Prefer refactors that are incremental, well-scoped, and easy to review.

--- a/.github/skills/tests/SKILL.md
+++ b/.github/skills/tests/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: Mantis Testing
+description: Write and maintain tests for Mantis.jl that verify correctness, numerical accuracy, API behavior, and regression safety while following the project's testing conventions.
+---
+
+# Mantis.jl Testing
+
+This skill describes how to write tests for Mantis.jl.
+
+Tests should verify **observable behaviour**, not implementation details.
+
+Prefer testing through the public interface whenever possible.
+
+---
+
+# Testing Philosophy
+
+A good test should:
+
+- verify mathematical correctness
+- verify numerical correctness
+- catch regressions
+- remain readable
+- be deterministic
+- be independent of execution order
+
+Avoid tests that depend on implementation details unless those details are part of a
+documented interface.
+
+---
+
+# Test Organization
+
+Mirror the source tree.
+
+Example:
+
+```
+src/
+    Geometry/
+        TensorProductGeometry.jl
+
+↓
+
+test/
+    Geometry/
+        TensorProductGeometryTests.jl
+```
+
+Every new test file must be registered inside the module's
+
+```
+test/<Module>/runtests.jl
+```
+
+which is then included from
+
+```
+test/runtests.jl
+```
+
+Do **not** wrap individual test files inside additional `@testset`s.
+
+Each test file should contain top-level `@test`s, as the enclosing `@testset` is provided by
+the module's `runtests.jl`.
+
+---
+
+# What to Test
+
+When adding new functionality, consider testing:
+
+## Public API
+
+Verify that public functions:
+
+- accept expected inputs
+- return expected outputs
+- throw expected exceptions
+- preserve documented behaviour
+
+---
+
+## Mathematical Properties
+
+Whenever possible, test mathematical identities rather than individual implementation steps.
+
+Examples include:
+
+- exact polynomial reproduction
+- commuting diagrams
+- exactness of complexes
+- partition of unity
+- interpolation properties
+- symmetry
+- conservation laws
+
+---
+
+## Numerical Accuracy
+
+For numerical algorithms, compare against:
+
+- analytical solutions
+- manufactured solutions
+- reference values
+- previously validated implementations
+
+Use tolerances appropriate for floating-point arithmetic.
+
+Avoid exact equality unless mathematically guaranteed.
+
+---
+
+## Edge Cases
+
+Consider testing:
+
+- empty inputs
+- degenerate meshes
+- boundary elements
+- single-element meshes
+- high polynomial orders
+- low polynomial orders
+- invalid arguments
+
+Ensure errors are informative and intentional.
+
+---
+
+## Regression Tests
+
+When fixing a bug:
+
+1. write a test that reproduces the bug
+2. verify it fails before the fix
+3. verify it passes afterwards
+
+Keep the regression test even after the bug is fixed.
+
+---
+
+# Forms
+
+Since Forms are symbolic expression trees, test both:
+
+- symbolic construction
+- numerical evaluation
+
+For example, verify that operators construct the expected expressions and that `evaluate`
+produces the correct numerical values.
+
+Avoid testing internal tree layouts unless they are part of the public API.
+
+---
+
+# Geometry
+
+Geometry tests should verify:
+
+- mappings from canonical to physical coordinates
+- Jacobians
+- inverse mappings (when applicable)
+- orientations
+- boundary mappings
+
+Prefer analytical geometries with known exact results.
+
+---
+
+# Function Spaces
+
+Test:
+
+- basis evaluation
+- interpolation
+- continuity
+- partition of unity
+- derivatives
+- degree-specific behaviour
+
+Whenever possible, compare against exact polynomial values.
+
+---
+
+# Quadrature
+
+Verify:
+
+- exact integration of polynomials or other spaces up to the expected degree
+- correct handling of weights
+- correct handling of mapped geometries
+
+---
+
+# Assemblers
+
+Assembly tests should verify:
+
+- correct matrix sizes
+- sparsity structure
+- symmetry (when expected)
+- consistency with analytical weak forms
+
+For larger systems, compare assembled operators against known reference solutions or
+invariants rather than individual entries.
+
+---
+
+# Floating-Point Comparisons
+
+Use tolerances appropriate to the computation.
+
+Prefer
+
+```
+@test isapprox(...)
+```
+
+over exact equality for floating-point results.
+
+Choose tolerances based on expected numerical error rather than arbitrary values.
+
+---
+
+# Determinism
+
+Tests should produce identical results across runs.
+
+Avoid dependence on:
+
+- random number generation (unless seeded)
+- execution order
+- iteration order of unordered collections
+- machine-specific behaviour
+
+---
+
+# Performance
+
+Performance tests generally do not belong in the standard test suite.
+
+If verifying a performance improvement:
+
+- use dedicated benchmarks
+- measure allocations when appropriate
+- avoid fragile timing-based assertions
+
+---
+
+# Inference Tests
+
+JET inference tests live under
+
+```
+test/Inference
+```
+
+They use a separate project and are only executed on supported Julia versions.
+
+Do not place ordinary correctness tests there.
+
+---
+
+# Documentation Examples
+
+If adding a `jldoctest` example:
+
+- ensure it executes successfully
+- keep it minimal
+- avoid unnecessary complexity
+
+Documentation examples should remain synchronized with the implementation.
+
+---
+
+# Test Checklist
+
+Before opening a PR, verify that:
+
+- new functionality has corresponding tests
+- tests mirror the source tree
+- new test files are registered in `runtests.jl`
+- public APIs are tested
+- edge cases are covered where appropriate
+- floating-point comparisons use appropriate tolerances
+- regression tests are added for bug fixes
+- tests are deterministic
+- the full test suite passes on supported Julia versions
+
+---
+
+# Things to Avoid
+
+Do not:
+
+- test private implementation details unnecessarily
+- duplicate existing tests without increasing coverage
+- rely on execution order
+- hard-code floating-point values without justification
+- use unnecessarily loose tolerances
+- remove regression tests after a bug is fixed
+- write brittle tests that fail after harmless refactoring
+
+Prefer tests that validate mathematical correctness and user-visible behaviour over tests
+that mirror the implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# Mantis.jl
+
+Julia package for high-order, structure-preserving finite element methods, built on the
+Finite Element Exterior Calculus (FEEC) framework. Supports piecewise-polynomial,
+non-polynomial, and adaptively-refinable (hierarchical B-spline) finite element spaces,
+among others.
+
+## Build & test Supports Julia 1.10 (LTS) through pre-release (CI runs lts, 1, pre).
+
+```
+bash
+julia --project=. -e 'using Pkg; Pkg.instantiate()'          # resolve deps
+julia --project=. -e 'using Pkg; Pkg.test()'                  # full suite
+julia --project=. -e 'include("test/Geometry/runtests.jl")'   # one module
+julia --project=. -e 'include("test/Assemblers/GlobalAssemblersTests.jl")'  # one file
+```
+
+Test files use plain import Mantis / top-level @tests (no @testset inside each file);
+@testset wrapping happens in each module's test/<Module>/runtests.jl, which is in turn
+included from test/runtests.jl. Mirror src/<Module> structure when adding tests, and
+register new files in the module's runtests.jl.
+JET type-inference tests (test/Inference) only run on Julia >= 1.12, non-prerelease, via
+their own nested project — skipped otherwise.
+
+Docs: julia --project=docs docs/make.jl.
+
+Example pages under docs/src/Examples are generated from examples/src/\*.jl via Literate.jl
+— edit the .jl source, not the generated .md.
+
+`jlfmt` is used to enforce consistent formatting.
+
+## Architecture src/Mantis.jl includes each submodule in dependency
+
+order and re-exports selected symbols. Modules depend roughly on those before them:
+GeneralHelpers -> Mesh -> Points -> Hierarchy -> Geometry -> FunctionSpaces -> Quadrature ->
+Forms -> Analysis -> Assemblers -> Plot
+
+Each module's <ModuleName>.jl defines the module, abstract types, exports, and top-level
+fallback methods (throw(MethodError(...)) documenting the interface concrete subtypes must
+implement), then includes the rest of the module at the bottom — read it first when
+exploring a module.
+
+- **Mesh**: topology-only connectivity, no geometry.
+- **Points**: point sets used for evaluation (e.g. CartesianPoints).
+- **Hierarchy**: bookkeeping for hierarchically-refined (adaptive) structures.
+- **Geometry**: AbstractGeometry{manifold_dim, image_dim, num_patches} maps the canonical
+  domain [0,1]^manifold_dim to physical space. Evaluation happens in the canonical domain,
+  not physical space — this distinction carries through Forms and Assemblers too.
+- **FunctionSpaces**: AbstractFESpace and concrete FE spaces (e.g. B-splines).
+- **Quadrature**: element-level and global quadrature rules. -
+  **Forms**: the FEEC layer. AbstractForm{manifold_dim, form_rank, expression_rank} is
+  central — expression_rank 0 = field (no basis), 1 = space (has a basis), 2 = two-basis
+  expression (e.g. from wedge products). Operators (d, ★, ♯, ∧, ∫, dstar/δ) build expression
+  trees rather than eagerly computing values; evaluate then walks the tree.
+- **Analysis**: error computation (e.g. L2 error).
+- **Assemblers**: turns Forms expressions into global sparse matrices/vectors
+  (GlobalAssemblers.jl + per-problem WeakFormulations).
+- **Time Integrators**: Use for solving time-dependent problems. Uses a GLM framework.
+- **Plot**: writes VTK output; Makie plotting lives in the weak-dependency extension
+  ext/MakieExt.jl. exports/Exports.jl and exports/Forms.jl are auxiliary re-exports of the
+  curated public API (marked "auto-generated") — keep in sync manually if you add/rename
+  public Forms exports.
+
+## Conventions
+
+- **Style**: [Blue Style](https://github.com/JuliaDiff/BlueStyle) with the modifications in
+  .JuliaFormatter.toml (no import->using conversion, short function defs stay short,
+  markdown/docstring formatting disabled, docs/ excluded).
+- **Docstrings**: public functions/types get # Arguments, # Returns (when arguments are not
+  clear), and where relevant # Exceptions sections, matching existing src/ style. Add #
+  Examples with a jldoctest block when it aids understanding.
+- **Commit messages** are enforced by .github/scripts/commit-msg.sh / CommitMessage.yml CI
+  (Conventional Commits): <type>: <text> (<type>!: <text> for breaking changes, revert:
+  <type>: <text> for reverts). Allowed types: bench, chore, ci, doc, feat, fix, perf,
+  refactor, style, test, revert, merge. Title <= 50 chars; first word of <text> must be
+  lower-case, imperative/future tense (not -ed/-s/-ing), e.g. feat: add new cool geometry.
+  Keep commits single-purpose — see docs/src/Support/Contributing.md (e.g. perf: commits
+  should quantify improvement with something like @allocations).
+- **Public-but-undocumented exports** use Julia's public keyword (guarded by VERSION >=
+  v"1.11.0-DEV.469" for Julia 1.10 compatibility) instead of export, e.g. abstract types in
+  Forms.jl.
+- **Weak dependencies**: go through a package extension in ext/, declared via
+  [weakdeps]/[extensions] in Project.toml, not a hard dependency.

--- a/docs/src/Design/Modules/Points.md
+++ b/docs/src/Design/Modules/Points.md
@@ -69,7 +69,7 @@ TensorProductPoints
 ```
 
 Tensor-product points are the natural choice whenever the evaluation sites themselves have a
-tensor-product structure — for instance, the nodes of a [Quadrature](@ref) rule on a
+tensor-product structure — for instance, the nodes of a [Quadrature](@ref DocQuadratureModule) rule on a
 multidimensional element.
 
 This concrete type has methods that help interface with [TensorProducts](@ref DocTensorProductsModule):
@@ -96,7 +96,7 @@ DocTensorProductsModule), and is used by every module that requires evaluation:
 - **[Forms](@ref)**: in the most general case, evaluates from a canonical set of points,
   using both parametric information from the underlying function spaces, and information
   from the physical geometry for pullbacks.
-- [Quadrature](@ref): quadrature rules store their nodes as `AbstractPoints`. The
+- [Quadrature](@ref DocQuadratureModule): quadrature rules store their nodes as `AbstractPoints`. The
   `TensorProductPoints` type is particularly useful here, as most multidimensional rules are
   formed from 1D factor rules.
 - [Plot](@ref): uses points to build visualisations written to VTK output.

--- a/docs/src/Design/Modules/Quadrature.md
+++ b/docs/src/Design/Modules/Quadrature.md
@@ -1,6 +1,223 @@
-# Quadrature
-
-## All docstrings from Mantis.Quadrature
-```@autodocs
-Modules = [Mantis.Quadrature]
+```@meta
+CurrentModule = Mantis.Quadrature
 ```
+# [Quadrature](@id DocQuadratureModule)
+
+```@docs
+Quadrature
+```
+
+## Overview
+
+Every integral that `Mantis` computes — mass and stiffness matrices, load vectors, error
+norms — is evaluated numerically. A quadrature rule replaces an integral by a weighted sum
+over a finite set of nodes,
+```math
+\int_{\Omega^{0}} f(\xi) \, \mathrm{d}\xi \approx \sum_{i=1}^{N} w_{i} \, f(\xi_{i}),
+```
+where ``\xi_{i}`` are the *nodes* and ``w_{i}`` the *weights*. The `Quadrature` module
+supplies these pairs and the bookkeeping needed to apply them across a mesh.
+
+Two conventions shape the whole module. First, rules live on the canonical domain
+``\Omega^{0} := [0, 1]^{n}``, where ``n`` is the manifold dimension, rather than on the
+``[-1, 1]`` interval of the classical literature. This matches the convention that
+[Points](@ref DocPointsModule) and [Geometry](@ref DocGeometryModule) already use, so one
+rule can be reused on every element of a mesh without remapping; the geometry supplies the
+Jacobian factor that accounts for the element's actual size. Consequently the weights of a
+rule sum to ``1``, the measure of ``\Omega^{0}``, rather than to ``2``.
+
+Second, nodes are stored as [Points](@ref DocPointsModule) objects rather than as bare
+arrays. A rule is therefore a valid argument anywhere in `Mantis` that accepts evaluation
+points, and multidimensional rules retain the tensor-product structure that function-space
+and geometry evaluation exploit.
+
+## [Element and global rules](@id QuadratureHierarchy)
+
+Integration in a finite element method happens element by element, but the caller usually
+wants to integrate over a whole domain. The module keeps these two levels apart. Both derive
+from a common root carrying only the manifold dimension:
+
+```@docs
+AbstractQuadratureRule
+```
+
+An *element* rule is a concrete set of nodes and weights, valid on one canonical element:
+
+```@docs
+AbstractElementQuadratureRule
+```
+
+A *global* rule covers an entire domain, and answers questions about which element rule
+applies where:
+
+```@docs
+AbstractGlobalQuadratureRule
+```
+
+Separating the two means a single element rule can be shared by every element of a mesh
+without being copied, while the global rule remains free to vary the rule from element to
+element — which is what non-uniform or hierarchically refined meshes need.
+
+## [Element quadrature rules](@id QuadratureElementRules)
+
+Element rules are represented by a single concrete type:
+
+```@docs
+CanonicalQuadratureRule
+```
+
+Every element rule exposes its nodes, its weights, and a human-readable label recording how
+it was built:
+
+```@docs
+get_nodes
+get_weights
+get_label
+```
+
+The label exists for verification rather than for dispatch. Because rules are composed
+(a tensor-product rule reports the rules it was built from), a mislabelled or unintended rule
+is visible on inspection instead of silently changing the accuracy of a computation.
+
+### [One-dimensional rules](@id QuadratureRules1D)
+
+The module builds every rule from one-dimensional constructors, each returning a
+[`CanonicalQuadratureRule{1}`](@ref CanonicalQuadratureRule). They differ in where they place
+nodes, and therefore in accuracy and in whether the endpoints of the interval are included:
+
+```@docs
+gauss_legendre
+gauss_lobatto
+```
+
+Gauss-Legendre places all nodes strictly inside the interval and is exact for polynomials of
+degree ``2N - 1`` with ``N`` nodes, the best attainable. Gauss-Lobatto sacrifices two degrees
+of exactness in order to include ``\xi = 0`` and ``\xi = 1``, which matters when the
+integrand must be sampled on element boundaries.
+
+```@docs
+clenshaw_curtis
+newton_cotes
+```
+
+Clenshaw-Curtis uses Chebyshev nodes, also including the endpoints, and although its
+guaranteed degree of exactness is only ``p``, in practice it often performs comparably to
+Gauss quadrature. Newton-Cotes uses equally spaced nodes, in a *closed* variant including the
+endpoints and an *open* variant excluding them; equally spaced nodes make it the natural
+choice when the integrand is only available on a uniform grid, at the cost of poor
+conditioning for large numbers of points.
+
+### [Tensor-product rules](@id QuadratureTensorProduct)
+
+Multidimensional rules are formed from one-dimensional factors, taking the Cartesian product
+of the nodes and the outer product of the weights:
+
+```@docs
+tensor_product_rule
+```
+
+The resulting nodes are a [`Points.TensorProductPoints`](@ref), so downstream evaluation can
+recover the one-dimensional factors and exploit them, rather than treating the rule as an
+unstructured cloud of points. This is the reason the module stores nodes as points objects at
+all: on a ``2 \times 2 \times 2`` rule the distinction is irrelevant, but tensor-product
+function spaces evaluated at tensor-product nodes are what make higher-degree computations
+affordable.
+
+## [Global quadrature rules](@id QuadratureGlobalRules)
+
+A global rule maps elements of a mesh to the element rules that integrate them. Two notions
+of "element" appear here, and the distinction matters when reading the rest of `Mantis`:
+
+- a **base element** is an element of the underlying mesh;
+- a **quadrature element**, also called an *evaluation element*, is a smallest unit on which
+  quadrature is actually performed.
+
+They coincide in the simple case, but a single base element may be subdivided into several
+quadrature elements — for instance when an integrand is only piecewise smooth across a base
+element, so that integrating it in one piece would lose accuracy. Any global rule reports
+both counts, and resolves a base element into its quadrature elements:
+
+```@docs
+get_num_evaluation_elements
+get_num_base_elements
+get_element_idxs
+```
+
+Given a quadrature element, the rule then supplies the element rule to use on it:
+
+```@docs
+get_element_quadrature_rule
+```
+
+These four functions are the whole interface a global rule must provide; the default
+implementations of the last two exist only to produce a clear error for types that have not
+implemented them.
+
+### [StandardQuadrature](@id QuadratureStandard)
+
+The common case is the same rule everywhere, with base and quadrature elements coinciding:
+
+```@docs
+StandardQuadrature
+get_canonical_quadrature_rule
+```
+
+This is what most of `Mantis` uses. Constructing one requires only an element rule and the
+number of elements in the geometry:
+
+```@repl QuadratureExample
+using Mantis
+qrule = Quadrature.tensor_product_rule((3, 3), Quadrature.gauss_legendre);
+Quadrature.get_label(qrule)
+Points.get_input_points(Quadrature.get_nodes(qrule))
+sum(Quadrature.get_weights(qrule))
+dΩ = Quadrature.StandardQuadrature(qrule, 4);
+Quadrature.get_num_evaluation_elements(dΩ)
+```
+
+## [Helper functions](@id QuadratureHelpers)
+
+Discretisations built on a de Rham complex frequently need several rules at once, of the same
+family but with different numbers of points. Building them individually is verbose, so the
+module provides a helper that constructs a whole tuple:
+
+```@docs
+get_canonical_quadrature_rules
+```
+
+A companion function, `get_global_quadrature_rules`, wraps each of these in a
+[`StandardQuadrature`](@ref) for a given number of elements.
+
+### [Internals: tensor-product weights](@id QuadratureInternalWeights)
+!!! note "Internal behaviour"
+    We explain how tensor-product weights are formed. However, this is considered an
+    implementational detail.
+
+The weights of a tensor-product rule are the products of the factor weights, laid out in the
+linear order that [TensorProducts](@ref DocTensorProductsModule) uses for the corresponding
+nodes, so that weight `i` always pairs with node `i`.
+
+```@docs
+_compute_tensor_product
+```
+
+## [Relationships to Other Modules](@id QuadratureRelationships)
+
+- **[Points](@ref DocPointsModule)**: quadrature nodes *are* `AbstractPoints`, and
+  multidimensional rules use `TensorProductPoints`.
+- [TensorProducts](@ref DocTensorProductsModule): supplies the index bookkeeping that relates
+  the linear ordering of tensor-product nodes and weights to their per-dimension factors.
+- **[Forms](@ref)**: the [integral operator](@ref FormsIntegrals) stores an
+  `AbstractGlobalQuadratureRule` and uses it to evaluate integrals of forms; the terminology
+  of evaluation elements used there is the one defined above.
+- [Assemblers](@ref DocAssemblyModule): weak formulations take global rules as arguments and
+  pass them to the integrals they assemble.
+- [Geometry](@ref DocGeometryModule): supplies the Jacobian that maps an integral on the
+  canonical domain to the physical element, which is why the rules themselves need no
+  knowledge of the mesh.
+
+## [References](@id QuadratureReferences)
+
+The Clenshaw-Curtis implementation follows the FFT-based algorithm of [Waldvogel2006](@cite);
+for its accuracy relative to Gauss quadrature see [Trefethen2008](@cite) and
+[Trefethen2022](@cite).

--- a/src/Quadrature/Quadrature.jl
+++ b/src/Quadrature/Quadrature.jl
@@ -1,3 +1,14 @@
+"""
+    module Quadrature
+
+Provides quadrature rules, i.e. sets of nodes and weights that approximate integrals by
+weighted sums.
+
+Rules are defined on the canonical domain ``[0, 1]^n``, matching the convention used by
+[Points](@ref DocPointsModule) and [Geometry](@ref DocGeometryModule), so that a single rule
+can be reused on every element of a mesh. The module distinguishes rules on a single element
+from rules covering a whole domain, and is used by [Forms](@ref) to evaluate integrals.
+"""
 module Quadrature
 
 import FastGaussQuadrature


### PR DESCRIPTION
This pr introduces skills to be used by coding agents. (The first commit is unrelated, it's just for some tools that I use.)

The important directory is `.ai`. This should contain all the relevant skills to be used by coding agents. The point of this is to avoid having to maintain duplicate versions of the same skills for (Copilot, Claude, etc...).

Therefore, we should write `.ai/skill/someskill.md`. Then, we run the script `.ai/sync.sh` which will populate all the found skills in a format the agents understand. (For example, `.claude/skills/someskill/SKILL.md`). Same thing for the instructions.

I also included `.ai/check.sh`, which checks if all the skills are up-to-date with `.ai`. We can add this as an action to prevent forgetting to update files.

Finally, I also populated `.ai/skills` with some skills I think will be useful.