### PR TITLE
Doc/add assemblers docs

### DIFF
--- a/docs/src/Design/Modules/Assemblers.md
+++ b/docs/src/Design/Modules/Assemblers.md
@@ -1,6 +1,175 @@
+```@meta
+CurrentModule = Mantis.Assemblers
+```
 # [Assemblers](@id DocAssemblyModule)
 
-## All docstrings from Mantis.Assemblers
-```@autodocs
-Modules = [Mantis.Assemblers]
+The assembly module contains two important pieces for assembly: the weak formulation and the assembly routine itself.
+The weak formulation contains all the terms that need to be assembled, the assembler creates the final system matrix.
+
+## [Weak Formulations](@id AssemblersWeakForms)
+A weak formulation describes the problem in detail, see [The Finite Element Method (FEM)](@ref) for more information.
+It consists of a few key ingredients: the given data (forcings, boundary conditions, etc.), the trial spaces, the test spaces, and the equations.
+In `Mantis`, there are two structures that are used to represent all this data: `WeakFormInputs` and `WeakForm`.
+
+### Representing problem data using `WeakFormInputs`
+The data, trial spaces, and test spaces are represented by the following object.
+```@docs
+WeakFormInputs
 ```
+
+The following getters are defined to obtain the data from a `WeakFormInputs` object.
+```@docs
+get_trial_forms(wfi::WeakFormInputs)
+get_test_forms(wfi::WeakFormInputs)
+get_forcings(wfi::WeakFormInputs)
+get_trial_form(wfi::WeakFormInputs, i::Int=1)
+get_test_form(wfi::WeakFormInputs, i::Int=1)
+get_forcing(wfi::WeakFormInputs, i::Int=1)
+get_num_trial(wfi::WeakFormInputs)
+get_num_test(wfi::WeakFormInputs)
+get_num_forcings(wfi::WeakFormInputs)
+```
+
+### Representing weak formulations using `WeakForm`
+The complete weak formulation is represented by the following object, that takes a `WeakFormInputs` and the left-hand and right-hand sides of the equations as inputs.
+```@docs
+WeakForm
+```
+
+For this object, the following getters are defined.
+```@docs
+get_lhs_expressions
+get_rhs_expressions
+get_inputs
+get_test_forms(wf::WeakForm)
+get_trial_forms(wf::WeakForm)
+get_forcings(wf::WeakForm)
+get_forcing(wf::WeakForm, id::Int=1)
+get_test_sizes
+get_trial_sizes
+get_test_size
+get_trial_size
+get_lhs_size
+get_rhs_size
+get_test_offsets
+get_trial_offsets
+get_estimated_nnz_per_elem
+get_num_elements
+get_num_evaluation_elements
+```
+
+### Example: setting up a weak form.
+As an example, consider the mixed ``n``-form Hodge-Laplacian in 3D also treated in [Finite Element Exterior Calculus (FEEC)](@ref).
+The weak formulation is written as:
+Given ``f \in L^2(\Omega)``, find ``(\sigma_h, u_h) \in V_h^{2} \times V_h^3`` such that
+```math
+    \begin{equation}
+        \begin{split}
+            (\sigma_h, \tau_h) - (u_h, d \tau_h) &= 0, \quad \forall \tau_h \in V_h^{2},\\
+            (d \sigma_h, v_h) &= (f, v_h), \quad \forall v_h \in V_h^3.
+        \end{split}
+    \end{equation}
+```
+We first create a `WeakFormInputs` object containing the test and trial spaces (which are the same in this case, so we only have to include them once), and the forcing (which we set to return one here for simplicity).
+```@repl nFormHodgeLaplacianWeakForm
+using Mantis
+V0, V1, V2, V3 = Forms.create_tensor_product_bspline_de_rham_complex(
+    (0.0, 0.0, 0.0), (1.0, 1.0, 1.0), (4, 4, 4), (3, 3, 3), (2, 2, 2)
+);
+
+geometry = Forms.get_geometry(V2);
+
+forcing_function(x) = [ones(size(x, 1))]
+f = Forms.AnalyticalFormField(3, forcing_function, geometry, "f");
+
+weak_form_inputs = Assemblers.WeakFormInputs((V2, V3), (f,));
+```
+With the `WeakFormInputs` object ready, we can create the complete `WeakForm` object.
+Note that the `lhs_expressions` and `rhs_expressions` contain the integer `0` where we don't need a term.
+```@repl nFormHodgeLaplacianWeakForm
+canonical_qrule = Quadrature.tensor_product_rule((4, 4, 4), Quadrature.gauss_legendre);
+dΩ = Quadrature.StandardQuadrature(canonical_qrule, Geometry.get_num_elements(geometry));
+
+τ_h, v_h = Assemblers.get_test_forms(weak_form_inputs);
+σ_h, u_h = Assemblers.get_trial_forms(weak_form_inputs);
+f = Assemblers.get_forcing(weak_form_inputs);
+
+A_11 = ∫(τ_h ∧ ★(σ_h), dΩ);
+A_12 = -∫(d(τ_h) ∧ ★(u_h), dΩ);
+A_21 = ∫(v_h ∧ ★(d(σ_h)), dΩ);
+lhs_expressions = ((A_11, A_12), (A_21, 0));
+
+b_21 = ∫(v_h ∧ ★(f), dΩ);
+rhs_expressions = ((0,), (b_21,));
+
+weak_form = Assemblers.WeakForm(lhs_expressions, rhs_expressions, weak_form_inputs);
+```
+
+The weak form object can now be assembled using the [`assemble`](@ref) function.
+
+### [Pre-implemented weak formulations](@id AssemblersWeakForms)
+While you can always write your own weak formulation, `Mantis` does provide a few common pre-made weak formulations. 
+The pre-implemented weak formulations require input spaces, forcings, and quadrature, but simplify the remaining steps.
+Most pre-implemented weak formulations consist of two parts: one that encodes the equations, another that also performs the remaining setup and solve steps.
+
+::: details ``L^2``-projection
+```@docs
+L2_projection
+solve_L2_projection
+```
+:::
+
+::: details Hodge-Laplacians
+```@docs
+zero_form_hodge_laplacian
+solve_zero_form_hodge_laplacian
+one_form_hodge_laplacian
+solve_one_form_hodge_laplacian
+n_form_hodge_laplacian
+solve_volume_form_hodge_laplacian
+```
+:::
+
+::: details Maxwell Eigenvalue Problems
+
+In this case, next to the functions `maxwell_eigenvalue` and `solve_maxwell_eig`, `Mantis` also provides two functions to obtain the analytical eigenvalues.
+```@docs
+maxwell_eigenvalue
+analytical_maxwell_eigenfunction
+get_analytical_maxwell_eig
+solve_maxwell_eig
+```
+:::
+
+## Assembling a weak formulation
+In `Mantis`, the actual assembly routine can be used by simply calling the following function.
+```@docs
+assemble
+```
+So, continuing the previous example, we can assemble our problem by simply calling
+```@repl nFormHodgeLaplacianWeakForm
+A, b = Assemblers.assemble(weak_form);
+```
+This gives us the left-hand side matrix `A` and right-hand side vector `b`. 
+You can solve this with a solver of your choosing.
+Here we pick Julia's backslash operator.
+We can obtain the final solution as a `FormField` using the `build_form_fields` helper.
+This helper takes the trial spaces and full solution vector as inputs, and combines the spaces and coefficients into the final solution objects.
+```@repl nFormHodgeLaplacianWeakForm
+sol = A \ b;
+sigma_h, u_h = Forms.build_form_fields((V2, V3), sol);
+```
+
+::: details Helpers used within `assemble`
+
+The assembly module also provides the following helper functions that are used within the assembly routine.
+```@docs
+get_pre_allocation
+add_expression_contributions!
+zero_rows!
+add_bc!
+set_diagonal!
+build_array
+```
+
+:::

--- a/src/Assemblers/Assemblers.jl
+++ b/src/Assemblers/Assemblers.jl
@@ -1,12 +1,7 @@
-"""
-    module Assemblers
-
-Contains all assembly-related structs and functions.
-"""
 module Assemblers
 
 import LinearAlgebra
-import SparseArrays; const spa = SparseArrays
+import SparseArrays as spa
 
 using ..Geometry
 using ..Forms
@@ -14,6 +9,54 @@ using ..Quadrature
 using ..Mesh
 using ..FunctionSpaces
 using ..Analysis
+
+# These exports make these symbols/functions/etc. available outside the Forms module. Only
+# if they are also exported in the Mantis.jl file will they be available when using Mantis.
+
+# Abstract types
+# The public keyword is only available in Julia 1.11 and up. Since we also support LTS
+# (currently 1.10), we add the following line from the manual:
+# https://docs.julialang.org/en/v1.12/manual/modules/#Export-lists
+VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse("public AbstractInputs"))
+
+# Global Assemblers
+export assemble
+
+# Weakforms and WeakFormInputs
+export WeakFormInputs,
+    WeakForm,
+    get_lhs_expressions,
+    get_rhs_expressions,
+    get_inputs,
+    get_test_forms,
+    get_trial_forms,
+    get_forcings,
+    get_forcing,
+    get_test_sizes,
+    get_trial_sizes,
+    get_test_size,
+    get_trial_size,
+    get_lhs_size,
+    get_rhs_size,
+    get_test_offsets,
+    get_trial_offsets,
+    get_estimated_nnz_per_elem,
+    get_num_elements,
+    get_num_evaluation_elements
+
+# Pre-defined weak formulations
+export L2_projection,
+    solve_L2_projection,
+    zero_form_hodge_laplacian,
+    solve_zero_form_hodge_laplacian,
+    one_form_hodge_laplacian,
+    solve_one_form_hodge_laplacian,
+    n_form_hodge_laplacian,
+    solve_volume_form_hodge_laplacian,
+    maxwell_eigenvalue,
+    analytical_maxwell_eigenfunction,
+    get_analytical_maxwell_eig,
+    solve_maxwell_eig
 
 abstract type AbstractInputs end
 

--- a/src/Assemblers/GlobalAssemblers.jl
+++ b/src/Assemblers/GlobalAssemblers.jl
@@ -301,7 +301,6 @@ end
 
 Remove the rows and columns of `lhs` and `rhs` as specified by the keys of `dirichlet_bcs`.
 See also [`set_diagonal!`](@ref).
-```
 """
 function add_bc!(lhs::AbstractMatrix, rhs::AbstractMatrix, dirichlet_bcs::Dict)
     return set_diagonal!(lhs, rhs, dirichlet_bcs)

--- a/src/Assemblers/GlobalAssemblers.jl
+++ b/src/Assemblers/GlobalAssemblers.jl
@@ -58,33 +58,37 @@ function assemble(
     rhs_rows, rhs_cols, rhs_vals = get_pre_allocation(weak_form, "rhs", rhs_type)
     lhs_counts, rhs_counts = 0, 0
     # TODO: The loop over elements should also handle boundary integrals.
-    # PERF: We might what to make the loop over elements the inner most one; that way we can
-    # skip the 0 expressions instead of checking them everytime.
-    for elem_id in 1:get_num_elements(weak_form), row in 1:num_rows
-        for col in 1:lhs_num_cols
-            lhs_rows, lhs_cols, lhs_vals, lhs_counts = add_expression_contributions!(
-                lhs_rows,
-                lhs_cols,
-                lhs_vals,
-                lhs_counts,
-                lhs_expressions[row][col],
-                elem_id,
-                test_offsets[row],
-                trial_offsets[col],
-            )
+
+    # The number of rows is the same, as enforced by the `WeakForm` constructor
+    for (row, (lhs_row, rhs_row)) in enumerate(zip(lhs_expressions, rhs_expressions))
+        for (col, expression) in enumerate(lhs_row)
+            for elem_id in 1:get_num_elements(weak_form)
+                lhs_rows, lhs_cols, lhs_vals, lhs_counts = add_expression_contributions!(
+                    lhs_rows,
+                    lhs_cols,
+                    lhs_vals,
+                    lhs_counts,
+                    expression,
+                    elem_id,
+                    test_offsets[row],
+                    trial_offsets[col],
+                )
+            end
         end
 
-        for col in 1:rhs_num_cols
-            rhs_rows, rhs_cols, rhs_vals, rhs_counts = add_expression_contributions!(
-                rhs_rows,
-                rhs_cols,
-                rhs_vals,
-                rhs_counts,
-                rhs_expressions[row][col],
-                elem_id,
-                test_offsets[row],
-                trial_offsets[col],
-            )
+        for (col, expression) in enumerate(rhs_row)
+            for elem_id in 1:get_num_elements(weak_form)
+                rhs_rows, rhs_cols, rhs_vals, rhs_counts = add_expression_contributions!(
+                    rhs_rows,
+                    rhs_cols,
+                    rhs_vals,
+                    rhs_counts,
+                    expression,
+                    elem_id,
+                    test_offsets[row],
+                    trial_offsets[col],
+                )
+            end
         end
     end
 
@@ -393,7 +397,7 @@ function build_array(
     vals::AbstractVector,
     size::Tuple{Int, Int},
 ) where {A <: AbstractArray}
-    throw(
+    return throw(
         ArgumentError("Assembly of array type `$(array_type)` not currently implemented.")
     )
 end

--- a/src/Assemblers/WeakFormulations/HodgeLaplace/0-form.jl
+++ b/src/Assemblers/WeakFormulations/HodgeLaplace/0-form.jl
@@ -7,21 +7,26 @@
         inputs::AbstractInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule
     )
 
-Function for assembling the weak form of the 0-form Hodge Laplacian.
+Set up the equations for the ``0``-form Hodge-Laplacian. Does not specify any boundary
+conditions.
+
+Weak form: for given ``f^0 \\in L^2\\Lambda^0(\\Omega)``, find
+``u^0 \\in H^1\\Lambda^0(\\Omega)`` such that
+```math
+    \\int d v^0 \\wedge \\star d u^0 = \\int v^0 \\wedge \\star f^0 \\quad \\forall v^0 \\in H^1_0\\Lambda^0(\\Omega)
+```
 
 # Arguments
-- `inputs::AbstractInputs`: The inputs for the weak form assembly, including test, trial and
-    forcing terms.
+- `inputs::AbstractInputs`: The inputs for the weak form assembly. See
+    [`WeakFormInputs`](@ref) for the details.
 - `dΩ::Quadrature.AbstractGlobalQuadratureRule`: The quadrature rule to use for the integral
     evaluation.
 
 # Returns
-- `lhs_expression<:NTuple{num_lhs_rows, NTuple{num_lhs_cols, AbstractRealValuedOperator}}`:
-    The left-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the left-hand side matrix.
-- `rhs_expression<:NTuple{num_rhs_rows, NTuple{num_rhs_cols, AbstractRealValuedOperator}}`:
-    The right-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the right-hand side matrix.
+- `lhs_expression<:NTuple{1, NTuple{1, AbstractRealValuedOperator}}`: The left-hand side of
+    the weak form.
+- `rhs_expression<:NTuple{1, NTuple{1, AbstractRealValuedOperator}}`: The right-hand side
+    of the weak form.
 """
 function zero_form_hodge_laplacian(
     inputs::AbstractInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule
@@ -40,7 +45,14 @@ end
 """
     solve_zero_form_hodge_laplacian(X⁰, fₑ, dΩ)
 
-Returns the solution of the weak form of the 0-form Hodge Laplacian.
+Returns the solution of the weak form of the 0-form Hodge Laplacian using homogeneous
+Dirichlet boundary conditions.
+
+Weak form: for given ``f_e^0 \\in L^2\\Lambda^k(\\Omega)``, find
+``u_h^0 \\in X^0_0`` such that
+```math
+    \\int d v^0 \\wedge \\star d u_h^0 = \\int v^0 \\wedge \\star f_e^0 \\quad \\forall v^0 \\in X^0
+```
 
 # Arguments
 - `X⁰`: The 0-form space to use as trial and test space.
@@ -48,7 +60,7 @@ Returns the solution of the weak form of the 0-form Hodge Laplacian.
 - `dΩ`: The quadrature rule to use for the assembly.
 
 # Returns
-- `::Forms.FormField`: The solution of the weak-formulation.
+- `uₕ::Forms.FormField`: The solution of the weak-formulation.
 """
 function solve_zero_form_hodge_laplacian(X⁰, fₑ, dΩ)
     weak_form_inputs = WeakFormInputs(X⁰, fₑ)

--- a/src/Assemblers/WeakFormulations/HodgeLaplace/1-form.jl
+++ b/src/Assemblers/WeakFormulations/HodgeLaplace/1-form.jl
@@ -7,21 +7,30 @@
         inputs::AbstractInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule
     )
 
-Function for assembling the weak form of the 1-form Hodge Laplacian problem.
+Set up the equations for the ``1``-form Hodge-Laplacian. Does not specify any boundary
+conditions.
+
+Weak form: for given ``f^1 \\in L^2\\Lambda^1(\\Omega)``, find
+``\\sigma^0, u^1 \\in H^1\\Lambda^{0}(\\Omega) \\times H(\\text{curl})\\Lambda^1(\\Omega)`` such that
+```math
+\\begin{align}
+    \\int \\tau^0 \\wedge \\star \\sigma^0 - \\int d \\tau^{0} \\wedge \\star u^1 &= 0 \\quad &&\\forall \\tau^{0} \\in H^1\\Lambda^{0}(\\Omega) \\\\
+    \\int v^1 \\wedge \\star d \\sigma^0 + \\int d v^1 \\wedge \\star d u^1 &= \\int v^1 \\wedge \\star f^1 \\quad &&\\forall v^1 \\in H(\\text{curl})\\Lambda^1(\\Omega)
+\\end{align}
+```
 
 # Arguments
-- `inputs::AbstractInputs`: The inputs for the weak form assembly, including test, trial and
-    forcing terms.
+- `inputs::AbstractInputs`: The inputs for the weak form assembly. See
+    [`WeakFormInputs`](@ref) for the details.
 - `dΩ::Quadrature.AbstractGlobalQuadratureRule`: The quadrature rule to use for the integral
     evaluation.
 
 # Returns
-- `lhs_expressions<:NTuple{num_lhs_rows, NTuple{num_lhs_cols, AbstractRealValuedOperator}}`:
-    The left-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the left-hand side matrix.
-- `rhs_expressions<:NTuple{num_rhs_rows, NTuple{num_rhs_cols, AbstractRealValuedOperator}}`:
-    The right-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the right-hand side matrix.
+- `lhs_expression<:NTuple{2, NTuple{2, Union{Int, AbstractRealValuedOperator}}}`: The
+    left-hand side of the weak form.
+- `rhs_expression<:NTuple{2, NTuple{1, Union{Int, AbstractRealValuedOperator}}}`: The
+    right-hand side of the weak form.
+Function for assembling the weak form of the 1-form Hodge Laplacian problem.
 """
 function one_form_hodge_laplacian(
     inputs::AbstractInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule
@@ -45,6 +54,15 @@ end
 
 Returns the solution of the weak form of the 1-form Hodge Laplacian.
 
+Weak form: for given ``f^1 \\in L^2\\Lambda^1(\\Omega)``, find
+``\\sigma^0_h, u^1_h \\in X^0 \\times X^1`` such that
+```math
+\\begin{align}
+    \\int \\tau^0_h \\wedge \\star \\sigma^0_h - \\int d \\tau^{0}_h \\wedge \\star u^1_h &= 0 \\quad &&\\forall \\tau^{0}_h \\in X^0 \\\\
+    \\int v^1_h \\wedge \\star d \\sigma^0_h + \\int d v^1_h \\wedge \\star d u^1_h &= \\int v^1 \\wedge \\star f^1 \\quad &&\\forall v^1_h \\in X^1
+\\end{align}
+```
+
 # Arguments
 - `X⁰`: The 0-form space to use as trial and test space.
 - `X¹`: The 1-form space to use as trial and test space.
@@ -52,7 +70,7 @@ Returns the solution of the weak form of the 1-form Hodge Laplacian.
 - `dΩ`: The quadrature rule to use for the assembly.
 
 # Returns
-- `δu¹ₕ::Forms.FormField`: The 0-form solution of the weak-formulation.
+- `σ⁰ₕ::Forms.FormField`: The 0-form solution of the weak-formulation.
 - `u¹ₕ::Forms.FormField`: The 1-form solution of the weak-formulation.
 """
 function solve_one_form_hodge_laplacian(X⁰, X¹, f¹, dΩ, bc_type="")

--- a/src/Assemblers/WeakFormulations/HodgeLaplace/n-form.jl
+++ b/src/Assemblers/WeakFormulations/HodgeLaplace/n-form.jl
@@ -7,21 +7,29 @@
         inputs::WeakFormInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule
     )
 
-Function for assembling the weak form of the n-form Hodge Laplacian problem.
+Set up the equations for the ``n``-form Hodge-Laplacian. Does not specify any boundary
+conditions.
+
+Weak form: for given ``f^n \\in L^2\\Lambda^n(\\Omega)``, find
+``u^{n-1}, \\phi^n \\in H(\\text{div})\\Lambda^{n-1}(\\Omega) \\times L^2\\Lambda^n(\\Omega)`` such that
+```math
+\\begin{align}
+    \\int \\epsilon^{n-1} \\wedge \\star u^{n-1} - \\int d \\epsilon^{n-1} \\wedge \\star \\phi^n &= 0 \\quad &&\\forall \\epsilon^{n-1} \\in H(\\text{div})\\Lambda^{n-1}(\\Omega) \\\\
+    \\int \\epsilon^n \\wedge \\star d u^{n-1} &= \\int \\epsilon^n \\wedge \\star f^n \\quad &&\\forall \\epsilon^n \\in L^2\\Lambda^n(\\Omega)
+\\end{align}
+```
 
 # Arguments
-- `inputs::WeakFormInputs`: The inputs for the weak form assembly, including test, trial and
-    forcing terms.
+- `inputs::AbstractInputs`: The inputs for the weak form assembly. See
+    [`WeakFormInputs`](@ref) for the details.
 - `dΩ::Quadrature.AbstractGlobalQuadratureRule`: The quadrature rule to use for the integral
     evaluation.
 
 # Returns
-- `lhs_expressions<:NTuple{num_lhs_rows, NTuple{num_lhs_cols, AbstractRealValuedOperator}}`:
-    The left-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the left-hand side matrix.
-- `rhs_expressions<:NTuple{num_rhs_rows, NTuple{num_rhs_cols, AbstractRealValuedOperator}}`:
-    The right-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the right-hand side matrix.
+- `lhs_expression<:NTuple{2, NTuple{2, Union{Int, AbstractRealValuedOperator}}}`: The
+    left-hand side of the weak form.
+- `rhs_expression<:NTuple{2, NTuple{1, Union{Int, AbstractRealValuedOperator}}}`: The
+    right-hand side of the weak form.
 """
 function n_form_hodge_laplacian(
     inputs::WeakFormInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule
@@ -44,6 +52,15 @@ end
 
 Returns the solution of the weak form of the n-form Hodge Laplacian.
 
+Weak form: for given ``f_e^n \\in L^2\\Lambda^n(\\Omega)``, find
+``u^{n-1}_h, \\phi^n_h \\in X^{n-1} \\times X^n`` such that
+```math
+\\begin{align}
+    \\int \\epsilon^{n-1}_h \\wedge \\star u^{n-1}_h - \\int d \\epsilon^{n-1}_h \\wedge \\star \\phi^n_h &= 0 \\quad &&\\forall \\epsilon^{n-1}_h \\in X^{n-1} \\\\
+    \\int \\epsilon^n_h \\wedge \\star d u^{n-1}_h &= \\int \\epsilon^n_h \\wedge \\star f_e^n \\quad &&\\forall \\epsilon^n_h \\in X^{n}
+\\end{align}
+```
+
 # Arguments
 - `Xⁿ⁻¹`: The (n-1)-form space to use as trial and test space.
 - `Xⁿ`: The n-form space to use as trial and test space.
@@ -51,8 +68,8 @@ Returns the solution of the weak form of the n-form Hodge Laplacian.
 - `dΩ`: The quadrature rule to use for the assembly.
 
 # Returns
-- `u¹ₕ`: The (n-1)-form solution of the weak-formulation.
-- `ϕ²ₕ`: The n-form solution of the weak-formulation.
+- `uⁿ⁻¹ₕ`: The (n-1)-form solution of the weak-formulation.
+- `ϕⁿₕ`: The n-form solution of the weak-formulation.
 """
 function solve_volume_form_hodge_laplacian(Xⁿ⁻¹, Xⁿ, fₑ, dΩ)
     weak_form_inputs = WeakFormInputs((Xⁿ⁻¹, Xⁿ), (fₑ,))

--- a/src/Assemblers/WeakFormulations/L2Projection/L2Projection.jl
+++ b/src/Assemblers/WeakFormulations/L2Projection/L2Projection.jl
@@ -5,21 +5,25 @@
 """
     L2_projection(inputs::AbstractInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule)
 
-Function to compute the L2 projection of a function onto a discrete form space.
+Set up the L2 projection equations of projecting a function onto a discrete form space.
+
+Weak form: for given ``f^k \\in L^2\\Lambda^k(\\Omega)``, find
+``u^k \\in L^2\\Lambda^k(\\Omega)`` such that
+```math
+    \\int v^k \\wedge \\star u^k = \\int v^k \\wedge \\star f^k \\quad \\forall v^k \\in L^2\\Lambda^k(\\Omega)
+```
 
 # Arguments
-- `inputs::AbstractInputs`: The inputs for the weak form assembly, including test, trial and
-    forcing terms.
+- `inputs::AbstractInputs`: The inputs for the weak form assembly. See
+    [`WeakFormInputs`](@ref) for the details.
 - `dΩ::Quadrature.AbstractGlobalQuadratureRule`: The quadrature rule to use for the integral
     evaluation.
 
 # Returns
-- `lhs_expression<:NTuple{num_lhs_rows, NTuple{num_lhs_cols, AbstractRealValuedOperator}}`:
-    The left-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the left-hand side matrix.
-- `rhs_expression<:NTuple{num_rhs_rows, NTuple{num_rhs_cols, AbstractRealValuedOperator}}`:
-    The right-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the right-hand side matrix.
+- `lhs_expression<:NTuple{1, NTuple{1, AbstractRealValuedOperator}}`: The left-hand side of
+    the weak form.
+- `rhs_expression<:NTuple{1, NTuple{1, AbstractRealValuedOperator}}`: The right-hand side
+    of the weak form.
 """
 function L2_projection(inputs::AbstractInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule)
     vᵏ = get_test_form(inputs)
@@ -37,6 +41,12 @@ end
     solve_L2_projection(Xᵏ, fₑ, dΩ)
 
 Returns the solution of the weak form of the L2 projection.
+
+Weak form: for given ``f_e^k \\in L^2\\Lambda^k(\\Omega)``, find
+``f_h^k \\in X^k`` such that
+```math
+    \\int v^k \\wedge \\star f_h^k = \\int v^k \\wedge \\star f_e^k \\quad \\forall v^k \\in X^k
+```
 
 # Arguments
 - `Xᵏ`: The k-form space to use as trial and test space.

--- a/src/Assemblers/WeakFormulations/MaxwellEigenvalue/MaxwellEigenvalue.jl
+++ b/src/Assemblers/WeakFormulations/MaxwellEigenvalue/MaxwellEigenvalue.jl
@@ -5,21 +5,24 @@
 """
     maxwell_eigenvalue(inputs::WeakFormInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule)
 
-Function for assembling the weak form of the Maxwell eigenvalue problem.
+Set up the equations for Maxwell's eigenvalue problem.
+
+Weak form: find ``u^1 \\in H(\\text{curl})\\Lambda^1(\\Omega)`` such that
+```math
+    \\int d v^1 \\wedge \\star d u^1 = \\int v^1 \\wedge \\star u^1 \\quad \\forall v^1 \\in H(\\text{curl})\\Lambda^1(\\Omega)
+```
 
 # Arguments
-- `inputs::WeakFormInputs`: The inputs for the weak form assembly, including test and trial
-    spaces.
+- `inputs::AbstractInputs`: The inputs for the weak form assembly. See
+    [`WeakFormInputs`](@ref) for the details.
 - `dΩ::Quadrature.AbstractGlobalQuadratureRule`: The quadrature rule to use for the integral
     evaluation.
 
 # Returns
-- `lhs_expression<:NTuple{num_lhs_rows, NTuple{num_lhs_cols, AbstractRealValuedOperator}}`:
-    The left-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the left-hand side matrix.
-- `rhs_expression<:NTuple{num_rhs_rows, NTuple{num_rhs_cols, AbstractRealValuedOperator}}`:
-    The right-hand side of the weak form, which is a tuple of tuples contain all the blocks
-    of the right-hand side matrix.
+- `lhs_expression<:NTuple{1, NTuple{1, AbstractRealValuedOperator}}`: The left-hand side of
+    the weak form.
+- `rhs_expression<:NTuple{1, NTuple{1, AbstractRealValuedOperator}}`: The right-hand side
+    of the weak form.
 """
 function maxwell_eigenvalue(
     inputs::WeakFormInputs, dΩ::Quadrature.AbstractGlobalQuadratureRule
@@ -119,10 +122,17 @@ end
 Returns the first `num_eig` eigenvalues and 1-form eigenfunctions of the Maxwell eigenvalue
 problem.
 
+Weak form: find ``u^1 \\in X^1`` such that
+```math
+    \\int d v^1 \\wedge \\star d u^1 = \\int v^1 \\wedge \\star u^1 \\quad \\forall v^1 \\in X^1
+```
+
 # Arguments
-- `X⁰::Forms.AbstractFormSpace{2, 0}`: The 0-form space to use as trial and test space.
+- `X⁰::Forms.AbstractFormSpace{2, 0}`: The 0-form space to compute the nullspace offset
+    with.
 - `X¹::Forms.AbstractFormSpace{2, 1}`: The 1-form space to use as trial and test space.
-- `dΩ::Quadrature.AbstractGlobalQuadratureRule{2}`: The quadrature rule to use for the assembly.
+- `dΩ::Quadrature.AbstractGlobalQuadratureRule{2}`: The quadrature rule to use for the
+    assembly.
 - `num_eig::Int`: The number of eigenvalues and eigenfunctions to compute.
 - `verbose::Bool=false`: Whether to print the nullspace offset.
 
@@ -165,8 +175,9 @@ function solve_maxwell_eig(
         u¹ₕ[eig_id] = Forms.FormField(
             X¹, zeros(Forms.get_num_basis(X¹)), original_label * subscript_str
         )
-        u¹ₕ[eig_id].coefficients[non_boundary_rows_cols] .=
-            real.(eig_vecs[:, nullspace_offset + eig_id])
+        u¹ₕ[eig_id].coefficients[non_boundary_rows_cols] .= real.(
+            eig_vecs[:, nullspace_offset + eig_id]
+        )
     end
 
     return ωₕ², u¹ₕ
@@ -244,7 +255,9 @@ function solve_maxwell_eig(
             H⁰, dorfler_marking
         )
         if Lchains
-            domains = FunctionSpaces.update_domains_with_lchains!(H⁰, marked_elements_per_level)
+            domains = FunctionSpaces.update_domains_with_lchains!(
+                H⁰, marked_elements_per_level
+            )
             complex = Forms.update_hierarchical_de_rham_complex(complex, domains)
         else
             complex = Forms.update_hierarchical_de_rham_complex(

--- a/src/Assemblers/WeakFormulations/WeakForm.jl
+++ b/src/Assemblers/WeakFormulations/WeakForm.jl
@@ -10,11 +10,75 @@ the left and right-hand sides of the formulation are given as blocks of real-val
 operators; these are defined from a set of inputs holding the test, trial and forcing terms,
 and a constructor method that defines where the blocks are placed.
 
+# Constructors
+- `WeakForm(
+        lhs_expressions::LHS, rhs_expressions::RHS, inputs::I
+    ) where {
+        manifold_dim,
+        lhs_num_rows,
+        lhs_num_cols,
+        rhs_num_rows,
+        rhs_num_cols,
+        LHS <: NTuple{
+            lhs_num_rows, NTuple{lhs_num_cols, Union{Int, Forms.AbstractRealValuedOperator}}
+        },
+        RHS <: NTuple{
+            rhs_num_rows, NTuple{rhs_num_cols, Union{Int, Forms.AbstractRealValuedOperator}}
+        },
+        I <: WeakFormInputs{manifold_dim},
+    }`: Creates a new `WeakForm` instance with the given inputs (the problem data and
+        spaces, see [`WeakFormInputs`](@ref) for more details), and the left- and
+        right-hand side expressions.
+
+# Example
+```jldoctest
+julia> using Mantis
+
+julia> V0, V1, V2, V3 = Forms.create_tensor_product_bspline_de_rham_complex((0.0, 0.0, 0.0), (1.0, 1.0, 1.0), (4, 4, 4), (3, 3, 3), (2, 2, 2));
+
+julia> geometry = Forms.get_geometry(V2);
+
+julia> forcing_function(x) = [ones(size(x))];
+
+julia> f = Forms.AnalyticalFormField(3, forcing_function, geometry, "f");
+
+julia> weak_form_inputs = Assemblers.WeakFormInputs((V2, V3), (f,));
+
+julia> canonical_qrule = Quadrature.tensor_product_rule((4, 4, 4), Quadrature.gauss_legendre);
+
+julia> dΩ = Quadrature.StandardQuadrature(canonical_qrule, Geometry.get_num_elements(geometry));
+
+julia> tau_h, v_h = Assemblers.get_test_forms(weak_form_inputs);
+
+julia> sigma_h, u_h = Assemblers.get_trial_forms(weak_form_inputs);
+
+julia> f = Assemblers.get_forcing(weak_form_inputs);
+
+julia> A_11 = ∫(tau_h ∧ ★(sigma_h), dΩ);
+
+julia> A_12 = -∫(d(tau_h) ∧ ★(u_h), dΩ);
+
+julia> A_21 = ∫(v_h ∧ ★(d(sigma_h)), dΩ);
+
+julia> lhs_expressions = ((A_11, A_12), (A_21, 0));
+
+julia> b_21 = ∫(v_h ∧ ★(f), dΩ);
+
+julia> rhs_expressions = ((0,), (b_21,));
+
+julia> weak_form = Assemblers.WeakForm(lhs_expressions, rhs_expressions, weak_form_inputs);
+
+julia> isa(weak_form, Assemblers.WeakForm{3})
+true
+
+```
+
 # Fields
 - `lhs_expressions::LHS`: The left-hand side blocks of the weak-formulation.
 - `rhs_expressions::RHS`: The right-hand side blocks of the weak-formulation.
 - `inputs::I`: The inputs for the weak-formulation, which include the test and trial spaces,
     and forcing terms.
+
 # Type parameters
 - `manifold_dim::Int`: The dimension of the manifold where the weak-formulation is defined.
 - `LHS`: The type of the left-hand side expressions. Each row-column entry should be a
@@ -22,10 +86,6 @@ and a constructor method that defines where the blocks are placed.
 - `RHS`: The type of the right-hand side expressions. Each row-column entry should be a
     subtype of  `AbstractRealValuedOperator` or `0`.
 - `I`: The type of the inputs. It should be a subtype of `WeakFormInputs{manifold_dim}`.
-# Inner constructors
-- `WeakForm(inputs::I, constructor::F)`: Creates a new `WeakForm` instance with the given
-    inputs and constructor function. The constructor function is used to generate the
-    left-hand side and right-hand side blocks of real-valued operators.
 """
 struct WeakForm{manifold_dim, LHS, RHS, I}
     lhs_expressions::LHS
@@ -90,18 +150,106 @@ end
 #                                         Getters                                          #
 ############################################################################################
 
+"""
+    get_lhs_expressions(wf::WeakForm)
+
+Return a tuple of [`Forms.AbstractRealValuedOperator`](@ref) representing the left-hand
+sides of the weak formulation.
+"""
 get_lhs_expressions(wf::WeakForm) = wf.lhs_expressions
+
+"""
+    get_rhs_expressions(wf::WeakForm)
+
+Return a tuple of [`Forms.AbstractRealValuedOperator`](@ref) representing the right-hand
+sides of the weak formulation.
+"""
 get_rhs_expressions(wf::WeakForm) = wf.rhs_expressions
+
+"""
+    get_inputs(wf::WeakForm)
+
+Return the [`WeakFormInputs`](@ref) object used in the weak form.
+"""
 get_inputs(wf::WeakForm) = wf.inputs
+
+"""
+    get_test_forms(wf::WeakForm)
+
+Return a tuple of [`Forms.AbstractFormSpace`](@ref) that are used as test spaces.
+"""
 get_test_forms(wf::WeakForm) = get_test_forms(get_inputs(wf))
+
+"""
+    get_trial_forms(wf::WeakForm)
+
+Return a tuple of [`Forms.AbstractFormSpace`](@ref) that are used as trial spaces.
+"""
 get_trial_forms(wf::WeakForm) = get_trial_forms(get_inputs(wf))
+
+"""
+    get_forcings(wf::WeakForm)
+
+Return a tuple of [`Forms.AbstractFormField`](@ref) that are used as test spaces.
+"""
 get_forcings(wf::WeakForm) = get_forcings(get_inputs(wf))
+
+"""
+    get_forcing(wf::WeakForm, id::Int=1)
+
+Return the `id`-th forcing [`Forms.AbstractFormField`](@ref).
+"""
 get_forcing(wf::WeakForm, id::Int=1) = get_forcing(get_inputs(wf), id)
+
+"""
+    get_test_sizes(wf::WeakForm)
+
+Return the number of degrees of freedom for each test form. Uses
+[`Forms.get_num_basis`](@ref).
+"""
 get_test_sizes(wf::WeakForm) = Forms.get_num_basis.(get_test_forms(wf))
+
+"""
+    get_trial_sizes(wf::WeakForm)
+
+Return the number of degrees of freedom for each trial form. Uses
+[`Forms.get_num_basis`](@ref).
+"""
 get_trial_sizes(wf::WeakForm) = Forms.get_num_basis.(get_trial_forms(wf))
+
+"""
+    get_test_size(wf::WeakForm)
+
+Return the total number of degrees of freedom for all test forms combined.
+"""
 get_test_size(wf::WeakForm) = sum(get_test_sizes(wf))
+
+"""
+    get_trial_size(wf::WeakForm)
+
+Return the total number of degrees of freedom for all trial forms combined.
+"""
 get_trial_size(wf::WeakForm) = sum(get_trial_sizes(wf))
+
+"""
+    get_lhs_size(wf::WeakForm)
+
+Return the size of the left-hand-side matrix. Does not require assembly.
+"""
 get_lhs_size(wf::WeakForm) = get_test_size(wf), get_trial_size(wf)
+
+"""
+    get_rhs_size(wf::WeakForm)
+
+Return the size of the right-hand-side matrix (or vector). Does not require assembly.
+"""
+function get_rhs_size(wf::WeakForm)
+    if isnothing(get_forcing(wf))
+        return get_test_size(wf), get_trial_size(wf)
+    end
+
+    return get_test_size(wf), 1
+end
 
 """
     get_test_offsets(
@@ -193,14 +341,6 @@ function get_trial_offsets(
     return ntuple(exp_id -> trial_cumsum[exp_id], lhs_num_cols)
 end
 
-function get_rhs_size(wf::WeakForm)
-    if isnothing(get_forcing(wf))
-        return get_test_size(wf), get_trial_size(wf)
-    end
-
-    return get_test_size(wf), 1
-end
-
 """
     get_estimated_nnz_per_elem(wf::WeakForm)
 
@@ -257,7 +397,9 @@ function get_num_elements(wf::WeakForm)
         return Forms.get_num_elements(expression)
     end
 
-    throw(ArgumentError("No elements found in the left-hand side of the weak-formulation."))
+    return throw(
+        ArgumentError("No elements found in the left-hand side of the weak-formulation.")
+    )
 end
 
 """

--- a/src/Assemblers/WeakFormulations/WeakFormInputs.jl
+++ b/src/Assemblers/WeakFormulations/WeakFormInputs.jl
@@ -1,28 +1,16 @@
 """
     WeakFormInputs{manifold_dim, TeF, TrF, F} <: AbstractInputs
 
-Container for test and trial spaces, and forcing terms to be used in a weak-formulation.
+Container for test and trial spaces, and forcing terms to be used in a [`WeakForm`](@ref).
 
-# Fields
-- `test_forms::TeF`: The test forms for the weak-formulation.
-- `trial_forms::TrF`: The trial forms for the weak-formulation.
-- `forcings::F`: The forcing terms for the weak-formulation, possibly nothing.
-# Type parameters
-- `manifold_dim::Int`: The dimension of the manifold where the weak-formulation is defined.
-- `TeF`: The type of the tupe of test forms. Each entry should be a subtype of
-    `Forms.AbstractFormSpace`.
-- `TrF`: The type of the tupe of trial forms. Each entry should be a subtype of
-    `Forms.AbstractFormSpace`.
-- `F`: The type of the tupe of forcing terms. Each entry should be a subtype of
-    `Forms.AbstractFormField`.
-# Inner constructors
+# Constructors
 - `WeakFormInputs(test_forms::TeF, trial_forms::TrF, forcings::F)`: Creates a new
     `WeakFormInputs` instance with the given test forms, trial forms, and forcing terms.
 - `WeakFormInputs(test_forms::TeF, trial_forms::TrF)`: Creates a new `WeakFormInputs`
     instance with the given test forms and trial forms. The forcing terms are set to
     nothing.
 - `WeakFormInputs(test_forms::TeF, trial_forms::TrF, forcing::F)`: Creates a new
-    `WeakFormInputs` instance from a single test and trial space and a forcing term. 
+    `WeakFormInputs` instance from a single test and trial space and a forcing term.
 - `WeakFormInputs(test_forms::TeF, trial_forms::TrF)`: Creates a new `WeakFormInputs`
     instance from a single test and trial space. The forcing terms are set to nothing.
 - `WeakFormInputs(forms::TrF, forcing::F)`: Creates a new `WeakFormInputs` instance with the
@@ -37,6 +25,39 @@ Container for test and trial spaces, and forcing terms to be used in a weak-form
 - `WeakFormInputs(forms::TrF)`: Creates a new `WeakFormInputs` instance with a single trial
     space. The test space is set to the same as the trial space and the forcing term is set
     to nothing.
+
+# Example
+```jldoctest
+julia> using Mantis
+
+julia> V0, V1, V2, V3 = Forms.create_tensor_product_bspline_de_rham_complex((0.0, 0.0, 0.0), (1.0, 1.0, 1.0), (4, 4, 4), (3, 3, 3), (2, 2, 2));
+
+julia> geometry = Forms.get_geometry(V2);
+
+julia> forcing_function(x) = [ones(size(x))];
+
+julia> f = Forms.AnalyticalFormField(3, forcing_function, geometry, "f");
+
+julia> weak_form_inputs = Assemblers.WeakFormInputs((V2, V3), (f,));
+
+julia> isa(weak_form_inputs, Assemblers.WeakFormInputs{3})
+true
+
+```
+
+# Fields
+- `test_forms::TeF`: The test forms for the weak-formulation.
+- `trial_forms::TrF`: The trial forms for the weak-formulation.
+- `forcings::F`: The forcing terms for the weak-formulation, possibly nothing.
+
+# Type parameters
+- `manifold_dim::Int`: The dimension of the manifold where the weak-formulation is defined.
+- `TeF`: The type of the tuple of test forms. Each entry should be a subtype of
+    [`Forms.AbstractFormSpace`](@ref).
+- `TrF`: The type of the tuple of trial forms. Each entry should be a subtype of
+    [`Forms.AbstractFormSpace`](@ref).
+- `F`: The type of the tuple of forcing terms. Each entry should be a subtype of
+    [`Forms.AbstractFormField`](@ref).
 """
 struct WeakFormInputs{manifold_dim, TeF, TrF, F} <: AbstractInputs
     test_forms::TeF
@@ -129,12 +150,65 @@ struct WeakFormInputs{manifold_dim, TeF, TrF, F} <: AbstractInputs
     end
 end
 
+"""
+    get_trial_forms(wfi::WeakFormInputs)
+
+Return a tuple of [`Forms.AbstractFormSpace`](@ref) that are used as trial spaces.
+"""
 get_trial_forms(wfi::WeakFormInputs) = wfi.trial_forms
+
+"""
+    get_test_forms(wfi::WeakFormInputs)
+
+Return a tuple of [`Forms.AbstractFormSpace`](@ref) that are used as test spaces.
+"""
 get_test_forms(wfi::WeakFormInputs) = wfi.test_forms
+
+"""
+    get_forcings(wfi::WeakFormInputs)
+
+Return a tuple of [`Forms.AbstractFormField`](@ref) that are used as test spaces.
+"""
 get_forcings(wfi::WeakFormInputs) = wfi.forcings
+
+"""
+    get_trial_form(wfi::WeakFormInputs, i::Int=1)
+
+Return the `i`-th trial [`Forms.AbstractFormSpace`](@ref).
+"""
 get_trial_form(wfi::WeakFormInputs, i::Int=1) = get_trial_forms(wfi)[i]
+
+"""
+    get_test_form(wfi::WeakFormInputs, i::Int=1)
+
+Return the `i`-th test [`Forms.AbstractFormSpace`](@ref).
+"""
 get_test_form(wfi::WeakFormInputs, i::Int=1) = get_test_forms(wfi)[i]
+
+"""
+    get_forcing(wfi::WeakFormInputs, i::Int=1)
+
+Return the `i`-th forcing [`Forms.AbstractFormField`](@ref).
+"""
 get_forcing(wfi::WeakFormInputs, i::Int=1) = get_forcings(wfi)[i]
+
+"""
+    get_num_trial(wfi::WeakFormInputs)
+
+Return the number of trial spaces.
+"""
 get_num_trial(wfi::WeakFormInputs) = length(get_trial_forms(wfi))
+
+"""
+    get_num_test(wfi::WeakFormInputs)
+
+Return the number of test spaces.
+"""
 get_num_test(wfi::WeakFormInputs) = length(get_test_forms(wfi))
+
+"""
+    get_num_forcings(wfi::WeakFormInputs)
+
+Return the number of forcing functions.
+"""
 get_num_forcings(wfi::WeakFormInputs) = length(get_forcings(wfi))


### PR DESCRIPTION
Updated docs for the assemblers module, including the weak forms.

@dccabanas, I haven't updated the 1-form and Maxwell eigenvalue solve functions that perform hierarchical refinements. Do you think they are useful as is? Or should they be turned into an example and removed?