### PR TITLE
perf/forms type stability

### DIFF
--- a/docs/src/Design/Modules/Forms.md
+++ b/docs/src/Design/Modules/Forms.md
@@ -255,6 +255,7 @@ It is also possible to directly obtain some useful information about the underly
 get_estimated_nnz_per_elem
 get_max_local_dim
 get_num_basis
+get_num_basis_per_expression
 ```
 
 ## [Helper Functions](@id FormsHelpers)

--- a/src/Forms/FormExpressions/FormSpaces.jl
+++ b/src/Forms/FormExpressions/FormSpaces.jl
@@ -205,9 +205,20 @@ function _pullback_to_canonical_coordinates(
                         form_evaluations[i][j][k] .*= element_dimensions[k]
                     end
                 elseif manifold_dim == 3
-                    form_evaluations[i][j][1] .*= prod(element_dimensions[2:3])
-                    form_evaluations[i][j][2] .*= prod(element_dimensions[1:2:3])
-                    form_evaluations[i][j][3] .*= prod(element_dimensions[1:2])
+                    for edi in eachindex(element_dimensions)
+                        if edi == 1
+                            form_evaluations[i][j][2] .*= element_dimensions[edi]
+                            form_evaluations[i][j][3] .*= element_dimensions[edi]
+                        elseif edi == 2
+                            form_evaluations[i][j][1] .*= element_dimensions[edi]
+                            form_evaluations[i][j][3] .*= element_dimensions[edi]
+                        elseif edi == 3
+                            form_evaluations[i][j][1] .*= element_dimensions[edi]
+                            form_evaluations[i][j][2] .*= element_dimensions[edi]
+                        else
+                            throw(ArgumentError("Something went wrong"))
+                        end
+                    end
                 else
                     throw(
                         ArgumentError(

--- a/src/Forms/FormOperators/Algebraic.jl
+++ b/src/Forms/FormOperators/Algebraic.jl
@@ -368,19 +368,21 @@ function evaluate(una_trans::UnaryOperatorTransformation, element_id::Int)
     operator = get_operator(una_trans)
     transformation = get_transformation(una_trans)
     eval, indices = evaluate(operator, element_id)
-    eval .= transformation.(eval)
+    for i in eachindex(eval)
+        eval[i] = transformation(eval[i])
+    end
 
     return eval, indices
 end
 
 function evaluate(bin_trans::BinaryOperatorTransformation, element_id::Int)
-    operators = get_operators(bin_trans)
+    operator_1, operator_2 = get_operators(bin_trans)
     transformation = get_transformation(bin_trans)
-    eval_1, indices = evaluate(operators[1], element_id)
-    eval_2, _ = evaluate(operators[2], element_id)
-    eval_1 .= transformation.(eval_1, eval_2)  # we store the output in eval_1 to avoid extra
-    # allocations, the same reason for using .= and
-    # transformation.()
+    eval_1, indices = evaluate(operator_1, element_id)
+    eval_2, _ = evaluate(operator_2, element_id)
+    for i in eachindex(eval_1, eval_2)
+        eval_1[i] = transformation(eval_1[i], eval_2[i])
+    end
 
     return eval_1, indices
 end
@@ -393,9 +395,10 @@ function evaluate(
     form = get_form(uni_trans)
     transformation = get_transformation(uni_trans)
     form_eval, indices = evaluate(form, element_id, xi)
-    form_eval .= transformation.(form_eval)  # we store the output in form_eval to avoid extra
-    # allocations, the same reason for using .= and
-    # transformation.()
+    for i in eachindex(form_eval)
+        form_eval[i] = transformation(form_eval[i])
+    end
+
     return form_eval, indices
 end
 
@@ -404,19 +407,16 @@ function evaluate(
     element_id::Int,
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim}
-    forms = get_forms(bin_trans)
+    form_1, form_2 = get_forms(bin_trans)
     transformation = get_transformation(bin_trans)
 
-    form_1_eval, indices = evaluate(forms[1], element_id, xi)
-    form_2_eval, indices = evaluate(forms[2], element_id, xi)
-    foreach(
-        c -> map!(
-            i -> transformation(form_1_eval[c][i], form_2_eval[c][i]),
-            form_1_eval[c],
-            eachindex(form_1_eval[c], form_2_eval[c]),
-        ),
-        eachindex(form_1_eval, form_2_eval),
-    )
+    form_1_eval, indices = evaluate(form_1, element_id, xi)
+    form_2_eval, _ = evaluate(form_2, element_id, xi)
+    for c in eachindex(form_1_eval, form_2_eval)
+        for i in eachindex(form_1_eval[c], form_2_eval[c])
+            form_1_eval[c][i] = transformation(form_1_eval[c][i], form_2_eval[c][i])
+        end
+    end
 
     return form_1_eval, indices
 end

--- a/src/Forms/FormOperators/ExteriorDerivative.jl
+++ b/src/Forms/FormOperators/ExteriorDerivative.jl
@@ -106,7 +106,7 @@ function _evaluate_exterior_derivative(
     element_id::Int,
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim}
-    throw(ArgumentError("Method not implement for type $(typeof(form))."))
+    return throw(MethodError(_evaluate_exterior_derivative, (form, element_id, xi)))
 end
 
 ############################################################################################
@@ -287,9 +287,7 @@ end
 ############################################################################################
 
 function _evaluate_exterior_derivative(
-    ::ConstantFormSpace{manifold_dim, 0},
-    ::Int,
-    xi::Points.AbstractPoints{manifold_dim},
+    ::ConstantFormSpace{manifold_dim, 0}, ::Int, xi::Points.AbstractPoints{manifold_dim}
 ) where {manifold_dim}
     # Preallocate memory for output array
     n_derivative_form_components = manifold_dim

--- a/src/Forms/FormOperators/Hodge.jl
+++ b/src/Forms/FormOperators/Hodge.jl
@@ -105,7 +105,7 @@ function _evaluate_hodge(
     element_id::Int,
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim, form_rank, expression_rank}
-    throw(ArgumentError("Method not implement for type $(typeof(form))."))
+    return throw(MethodError(_evaluate_hodge, (form, element_id, xi)))
 end
 
 ############################################################################################

--- a/src/Forms/FormOperators/Wedge.jl
+++ b/src/Forms/FormOperators/Wedge.jl
@@ -112,7 +112,9 @@ function get_forms(form::Wedge)
 end
 
 function get_form(form::Wedge)
-    throw(ArgumentError("'get_form' is not defined for Wedges. Use 'get_forms' instead."))
+    return throw(
+        ArgumentError("'get_form' is not defined for Wedges. Use 'get_forms' instead.")
+    )
 end
 
 function get_geometry(form::Wedge)
@@ -120,7 +122,19 @@ function get_geometry(form::Wedge)
 end
 
 function get_estimated_nnz_per_elem(form::Wedge)
-    return mapreduce(get_estimated_nnz_per_elem, *, get_forms(form))
+    return prod(map(get_estimated_nnz_per_elem, get_forms(form)))
+end
+
+function get_num_basis_per_expression(
+    form::Wedge{manifold_dim, form_rank, 1}, element_id::Int
+) where {manifold_dim, form_rank}
+    bpb_all = map(get_num_basis, get_forms(form), (element_id, element_id))
+    if length(bpb_all[1]) == 0
+        return (bpb_all[2],)
+    else
+        return (bpb_all[1],)
+    end
+    # return (get_num_basis(get_form(form), element_id),)
 end
 
 function get_form_space_tree(wedge::Wedge)
@@ -147,7 +161,7 @@ function _evaluate_wedge(
     element_id::Int,
     xi::Points.AbstractPoints{manifold_dim},
 ) where {manifold_dim}
-    throw(ArgumentError("Method not implemented for the given form expressions."))
+    return throw(ArgumentError("Method not implemented for the given form expressions."))
 end
 
 ############################################################################################
@@ -222,7 +236,7 @@ function _evaluate_wedge(
     #   α⁰ ∧ β⁰ = (αβ)⁰
 
     # Get the number of basis for the first expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
 
     # Get the number of components of the wedge
     # In this case because it is the wedge of a 0-form with a 0-form
@@ -279,7 +293,7 @@ function _evaluate_wedge(
     #   α⁰ ∧ β⁰ = (αβ)⁰
 
     # Get the number of basis for the second expression
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of components of the wedge
     # In this case because it is the wedge of a 0-form with a 0-form
@@ -338,8 +352,8 @@ function _evaluate_wedge(
     #   α⁰ ∧ β⁰ = (αβ)⁰
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -448,7 +462,7 @@ function _evaluate_wedge(
     n_components_wedge = n_components_form_expression_1
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -507,7 +521,7 @@ function _evaluate_wedge(
     n_components_wedge = n_components_form_expression_1
 
     # Get the number of basis in each expression
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -566,8 +580,8 @@ function _evaluate_wedge(
     n_components_wedge = n_components_form_expression_1
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Assign wedge_indices: wedge_indices is just the concatenation of the indices of each expression
     wedge_indices = vcat(form_expression_1_indices, form_expression_2_indices)
@@ -674,7 +688,7 @@ function _evaluate_wedge(
     n_components_wedge = n_components_form_expression_2
 
     # Get the number of basis in the first expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -731,7 +745,7 @@ function _evaluate_wedge(
     n_components_wedge = n_components_form_expression_2
 
     # Get the number of basis in the first expression
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -790,8 +804,8 @@ function _evaluate_wedge(
     n_components_wedge = n_components_form_expression_2
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -886,7 +900,7 @@ function _evaluate_wedge(
     #   α¹ ∧ β¹ = (α₁β₂ - α₂β₁)dξ¹∧dξ²
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -937,7 +951,7 @@ function _evaluate_wedge(
     #   α¹ ∧ β¹ = (α₁β₂ - α₂β₁)dξ¹∧dξ²
 
     # Get the number of basis in each expression
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -990,8 +1004,8 @@ function _evaluate_wedge(
     #   α¹ ∧ β¹ = (α₁β₂ - α₂β₁)dξ¹∧dξ²
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -1104,7 +1118,7 @@ function _evaluate_wedge(
     #   α¹ ∧ β¹ = (α₂β₃ - α₃β₂)dξ²∧dξ³ + (α₃β₁ - α₁β₃)dξ³∧dξ¹ + (α₁β₂ - α₂β₁)dξ¹∧dξ²
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -1175,7 +1189,7 @@ function _evaluate_wedge(
     #   α¹ ∧ β¹ = (α₂β₃ - α₃β₂)dξ²∧dξ³ + (α₃β₁ - α₁β₃)dξ³∧dξ¹ + (α₁β₂ - α₂β₁)dξ¹∧dξ²
 
     # Get the number of basis in each expression
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -1248,8 +1262,8 @@ function _evaluate_wedge(
     #   α¹ ∧ β¹ = (α₂β₃ - α₃β₂)dξ²∧dξ³ + (α₃β₁ - α₁β₃)dξ³∧dξ¹ + (α₁β₂ - α₂β₁)dξ¹∧dξ²
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -1375,7 +1389,7 @@ function _evaluate_wedge(
     #   α¹ ∧ β² = (α₁β₁ + α₂β₂ + α₃β₃) dξ¹∧dξ²∧dξ³
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -1433,7 +1447,7 @@ function _evaluate_wedge(
     #   α¹ ∧ β² = (α₁β₁ + α₂β₂ + α₃β₃) dξ¹∧dξ²∧dξ³
 
     # Get the number of basis in each expression
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -1493,8 +1507,8 @@ function _evaluate_wedge(
     #   α¹ ∧ β² = (α₁β₁ + α₂β₂ + α₃β₃) dξ¹∧dξ²∧dξ³
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -1601,7 +1615,7 @@ function _evaluate_wedge(
     #   α² ∧ β¹ = (α₁β₁ + α₂β₂ + α₃β₃) dξ¹∧dξ²∧dξ³
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -1659,7 +1673,7 @@ function _evaluate_wedge(
     #   α² ∧ β¹ = (α₁β₁ + α₂β₂ + α₃β₃) dξ¹∧dξ²∧dξ³
 
     # Get the number of basis in each expression
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points
@@ -1719,8 +1733,8 @@ function _evaluate_wedge(
     #   α² ∧ β¹ = (α₁β₁ + α₂β₂ + α₃β₃) dξ¹∧dξ²∧dξ³
 
     # Get the number of basis in each expression
-    num_basis_form_expression_1 = size.(form_expression_1_indices, 1)
-    num_basis_form_expression_2 = size.(form_expression_2_indices, 1)
+    num_basis_form_expression_1 = get_num_basis_per_expression(form_expression_1, element_id)
+    num_basis_form_expression_2 = get_num_basis_per_expression(form_expression_2, element_id)
 
     # Get the number of evaluation points
     n_evaluation_points = size(form_expression_1_eval[1], 1)  # all components are evaluated at the same points and both forms are evaluated at the same points

--- a/src/Forms/Forms.jl
+++ b/src/Forms/Forms.jl
@@ -258,7 +258,7 @@ Returns the estimated number of non-zero entries per element for the given form 
 - `::Int`: The estimated number of non-zero entries per element.
 """
 function get_estimated_nnz_per_elem(form::AbstractForm)
-    return prod(get_estimated_nnz_per_elem.(get_forms(form)))
+    return prod(map(get_estimated_nnz_per_elem, get_forms(form)))
 end
 
 function get_estimated_nnz_per_elem(::AbstractFormField)
@@ -336,6 +336,40 @@ the given form space.
 """
 function get_num_basis(form_space::AbstractFormSpace, element_id::Int)
     return get_num_basis(get_form(form_space), element_id)
+end
+
+"""
+    get_num_basis_per_expression(
+        form::AbstractForm{manifold_dim, form_rank}, element_id::Int
+    ) where {manifold_dim, form_rank}
+
+Returns the number of basis functions at the given element of each expression within `form`.
+There are `expression_rank` many expressions.
+
+# Arguments
+- `form::AbstractForm`: The form space.
+- `element_id::Int`: The element on which to get the number of basis functions.
+
+# Returns
+- `::NTuple{expression_rank, Int}`: The number of basis functions at the given element per
+    expression. Note that if the `expression_rank` is 0, the tuple will be of length 0.
+"""
+function get_num_basis_per_expression(
+    form::AbstractForm{manifold_dim, form_rank, 0}, element_id::Int
+) where {manifold_dim, form_rank}
+    return ()
+end
+
+function get_num_basis_per_expression(
+    form::AbstractForm{manifold_dim, form_rank, 1}, element_id::Int
+) where {manifold_dim, form_rank}
+    return (get_num_basis(get_form(form), element_id),)
+end
+
+function get_num_basis_per_expression(
+    form::AbstractForm{manifold_dim, form_rank, 2}, element_id::Int
+) where {manifold_dim, form_rank}
+    return map(get_num_basis, get_forms(form), (element_id, element_id))
 end
 
 ############################################################################################

--- a/src/Forms/FormsHelpers.jl
+++ b/src/Forms/FormsHelpers.jl
@@ -40,7 +40,9 @@ end
 function build_form_fields(
     form_spaces::FS; labels::Union{L, Nothing}=nothing
 ) where {
-    num_forms, FS <: NTuple{num_forms, AbstractFormSpace}, L <: NTuple{num_forms, AbstractString}
+    num_forms,
+    FS <: NTuple{num_forms, AbstractFormSpace},
+    L <: NTuple{num_forms, AbstractString},
 }
     if isnothing(labels)
         labels = ntuple(num_forms) do _
@@ -70,9 +72,7 @@ function build_form_fields(
     form_fields = ntuple(num_forms) do i
         num_coeffs = get_num_basis(form_spaces[i])
         ff = build_form_field(
-            form_spaces[i],
-            coeffs[start_id:(start_id + num_coeffs - 1)];
-            label=labels[i],
+            form_spaces[i], coeffs[start_id:(start_id + num_coeffs - 1)]; label=labels[i]
         )
         start_id += num_coeffs
 
@@ -431,23 +431,13 @@ function create_hierarchical_de_rham_complex(
     truncate::Bool,
     simplified::Bool,
 ) where {manifold_dim, F <: FunctionSpaces.AbstractCanonicalSpace}
-    # number of dofs on the left and right boundary of the domain
-    n_dofs_left = tuple((1 for _ in 1:manifold_dim)...)
-    n_dofs_right = tuple((1 for _ in 1:manifold_dim)...)
-
     # store all univariate FEM spaces helper
     fem_spaces = Vector{NTuple{manifold_dim, FunctionSpaces.AbstractFESpace{1, 1}}}(
         undef, 2
     )
     # first, create all univariate FEM spaces corresponding to directional-zero forms
     fem_spaces[1] = FunctionSpaces.create_dim_wise_bspline_spaces(
-        starting_points,
-        box_sizes,
-        num_elements,
-        section_spaces,
-        regularities,
-        n_dofs_left,
-        n_dofs_right,
+        starting_points, box_sizes, num_elements, section_spaces, regularities
     )
     # next, create all univariate FEM spaces corresponding to directional-one forms
     fem_spaces[2] = map(FunctionSpaces.get_derivative_space, fem_spaces[1])
@@ -541,7 +531,7 @@ function update_hierarchical_de_rham_complex(
             comp_spaces = FunctionSpaces.get_component_spaces(get_fe_space(complex[k]))
             new_space = FunctionSpaces.DirectSumSpace(
                 ntuple(num_components) do c
-                    FunctionSpaces.refine_space(comp_spaces[c], data)
+                    return FunctionSpaces.refine_space(comp_spaces[c], data)
                 end,
             )
         end

--- a/src/FunctionSpaces/FunctionSpaceHelpers.jl
+++ b/src/FunctionSpaces/FunctionSpaceHelpers.jl
@@ -315,12 +315,12 @@ function create_dim_wise_bspline_spaces(
     box_sizes::NTuple{manifold_dim, Float64},
     num_elements::NTuple{manifold_dim, Int},
     section_spaces::F,
-    regularities::NTuple{manifold_dim, Int},
+    regularities::NTuple{manifold_dim, Int};
     n_dofs_left::NTuple{manifold_dim, Int}=ntuple(i -> 1, manifold_dim),
     n_dofs_right::NTuple{manifold_dim, Int}=ntuple(i -> 1, manifold_dim),
 ) where {manifold_dim, F <: NTuple{manifold_dim, AbstractCanonicalSpace}}
     return ntuple(manifold_dim) do i
-        create_bspline_space(
+        return create_bspline_space(
             starting_points[i],
             box_sizes[i],
             num_elements[i],
@@ -375,9 +375,9 @@ function create_bspline_space(
         box_sizes,
         num_elements,
         degrees,
-        regularities,
-        n_dofs_left,
-        n_dofs_right,
+        regularities;
+        n_dofs_left=n_dofs_left,
+        n_dofs_right=n_dofs_right,
     )
 
     return TensorProductSpace(
@@ -418,12 +418,12 @@ function create_dim_wise_bspline_spaces(
     box_sizes::NTuple{manifold_dim, Float64},
     num_elements::NTuple{manifold_dim, Int},
     degrees::NTuple{manifold_dim, Int},
-    regularities::NTuple{manifold_dim, Int},
-    n_dofs_left::NTuple{manifold_dim, Int},
-    n_dofs_right::NTuple{manifold_dim, Int},
+    regularities::NTuple{manifold_dim, Int};
+    n_dofs_left::NTuple{manifold_dim, Int}=ntuple(i -> 1, manifold_dim),
+    n_dofs_right::NTuple{manifold_dim, Int}=ntuple(i -> 1, manifold_dim),
 ) where {manifold_dim}
     return ntuple(manifold_dim) do i
-        create_bspline_space(
+        return create_bspline_space(
             starting_points[i],
             box_sizes[i],
             num_elements[i],
@@ -532,7 +532,13 @@ function create_scalar_polar_spline_space(
 ) where {F <: NTuple{2, AbstractCanonicalSpace}}
     # spaces used for creating degenerate geometry
     Bθ_g, Br_g = create_dim_wise_bspline_spaces(
-        (0.0, 0.0), box_sizes, num_elements, section_spaces, regularities, (1, 1), (1, 1)
+        (0.0, 0.0),
+        box_sizes,
+        num_elements,
+        section_spaces,
+        regularities;
+        n_dofs_left=(1, 1),
+        n_dofs_right=(1, 1),
     )
     GBθ_g = GTBSplineSpace((Bθ_g,), [regularities[1]])
 
@@ -543,9 +549,9 @@ function create_scalar_polar_spline_space(
             box_sizes,
             num_elements,
             get_derivative_space.(section_spaces),
-            regularities .- 1,
-            (1, 1),
-            (1, 1),
+            regularities .- 1;
+            n_dofs_left=(1, 1),
+            n_dofs_right=(1, 1),
         )
         GBθ = GTBSplineSpace((Bθ,), [regularities[1] - 1])
 
@@ -652,7 +658,13 @@ function create_vector_polar_spline_space(
 ) where {F <: NTuple{2, AbstractCanonicalSpace}}
     # spaces used for creating degenerate geometry
     Bθ_g, Br_g = create_dim_wise_bspline_spaces(
-        (0.0, 0.0), box_sizes, num_elements, section_spaces, regularities, (1, 1), (1, 1)
+        (0.0, 0.0),
+        box_sizes,
+        num_elements,
+        section_spaces,
+        regularities;
+        n_dofs_left=(1, 1),
+        n_dofs_right=(1, 1),
     )
     GBθ_g = GTBSplineSpace((Bθ_g,), [regularities[1]])
 
@@ -712,7 +724,13 @@ function create_polar_geometry_data(
     box_sizes::NTuple{2, Float64}=(1.0, 1.0),
 ) where {F <: NTuple{2, AbstractCanonicalSpace}}
     Bθ, Br = create_dim_wise_bspline_spaces(
-        (0.0, 0.0), box_sizes, num_elements, section_spaces, regularities, (1, 1), (1, 1)
+        (0.0, 0.0),
+        box_sizes,
+        num_elements,
+        section_spaces,
+        regularities;
+        n_dofs_left=(1, 1),
+        n_dofs_right=(1, 1),
     )
     # impose periodicity
     GBθ = GTBSplineSpace((Bθ,), [regularities[1]])

--- a/src/Geometry/CartesianGeometry.jl
+++ b/src/Geometry/CartesianGeometry.jl
@@ -199,7 +199,7 @@ function get_element_measure(geometry::CartesianGeometry, element_id::Int)
 end
 
 function get_factor_manifold_indices(::CartesianGeometry{manifold_dim}) where {manifold_dim}
-    return ntuple(i -> i:i, manifold_dim)
+    return ntuple(i -> (i,), manifold_dim)
 end
 
 function get_factor_evaluation_points(

--- a/test/Geometry/DiscreteGeometryTests.jl
+++ b/test/Geometry/DiscreteGeometryTests.jl
@@ -39,7 +39,13 @@ regularities = (1, -1)
 
 # create tensor-product space
 Bθ, Br = FunctionSpaces.create_dim_wise_bspline_spaces(
-    starting_points, box_sizes, num_elements, section_spaces, regularities, (1, 1), (1, 1)
+    starting_points,
+    box_sizes,
+    num_elements,
+    section_spaces,
+    regularities;
+    n_dofs_left=(1, 1),
+    n_dofs_right=(1, 1),
 )
 Bθ_periodic = FunctionSpaces.GTBSplineSpace((Bθ,), [1])
 TP = FunctionSpaces.TensorProductSpace((Bθ_periodic, Br))
@@ -138,8 +144,8 @@ geom_coeffs_0 = [
 r0 = 1
 r1 = 2
 geom_coeffs = [
-    geom_coeffs_0.*r0 [-1.0, 1.0, -1.0, 1.0]
-    geom_coeffs_0.*r1 [1.0, -1.0, 1.0, -1.0]
+    geom_coeffs_0 .* r0 [-1.0, 1.0, -1.0, 1.0]
+    geom_coeffs_0 .* r1 [1.0, -1.0, 1.0, -1.0]
 ]
 geom = FunctionSpaces.DiscreteGeometry(TP, geom_coeffs)
 file_name = "fem_geometry_wavy_surface_test"
@@ -163,8 +169,8 @@ geom_coeffs_0 = [
 r0 = 1
 r1 = 2
 geom_coeffs = [
-    geom_coeffs_0.*r0 zeros(3)
-    geom_coeffs_0.*r1 zeros(3)
+    geom_coeffs_0 .* r0 zeros(3)
+    geom_coeffs_0 .* r1 zeros(3)
 ]
 geom = FunctionSpaces.DiscreteGeometry(TP, geom_coeffs)
 file_name = "fem_geometry_nurbs_quarter_annulus_test"
@@ -191,8 +197,8 @@ geom_coeffs_0 = [
 r0 = 1
 r1 = 2
 geom_coeffs = [
-    geom_coeffs_0.*r0 zeros(4)
-    geom_coeffs_0.*r1 zeros(4)
+    geom_coeffs_0 .* r0 zeros(4)
+    geom_coeffs_0 .* r1 zeros(4)
 ]
 geom = FunctionSpaces.DiscreteGeometry(TP, geom_coeffs)
 file_name = "fem_geometry_nurbs_annulus_test"
@@ -219,8 +225,8 @@ geom_coeffs_0 = [
 r0 = 1
 r1 = 2
 geom_coeffs = [
-    geom_coeffs_0.*r0 [-1.0, 1.0, -1.0, 1.0]
-    geom_coeffs_0.*r1 [1.0, -1.0, 1.0, -1.0]
+    geom_coeffs_0 .* r0 [-1.0, 1.0, -1.0, 1.0]
+    geom_coeffs_0 .* r1 [1.0, -1.0, 1.0, -1.0]
 ]
 geom = FunctionSpaces.DiscreteGeometry(TP, geom_coeffs)
 file_name = "fem_geometry_nurbs_wavy_surface_test"
@@ -261,8 +267,8 @@ geom_coeffs_0 = [
 r0 = 1
 r1 = 2
 geom_coeffs = [
-    geom_coeffs_0.*r0 zeros(4)
-    geom_coeffs_0.*r1 zeros(4)
+    geom_coeffs_0 .* r0 zeros(4)
+    geom_coeffs_0 .* r1 zeros(4)
 ]
 
 # NURBS annulus with B-spline and NURBS bases

--- a/test/Inference/FESpacesInferenceTests.jl
+++ b/test/Inference/FESpacesInferenceTests.jl
@@ -1,6 +1,4 @@
-module GeometryInferenceTests
-
-import Pkg
+module FESpacesInferenceTests
 
 using Mantis
 using Memoization
@@ -31,9 +29,7 @@ B1ELL = FunctionSpaces.BSplineSpace(geometry1, geometry1multi, el_poly, fill(-1,
 
 # Rational
 R1 = FunctionSpaces.RationalFESpace(B1, [0.2, 0.8])
-R1m = FunctionSpaces.RationalFESpace(
-    B1multi, rand(FunctionSpaces.get_num_basis(B1multi))
-)
+R1m = FunctionSpaces.RationalFESpace(B1multi, rand(FunctionSpaces.get_num_basis(B1multi)))
 
 # Multi-variate and multi-component ---
 # TensorProduct
@@ -52,6 +48,16 @@ TP_R1mR1mR1m = FunctionSpaces.TensorProductSpace((R1m, R1m, R1m))
 # Two-space (Bspline, Rational), single-patch, multi element, 2D
 TP_B1mR1m = FunctionSpaces.TensorProductSpace((B1multi, R1m))
 
+# The helper function used here creates a TensorProductSpace using a CartesianGeometry. The
+# above constructors use a TensorProductGeometry instead.
+B1_3D = FunctionSpaces.create_bspline_space(
+    (0.0, 0.0, 0.0),
+    (1.0, 1.0, 1.0),
+    (3, 4, 5),
+    (FunctionSpaces.Bernstein(2), FunctionSpaces.Bernstein(2), FunctionSpaces.Bernstein(3)),
+    (1, 1, 1),
+)
+
 # DirectSumSpace
 # Reduction test, single-component, single-patch, single element, 1D.
 DS1 = FunctionSpaces.DirectSumSpace((B1,))
@@ -62,11 +68,9 @@ DS_TP1mTP1m = FunctionSpaces.DirectSumSpace((TP_B1mB1m, TP_B1mB1m))
 # 3-component, two distinct spaces, 2D, multi-element, single-patch
 DS_TP1mTPR1mTP1m = FunctionSpaces.DirectSumSpace((TP_B1mB1m, TP_R1mR1m, TP_B1mB1m))
 # 3-component, three distinct spaces, 2D, multi-element, single-patch
-DS_TPB1mTPR1mTPBR1m = FunctionSpaces.DirectSumSpace((
-    TP_B1mB1m, TP_R1mR1m, TP_B1mR1m
-))
+DS_TPB1mTPR1mTPBR1m = FunctionSpaces.DirectSumSpace((TP_B1mB1m, TP_R1mR1m, TP_B1mR1m))
 
-const spaces = (
+spaces = (
     B1,
     B1multi,
     B1LL,
@@ -80,6 +84,7 @@ const spaces = (
     TP_R1mR1m,
     TP_R1mR1mR1m,
     TP_B1mR1m,
+    B1_3D,
     DS1,
     DS_B1mB1m,
     DS_TP1mTP1m,
@@ -89,14 +94,14 @@ const spaces = (
 
 # Note that JET only uses the types of the inputs, so which numbers we pick
 # here is irrelevant.
-const xi_1D = Points.TensorProductPoints(([0.0, 1.0],))
-const xi_2D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0]))
-const xi_3D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0], [0.0, 1.0]))
+xi_1D = Points.TensorProductPoints(([0.0, 1.0],))
+xi_2D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0]))
+xi_3D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0], [0.0, 1.0]))
 
-const element_id = 1
-const component_id = 1
-const nderivatives = 1
-const basis_id = 4
+element_id = 1
+component_id = 1
+nderivatives = 2
+basis_id = 4
 
 foreach(spaces) do space
 
@@ -109,9 +114,7 @@ foreach(spaces) do space
     @test_opt FunctionSpaces.get_component_spaces(space)
     @test_opt FunctionSpaces.get_extraction_operator(space)
     @test_opt FunctionSpaces.get_extraction(space, element_id, component_id)
-    @test_opt FunctionSpaces.get_extraction_coefficients(
-        space, element_id, component_id
-    )
+    @test_opt FunctionSpaces.get_extraction_coefficients(space, element_id, component_id)
     @test_opt FunctionSpaces.get_basis_indices(space, element_id)
     @test_opt FunctionSpaces.get_basis_permutation(space, element_id, component_id)
     @test_opt FunctionSpaces.get_num_basis(space)

--- a/test/Inference/FESpacesInferenceTests.jl
+++ b/test/Inference/FESpacesInferenceTests.jl
@@ -103,7 +103,7 @@ component_id = 1
 nderivatives = 2
 basis_id = 4
 
-foreach(spaces) do space
+for space in spaces
 
     # Methods on the type.
     @test_opt FunctionSpaces.get_manifold_dim(space)

--- a/test/Inference/Forms/CoDifferentialInferenceTests.jl
+++ b/test/Inference/Forms/CoDifferentialInferenceTests.jl
@@ -46,7 +46,7 @@ for form in forms
         @test_opt Forms.get_num_basis(coder)
         @test_opt Forms.get_num_basis(coder, element_id)
         @test_opt Forms.get_max_local_dim(coder)
-        @test_opt Forms.get_num_basis_per_basis(coder, element_id)
+        @test_opt Forms.get_num_basis_per_expression(coder, element_id)
     end
 
     # Evaluate.

--- a/test/Inference/Forms/CoDifferentialInferenceTests.jl
+++ b/test/Inference/Forms/CoDifferentialInferenceTests.jl
@@ -1,0 +1,68 @@
+module CoDifferentialInferenceTests
+
+const verbose = false
+
+include("FormsInferenceTestSetup.jl")
+
+for form in forms
+    manifold_dim = Forms.get_manifold_dim(form)
+    form_rank = Forms.get_form_rank(form)
+    if form_rank == 0
+        # We can't construct the exterior derivative of a top form.
+        continue
+    end
+    # The following two conditions are current limitations only.
+    if manifold_dim > 2
+        continue
+    elseif form_rank > 1
+        continue
+    end
+
+    if verbose
+        @show nameof(typeof(form))
+        @show Forms.get_manifold_dim(form)
+        @show Forms.get_form_rank(form)
+        @show Forms.get_expression_rank(form)
+    end
+
+    # Construction
+    @test_opt Forms.CoDifferential(form)
+    coder = Forms.CoDifferential(form)
+
+    # Methods defined for all forms (they can be specialised or throw an error).
+    @test_opt Forms.get_manifold_dim(coder)
+    @test_opt Forms.get_form_rank(coder)
+    @test_opt Forms.get_expression_rank(coder)
+    @test_opt Forms.get_label(coder)
+    @test_opt Forms.get_form(coder)
+    @test_opt Forms.get_form_space_tree(coder)
+    @test_opt Forms.get_geometry(coder)
+    @test_opt Forms.get_num_elements(coder)
+    @test_opt Forms.get_estimated_nnz_per_elem(coder)
+    @test_opt Forms.get_fe_space(coder)
+
+    # Methods defined for all AbstractForms with expression rank 1 (AbstractFormSpaces).
+    if Forms.get_expression_rank(coder) == 1
+        @test_opt Forms.get_num_basis(coder)
+        @test_opt Forms.get_num_basis(coder, element_id)
+        @test_opt Forms.get_max_local_dim(coder)
+        @test_opt Forms.get_num_basis_per_basis(coder, element_id)
+    end
+
+    # Evaluate.
+    if Forms.get_manifold_dim(coder) == 1
+        @test_opt Forms.evaluate(coder, element_id_1D, xi_1D)
+    elseif Forms.get_manifold_dim(coder) == 2
+        @test_opt Forms.evaluate(coder, element_id_2D, xi_2D)
+    elseif Forms.get_manifold_dim(coder) == 3
+        @test_opt Forms.evaluate(coder, element_id_3D, xi_3D)
+    elseif Forms.get_manifold_dim(coder) == 4
+        @test_opt Forms.evaluate(coder, element_id_4D, xi_4D)
+    elseif Forms.get_manifold_dim(coder) == 5
+        @test_opt Forms.evaluate(coder, element_id_5D, xi_5D)
+    else
+        @warn "CodifferentialInference: The evaluate for this coder was not tested: $(coder)"
+    end
+end
+
+end

--- a/test/Inference/Forms/ExteriorDerivativeInferenceTests.jl
+++ b/test/Inference/Forms/ExteriorDerivativeInferenceTests.jl
@@ -40,7 +40,7 @@ for form in forms
         @test_opt Forms.get_num_basis(extder)
         @test_opt Forms.get_num_basis(extder, element_id)
         @test_opt Forms.get_max_local_dim(extder)
-        @test_opt Forms.get_num_basis_per_basis(extder, element_id)
+        @test_opt Forms.get_num_basis_per_expression(extder, element_id)
     end
 
     # Evaluate.

--- a/test/Inference/Forms/ExteriorDerivativeInferenceTests.jl
+++ b/test/Inference/Forms/ExteriorDerivativeInferenceTests.jl
@@ -1,0 +1,62 @@
+module ExteriorDerivativeInferenceTests
+
+const verbose = false
+
+include("FormsInferenceTestSetup.jl")
+
+for form in forms
+    manifold_dim = Forms.get_manifold_dim(form)
+    form_rank = Forms.get_form_rank(form)
+    if form_rank == manifold_dim
+        # We can't construct the exterior derivative of a top form.
+        continue
+    end
+
+    if verbose
+        @show nameof(typeof(form))
+        @show Forms.get_manifold_dim(form)
+        @show Forms.get_form_rank(form)
+        @show Forms.get_expression_rank(form)
+    end
+
+    # Construction
+    @test_opt Forms.ExteriorDerivative(form)
+    extder = Forms.ExteriorDerivative(form)
+
+    # Methods defined for all forms (they can be specialised or throw an error).
+    @test_opt Forms.get_manifold_dim(extder)
+    @test_opt Forms.get_form_rank(extder)
+    @test_opt Forms.get_expression_rank(extder)
+    @test_opt Forms.get_label(extder)
+    @test_opt Forms.get_form(extder)
+    @test_opt Forms.get_form_space_tree(extder)
+    @test_opt Forms.get_geometry(extder)
+    @test_opt Forms.get_num_elements(extder)
+    @test_opt Forms.get_estimated_nnz_per_elem(extder)
+    @test_opt Forms.get_fe_space(extder)
+
+    # Methods defined for all AbstractForms with expression rank 1 (AbstractFormSpaces).
+    if Forms.get_expression_rank(extder) == 1
+        @test_opt Forms.get_num_basis(extder)
+        @test_opt Forms.get_num_basis(extder, element_id)
+        @test_opt Forms.get_max_local_dim(extder)
+        @test_opt Forms.get_num_basis_per_basis(extder, element_id)
+    end
+
+    # Evaluate.
+    if Forms.get_manifold_dim(extder) == 1
+        @test_opt Forms.evaluate(extder, element_id_1D, xi_1D)
+    elseif Forms.get_manifold_dim(extder) == 2
+        @test_opt Forms.evaluate(extder, element_id_2D, xi_2D)
+    elseif Forms.get_manifold_dim(extder) == 3
+        @test_opt Forms.evaluate(extder, element_id_3D, xi_3D)
+    elseif Forms.get_manifold_dim(extder) == 4
+        @test_opt Forms.evaluate(extder, element_id_4D, xi_4D)
+    elseif Forms.get_manifold_dim(extder) == 5
+        @test_opt Forms.evaluate(extder, element_id_5D, xi_5D)
+    else
+        @warn "ExteriorDerivativeInference: The evaluate for this extder was not tested: $(extder)"
+    end
+end
+
+end

--- a/test/Inference/Forms/FormsInferenceTestSetup.jl
+++ b/test/Inference/Forms/FormsInferenceTestSetup.jl
@@ -1,0 +1,260 @@
+
+using Mantis
+
+using Test
+using JET
+
+# Note that JET only uses the types of the inputs, so which numbers we pick here is
+# irrelevant.
+const xi_1D = Points.TensorProductPoints(([0.0, 1.0],))
+const xi_2D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0]))
+const xi_3D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0], [0.0, 1.0]))
+const xi_4D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [0.0, 1.0]))
+const xi_5D = Points.TensorProductPoints((
+    [0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [0.0, 1.0]
+))
+
+element_id = 2
+element_id_1D = 2
+element_id_2D = 5
+element_id_3D = 15
+element_id_4D = 8
+element_id_5D = 9
+
+const nodes = Points.get_factor_points(Quadrature.get_nodes(Quadrature.gauss_lobatto(3)))[1]
+
+# Setup ------------------------------------------------------------------------------------
+# 1D
+B1_1D = FunctionSpaces.create_bspline_space(
+    (0.0,), (1.0,), (3,), (FunctionSpaces.Bernstein(2),), (1,)
+)
+B2_1D = FunctionSpaces.create_bspline_space(
+    (0.0,), (1.0,), (3,), (FunctionSpaces.Bernstein(1),), (0,)
+)
+L1_1D = FunctionSpaces.create_bspline_space(
+    (0.0,), (1.0,), (3,), (FunctionSpaces.Lagrange(nodes),), (0,)
+)
+E1_1D = FunctionSpaces.create_bspline_space(
+    (0.0,), (1.0,), (3,), (FunctionSpaces.Edge(nodes),), (-1,)
+)
+# FormSpaces
+zero_form_space_B1_1D = Forms.FormSpace(0, B1_1D, "0S-B1-1D")
+zero_form_space_L1_1D = Forms.FormSpace(0, L1_1D, "0S-L1-1D")
+one_form_space_B2_1D = Forms.FormSpace(1, B2_1D, "1S-B2-1D")
+one_form_space_E1_1D = Forms.FormSpace(1, E1_1D, "1S-E1-1D")
+# FormFields
+coeffs_1D_B1 = ones(Forms.get_num_basis(zero_form_space_B1_1D))
+coeffs_1D_B2 = ones(Forms.get_num_basis(one_form_space_B2_1D))
+coeffs_1D_L1 = ones(Forms.get_num_basis(zero_form_space_L1_1D))
+coeffs_1D_E1 = ones(Forms.get_num_basis(one_form_space_E1_1D))
+zero_form_field_B1_1D = Forms.FormField(zero_form_space_B1_1D, coeffs_1D_B1, "0F-B1-1D")
+zero_form_field_L1_1D = Forms.FormField(zero_form_space_L1_1D, coeffs_1D_L1, "0F-L1-1D")
+one_form_field_B2_1D = Forms.FormField(one_form_space_B2_1D, coeffs_1D_B2, "1F-B2-1D")
+one_form_field_E1_1D = Forms.FormField(one_form_space_E1_1D, coeffs_1D_E1, "1F-B2-1D")
+
+# 2D
+B1_2D = FunctionSpaces.create_bspline_space(
+    (0.0, 0.0),
+    (1.0, 1.0),
+    (3, 4),
+    (FunctionSpaces.Bernstein(2), FunctionSpaces.Bernstein(2)),
+    (1, 1),
+)
+L1_2D = FunctionSpaces.create_bspline_space(
+    (0.0, 0.0),
+    (1.0, 1.0),
+    (3, 4),
+    (FunctionSpaces.Lagrange(nodes), FunctionSpaces.Lagrange(nodes)),
+    (0, 0),
+)
+B12_2D = FunctionSpaces.TensorProductSpace((B1_1D, B2_1D))
+B21_2D = FunctionSpaces.TensorProductSpace((B2_1D, B1_1D))
+LE_2D = FunctionSpaces.TensorProductSpace((L1_1D, E1_1D))
+EL_2D = FunctionSpaces.TensorProductSpace((E1_1D, L1_1D))
+DS_BB_2D = FunctionSpaces.DirectSumSpace((B12_2D, B21_2D))
+DS_LE_2D = FunctionSpaces.DirectSumSpace((LE_2D, EL_2D))
+# FormSpaces
+zero_form_space_B1_2D = Forms.FormSpace(0, B1_2D, "0S-B1-2D")
+zero_form_space_L1_2D = Forms.FormSpace(0, L1_2D, "0S-L1-2D")
+one_form_space_BB_2D = Forms.FormSpace(1, DS_BB_2D, "1S-BB-2D")
+one_form_space_LE_2D = Forms.FormSpace(1, DS_LE_2D, "1S-LE-2D")
+# FormFields
+coeffs_2D = ones(Forms.get_num_basis(zero_form_space_B1_2D))
+coeffs_2D_BB = ones(Forms.get_num_basis(one_form_space_BB_2D))
+zero_form_field_B1_2D = Forms.FormField(zero_form_space_B1_2D, coeffs_2D, "0F-B1-2D")
+one_form_field_BB_2D = Forms.FormField(one_form_space_BB_2D, coeffs_2D_BB, "1F-BB-2D")
+
+# 3D
+B1_3D = FunctionSpaces.create_bspline_space(
+    (0.0, 0.0, 0.0),
+    (1.0, 1.0, 1.0),
+    (3, 4, 5),
+    (FunctionSpaces.Bernstein(2), FunctionSpaces.Bernstein(2), FunctionSpaces.Bernstein(3)),
+    (1, 1, 1),
+)
+L1_3D = FunctionSpaces.create_bspline_space(
+    (0.0, 0.0, 0.0),
+    (1.0, 1.0, 1.0),
+    (3, 4, 5),
+    (
+        FunctionSpaces.Lagrange(nodes),
+        FunctionSpaces.Lagrange(nodes),
+        FunctionSpaces.Lagrange(nodes),
+    ),
+    (0, 0, 0),
+)
+zero_form_space_B1_3D = Forms.FormSpace(0, B1_3D, "zero-form-B1-3D")
+zero_form_space_L1_3D = Forms.FormSpace(0, L1_3D, "zero-form-L1-3D")
+coeffs_3D = ones(Forms.get_num_basis(zero_form_space_B1_3D))
+zero_form_field_B1_3D = Forms.FormField(
+    zero_form_space_B1_3D, coeffs_3D, "zero-form-field-B1-3D"
+)
+B112_3D = FunctionSpaces.TensorProductSpace((B1_1D, B1_1D, B2_1D))
+B121_3D = FunctionSpaces.TensorProductSpace((B1_1D, B2_1D, B1_1D))
+B211_3D = FunctionSpaces.TensorProductSpace((B2_1D, B1_1D, B1_1D))
+LLE_3D = FunctionSpaces.TensorProductSpace((L1_1D, L1_1D, E1_1D))
+LEL_3D = FunctionSpaces.TensorProductSpace((L1_1D, E1_1D, L1_1D))
+ELL_3D = FunctionSpaces.TensorProductSpace((E1_1D, L1_1D, L1_1D))
+
+DS_BBB_3D = FunctionSpaces.DirectSumSpace((B112_3D, B121_3D, B211_3D))
+DS_LEL_3D = FunctionSpaces.DirectSumSpace((LLE_3D, LEL_3D, ELL_3D))
+
+one_form_space_BBB_3D = Forms.FormSpace(1, DS_BBB_3D, "one-form-BBB")
+one_form_space_LEL_3D = Forms.FormSpace(1, DS_LEL_3D, "one-form-LEL")
+coeffs_3D_BBB = ones(Forms.get_num_basis(one_form_space_BBB_3D))
+one_form_field_BBB_3D = Forms.FormField(
+    one_form_space_BBB_3D, coeffs_3D_BBB, "one-form-field-BBB"
+)
+
+B122_3D = FunctionSpaces.TensorProductSpace((B1_1D, B2_1D, B2_1D))
+B221_3D = FunctionSpaces.TensorProductSpace((B2_1D, B2_1D, B1_1D))
+B212_3D = FunctionSpaces.TensorProductSpace((B2_1D, B1_1D, B2_1D))
+LEE_3D = FunctionSpaces.TensorProductSpace((L1_1D, E1_1D, E1_1D))
+EEL_3D = FunctionSpaces.TensorProductSpace((E1_1D, E1_1D, L1_1D))
+ELE_3D = FunctionSpaces.TensorProductSpace((E1_1D, L1_1D, E1_1D))
+
+DS_BBB_3D_2 = FunctionSpaces.DirectSumSpace((B122_3D, B212_3D, B221_3D))
+DS_LEE_3D = FunctionSpaces.DirectSumSpace((LEE_3D, ELE_3D, EEL_3D))
+
+two_form_space_BBB_3D_2 = Forms.FormSpace(2, DS_BBB_3D_2, "two-form-BBB-2")
+two_form_space_LEE_3D = Forms.FormSpace(2, DS_LEE_3D, "two-form-LEE")
+coeffs_3D_BBB_2 = ones(Forms.get_num_basis(two_form_space_BBB_3D_2))
+two_form_field_BBB_3D_2 = Forms.FormField(
+    two_form_space_BBB_3D_2, coeffs_3D_BBB_2, "two-form-field-BBB-2"
+)
+
+# 4D
+B1111_4D = FunctionSpaces.TensorProductSpace((B1_1D, B1_1D, B1_1D, B1_1D))
+B1112_4D = FunctionSpaces.TensorProductSpace((B1_1D, B1_1D, B1_1D, B2_1D))
+B1121_4D = FunctionSpaces.TensorProductSpace((B1_1D, B1_1D, B2_1D, B1_1D))
+B1211_4D = FunctionSpaces.TensorProductSpace((B1_1D, B2_1D, B1_1D, B1_1D))
+B2111_4D = FunctionSpaces.TensorProductSpace((B2_1D, B1_1D, B1_1D, B1_1D))
+
+DS_BBBB_4D = FunctionSpaces.DirectSumSpace((B1112_4D, B1121_4D, B1211_4D, B2111_4D))
+
+zero_form_space_BBBB_4D = Forms.FormSpace(0, B1111_4D, "zero-form-BBBB")
+one_form_space_BBBB_4D = Forms.FormSpace(1, DS_BBBB_4D, "one-form-BBBB")
+
+# 5D
+B11111_5D = FunctionSpaces.TensorProductSpace((B1_1D, B1_1D, B1_1D, B1_1D, B1_1D))
+zero_form_space_BBBBB_5D = Forms.FormSpace(0, B11111_5D, "zero-form-BBBBB")
+
+forms_base = (
+    zero_form_space_B1_1D,
+    zero_form_space_L1_1D,
+    one_form_space_B2_1D,
+    one_form_space_E1_1D,
+    zero_form_field_B1_1D,
+    zero_form_field_L1_1D,
+    one_form_field_B2_1D,
+    one_form_field_E1_1D,
+    zero_form_space_B1_2D,
+    zero_form_space_L1_2D,
+    one_form_space_BB_2D,
+    one_form_space_LE_2D,
+    zero_form_field_B1_2D,
+    one_form_field_BB_2D,
+    zero_form_space_B1_3D,
+    zero_form_space_L1_3D,
+    zero_form_field_B1_3D,
+    one_form_space_BBB_3D,
+    one_form_space_LEL_3D,
+    one_form_field_BBB_3D,
+    two_form_space_BBB_3D_2,
+    two_form_space_LEE_3D,
+    two_form_field_BBB_3D_2,
+    zero_form_space_BBBB_4D,
+    one_form_space_BBBB_4D,
+    zero_form_space_BBBBB_5D,
+)
+
+forms_base_uni_min = (
+    -zero_form_space_B1_1D,
+    -zero_form_space_L1_1D,
+    -one_form_space_B2_1D,
+    -one_form_space_E1_1D,
+    -zero_form_field_B1_1D,
+    -zero_form_field_L1_1D,
+    -one_form_field_B2_1D,
+    -one_form_field_E1_1D,
+    -zero_form_space_B1_2D,
+    -zero_form_space_L1_2D,
+    -one_form_space_BB_2D,
+    -one_form_space_LE_2D,
+    -zero_form_field_B1_2D,
+    -one_form_field_BB_2D,
+    -zero_form_space_B1_3D,
+    -zero_form_space_L1_3D,
+    -zero_form_field_B1_3D,
+    -one_form_space_BBB_3D,
+    -one_form_space_LEL_3D,
+    -one_form_field_BBB_3D,
+    -two_form_space_BBB_3D_2,
+    -two_form_space_LEE_3D,
+    -two_form_field_BBB_3D_2,
+    -zero_form_space_BBBB_4D,
+    -one_form_space_BBBB_4D,
+    -zero_form_space_BBBBB_5D,
+)
+
+forms_base_uni_prod = (
+    3.0 * zero_form_space_B1_1D,
+    3.0 * zero_form_space_L1_1D,
+    3.0 * one_form_space_B2_1D,
+    3.0 * one_form_space_E1_1D,
+    3.0 * zero_form_field_B1_1D,
+    3.0 * zero_form_field_L1_1D,
+    3.0 * one_form_field_B2_1D,
+    3.0 * one_form_field_E1_1D,
+    3.0 * zero_form_space_B1_2D,
+    3.0 * zero_form_space_L1_2D,
+    3.0 * one_form_space_BB_2D,
+    3.0 * one_form_space_LE_2D,
+    3.0 * zero_form_field_B1_2D,
+    3.0 * one_form_field_BB_2D,
+    3.0 * zero_form_space_B1_3D,
+    3.0 * zero_form_space_L1_3D,
+    3.0 * zero_form_field_B1_3D,
+    3.0 * one_form_space_BBB_3D,
+    3.0 * one_form_space_LEL_3D,
+    3.0 * one_form_field_BBB_3D,
+    3.0 * two_form_space_BBB_3D_2,
+    3.0 * two_form_space_LEE_3D,
+    3.0 * two_form_field_BBB_3D_2,
+    3.0 * zero_form_space_BBBB_4D,
+    3.0 * one_form_space_BBBB_4D,
+    3.0 * zero_form_space_BBBBB_5D,
+)
+
+forms_base_bin_min = (f - f for f in forms_base)
+forms_base_bin_plus = (f + f for f in forms_base)
+forms_base_bin_prod = (f * f for f in forms_base)
+
+forms = (
+    forms_base...,
+    forms_base_uni_min...,
+    forms_base_uni_prod...,
+    forms_base_bin_min...,
+    forms_base_bin_plus...,
+    forms_base_bin_prod...,
+)

--- a/test/Inference/Forms/HodgeInferenceTests.jl
+++ b/test/Inference/Forms/HodgeInferenceTests.jl
@@ -40,7 +40,7 @@ for form in forms
         @test_opt Forms.get_num_basis(hodge)
         @test_opt Forms.get_num_basis(hodge, element_id)
         @test_opt Forms.get_max_local_dim(hodge)
-        @test_opt Forms.get_num_basis_per_basis(hodge, element_id)
+        @test_opt Forms.get_num_basis_per_expression(hodge, element_id)
     end
 
     # Evaluate.

--- a/test/Inference/Forms/HodgeInferenceTests.jl
+++ b/test/Inference/Forms/HodgeInferenceTests.jl
@@ -1,0 +1,62 @@
+module HodgeInferenceTests
+
+const verbose = false
+
+include("FormsInferenceTestSetup.jl")
+
+for form in forms
+    expression_rank = Forms.get_expression_rank(form)
+    if expression_rank >= 2
+        # We can't construct the hodge of a form with an expression rank of 2 or higher.
+        continue
+    end
+
+    if verbose
+        println("New test ---")
+        @show nameof(typeof(form))
+        @show Forms.get_manifold_dim(form)
+        @show Forms.get_form_rank(form)
+        @show Forms.get_expression_rank(form)
+    end
+
+    # Construction
+    @test_opt Forms.Hodge(form)
+    hodge = Forms.Hodge(form)
+
+    # Methods defined for all forms (they can be specialised or throw an error).
+    @test_opt Forms.get_manifold_dim(hodge)
+    @test_opt Forms.get_form_rank(hodge)
+    @test_opt Forms.get_expression_rank(hodge)
+    @test_opt Forms.get_label(hodge)
+    @test_opt Forms.get_form(hodge)
+    @test_opt Forms.get_form_space_tree(hodge)
+    @test_opt Forms.get_geometry(hodge)
+    @test_opt Forms.get_num_elements(hodge)
+    @test_opt Forms.get_estimated_nnz_per_elem(hodge)
+    @test_opt Forms.get_fe_space(hodge)
+
+    # Methods defined for all AbstractForms with expression rank 1 (AbstractFormSpaces).
+    if Forms.get_expression_rank(hodge) == 1
+        @test_opt Forms.get_num_basis(hodge)
+        @test_opt Forms.get_num_basis(hodge, element_id)
+        @test_opt Forms.get_max_local_dim(hodge)
+        @test_opt Forms.get_num_basis_per_basis(hodge, element_id)
+    end
+
+    # Evaluate.
+    if Forms.get_manifold_dim(hodge) == 1
+        @test_opt Forms.evaluate(hodge, element_id_1D, xi_1D)
+    elseif Forms.get_manifold_dim(hodge) == 2
+        @test_opt Forms.evaluate(hodge, element_id_2D, xi_2D)
+    elseif Forms.get_manifold_dim(hodge) == 3
+        @test_opt Forms.evaluate(hodge, element_id_3D, xi_3D)
+    elseif Forms.get_manifold_dim(hodge) == 4
+        @test_opt Forms.evaluate(hodge, element_id_4D, xi_4D)
+    elseif Forms.get_manifold_dim(hodge) == 5
+        @test_opt Forms.evaluate(hodge, element_id_5D, xi_5D)
+    else
+        @warn "HodgeInference: The evaluate for this hodge was not tested: $(hodge)"
+    end
+end
+
+end

--- a/test/Inference/Forms/IntegralInferenceTests.jl
+++ b/test/Inference/Forms/IntegralInferenceTests.jl
@@ -1,0 +1,63 @@
+module IntegralInferenceTests
+
+const verbose = false
+
+include("FormsInferenceTestSetup.jl")
+
+for form in forms
+    manifold_dim = Forms.get_manifold_dim(form)
+    form_rank = Forms.get_form_rank(form)
+    if form_rank != manifold_dim
+        # We can only construct integrals of top forms.
+        continue
+    end
+
+    if verbose
+        println("New test ---")
+        @show nameof(typeof(form))
+        @show Forms.get_manifold_dim(form)
+        @show Forms.get_form_rank(form)
+        @show Forms.get_expression_rank(form)
+    end
+
+    element_quad_rule = Quadrature.tensor_product_rule(
+        ntuple(i -> 3, manifold_dim), Quadrature.gauss_legendre
+    )
+    quad_rule = Quadrature.StandardQuadrature(
+        element_quad_rule, Forms.get_num_elements(form)
+    )
+
+    # Construction
+    @test_opt Forms.Integral(form, quad_rule)
+    int = Forms.Integral(form, quad_rule)
+
+    # Methods defined for all real valued operators (they can be specialised or throw an
+    # error).
+    @test_opt Forms.get_manifold_dim(int)
+    @test_opt Forms.get_expression_rank(int)
+    @test_opt Forms.get_form(int)
+    @test_opt Forms.get_form_space_tree(int)
+    @test_opt Forms.get_geometry(int)
+
+    @test_opt Forms.get_quadrature_rule(int)
+    @test_opt Forms.get_num_elements(int)
+    @test_opt Forms.get_num_evaluation_elements(int)
+    @test_opt Forms.get_estimated_nnz_per_elem(int)
+
+    # Evaluate.
+    if Forms.get_manifold_dim(int) == 1
+        @test_opt Forms.evaluate(int, element_id_1D)
+    elseif Forms.get_manifold_dim(int) == 2
+        @test_opt Forms.evaluate(int, element_id_2D)
+    elseif Forms.get_manifold_dim(int) == 3
+        @test_opt Forms.evaluate(int, element_id_3D)
+    elseif Forms.get_manifold_dim(int) == 4
+        @test_opt Forms.evaluate(int, element_id_4D)
+    elseif Forms.get_manifold_dim(int) == 5
+        @test_opt Forms.evaluate(int, element_id_5D)
+    else
+        @warn "IntegralInference: The evaluate for this int was not tested: $(int)"
+    end
+end
+
+end

--- a/test/Inference/Forms/SharpInferenceTests.jl
+++ b/test/Inference/Forms/SharpInferenceTests.jl
@@ -1,0 +1,50 @@
+module SharpInferenceTests
+
+const verbose = false
+
+include("FormsInferenceTestSetup.jl")
+
+for form in forms
+    manifold_dim = Forms.get_manifold_dim(form)
+    form_rank = Forms.get_form_rank(form)
+    expression_rank = Forms.get_expression_rank(form)
+    if !(manifold_dim >= 2 && form_rank == 1 && expression_rank == 0)
+        # We can only construct the Sharp for 1 forms of fields in 2D or up.
+        continue
+    end
+
+    if verbose
+        println("New test ---")
+        @show nameof(typeof(form))
+        @show Forms.get_manifold_dim(form)
+        @show Forms.get_form_rank(form)
+        @show Forms.get_expression_rank(form)
+    end
+
+    # The Sharp is not a form itself, so it has far fewer methods than the other operators.
+
+    # Construction
+    @test_opt Forms.Sharp(form)
+    sharp = Forms.Sharp(form)
+
+    # Methods defined for all forms (they can be specialised or throw an error).
+    @test_opt Forms.get_form(sharp)
+    @test_opt Forms.get_form_space_tree(sharp)
+
+    # Evaluate.
+    if Forms.get_manifold_dim(form) == 1
+        @test_opt Forms.evaluate(sharp, element_id_1D, xi_1D)
+    elseif Forms.get_manifold_dim(form) == 2
+        @test_opt Forms.evaluate(sharp, element_id_2D, xi_2D)
+    elseif Forms.get_manifold_dim(form) == 3
+        @test_opt Forms.evaluate(sharp, element_id_3D, xi_3D)
+    elseif Forms.get_manifold_dim(form) == 4
+        @test_opt Forms.evaluate(sharp, element_id_4D, xi_4D)
+    elseif Forms.get_manifold_dim(form) == 5
+        @test_opt Forms.evaluate(sharp, element_id_5D, xi_5D)
+    else
+        @warn "SharpInference: The evaluate for this sharp was not tested: $(sharp)"
+    end
+end
+
+end

--- a/test/Inference/Forms/WedgeInferenceTests.jl
+++ b/test/Inference/Forms/WedgeInferenceTests.jl
@@ -210,7 +210,7 @@ for wedge in wedges
         @test_opt Forms.get_num_basis(wedge)
         @test_opt Forms.get_num_basis(wedge, element_id)
         @test_opt Forms.get_max_local_dim(wedge)
-        @test_opt Forms.get_num_basis_per_basis(wedge, element_id)
+        @test_opt Forms.get_num_basis_per_expression(wedge, element_id)
     end
 
     # Methods that only exist for the wedge.

--- a/test/Inference/Forms/WedgeInferenceTests.jl
+++ b/test/Inference/Forms/WedgeInferenceTests.jl
@@ -1,0 +1,235 @@
+module WedgeInferenceTests
+
+include("FormsInferenceTestSetup.jl")
+
+# Wedge construction
+# wedge_formrank1formrank2_expr.rank1expr.rank2
+# 1D
+@test_opt Forms.Wedge(zero_form_space_B1_1D, zero_form_space_B1_1D)
+@test_opt Forms.Wedge(zero_form_space_B1_1D, zero_form_space_L1_1D)
+@test_opt Forms.Wedge(zero_form_space_L1_1D, zero_form_space_B1_1D)
+@test_opt Forms.Wedge(zero_form_space_B1_1D, zero_form_field_B1_1D)
+@test_opt Forms.Wedge(zero_form_field_B1_1D, zero_form_space_L1_1D)
+@test_opt Forms.Wedge(zero_form_field_B1_1D, zero_form_space_B1_1D)
+@test_opt Forms.Wedge(zero_form_field_B1_1D, zero_form_field_B1_1D)
+@test_opt Forms.Wedge(one_form_space_B2_1D, zero_form_space_B1_1D)
+@test_opt Forms.Wedge(one_form_space_B2_1D, zero_form_space_L1_1D)
+@test_opt Forms.Wedge(zero_form_space_L1_1D, one_form_space_B2_1D)
+@test_opt Forms.Wedge(one_form_space_B2_1D, zero_form_field_B1_1D)
+@test_opt Forms.Wedge(one_form_field_B2_1D, zero_form_space_L1_1D)
+@test_opt Forms.Wedge(zero_form_field_B1_1D, one_form_space_B2_1D)
+@test_opt Forms.Wedge(one_form_field_B2_1D, zero_form_field_B1_1D)
+@test_opt Forms.Wedge(zero_form_field_B1_1D, one_form_field_B2_1D)
+
+wedge_00_11_B1B1_1D = Forms.Wedge(zero_form_space_B1_1D, zero_form_space_B1_1D)
+wedge_00_11_B1L1_1D = Forms.Wedge(zero_form_space_B1_1D, zero_form_space_L1_1D)
+wedge_00_11_L1B1_1D = Forms.Wedge(zero_form_space_L1_1D, zero_form_space_B1_1D)
+wedge_00_10_B1B1_1D = Forms.Wedge(zero_form_space_B1_1D, zero_form_field_B1_1D)
+wedge_00_01_B1L1_1D = Forms.Wedge(zero_form_field_B1_1D, zero_form_space_L1_1D)
+wedge_00_01_B1B1_1D = Forms.Wedge(zero_form_field_B1_1D, zero_form_space_B1_1D)
+wedge_00_00_B1B1_1D = Forms.Wedge(zero_form_field_B1_1D, zero_form_field_B1_1D)
+wedge_10_11_B2B1_1D = Forms.Wedge(one_form_space_B2_1D, zero_form_space_B1_1D)
+wedge_10_11_B2L1_1D = Forms.Wedge(one_form_space_B2_1D, zero_form_space_L1_1D)
+wedge_01_11_L1B2_1D = Forms.Wedge(zero_form_space_L1_1D, one_form_space_B2_1D)
+wedge_10_10_B2B2_1D = Forms.Wedge(one_form_space_B2_1D, zero_form_field_B1_1D)
+wedge_10_01_B2E1_1D = Forms.Wedge(one_form_field_B2_1D, zero_form_space_L1_1D)
+wedge_01_01_B2B2_1D = Forms.Wedge(zero_form_field_B1_1D, one_form_space_B2_1D)
+wedge_10_00_B2B2_1D = Forms.Wedge(one_form_field_B2_1D, zero_form_field_B1_1D)
+wedge_01_00_B1B2_1D = Forms.Wedge(zero_form_field_B1_1D, one_form_field_B2_1D)
+
+# 2D
+@test_opt Forms.Wedge(zero_form_space_B1_2D, zero_form_space_B1_2D)
+@test_opt Forms.Wedge(zero_form_space_B1_2D, zero_form_space_L1_2D)
+@test_opt Forms.Wedge(zero_form_space_L1_2D, zero_form_space_B1_2D)
+@test_opt Forms.Wedge(zero_form_space_B1_2D, zero_form_field_B1_2D)
+@test_opt Forms.Wedge(zero_form_field_B1_2D, zero_form_space_L1_2D)
+@test_opt Forms.Wedge(zero_form_field_B1_2D, zero_form_space_B1_2D)
+@test_opt Forms.Wedge(zero_form_field_B1_2D, zero_form_field_B1_2D)
+@test_opt Forms.Wedge(one_form_space_BB_2D, one_form_space_BB_2D)
+@test_opt Forms.Wedge(one_form_space_BB_2D, one_form_space_LE_2D)
+@test_opt Forms.Wedge(one_form_space_LE_2D, one_form_space_BB_2D)
+@test_opt Forms.Wedge(one_form_space_BB_2D, one_form_field_BB_2D)
+@test_opt Forms.Wedge(one_form_field_BB_2D, one_form_space_LE_2D)
+@test_opt Forms.Wedge(one_form_field_BB_2D, one_form_space_BB_2D)
+@test_opt Forms.Wedge(one_form_field_BB_2D, one_form_field_BB_2D)
+
+wedge_00_11_B1B1_2D = Forms.Wedge(zero_form_space_B1_2D, zero_form_space_B1_2D)
+wedge_00_11_B1L1_2D = Forms.Wedge(zero_form_space_B1_2D, zero_form_space_L1_2D)
+wedge_00_11_L1B1_2D = Forms.Wedge(zero_form_space_L1_2D, zero_form_space_B1_2D)
+wedge_00_10_B1B1_2D = Forms.Wedge(zero_form_space_B1_2D, zero_form_field_B1_2D)
+wedge_00_01_B1L1_2D = Forms.Wedge(zero_form_field_B1_2D, zero_form_space_L1_2D)
+wedge_00_01_B1B1_2D = Forms.Wedge(zero_form_field_B1_2D, zero_form_space_B1_2D)
+wedge_00_00_B1B1_2D = Forms.Wedge(zero_form_field_B1_2D, zero_form_space_B1_2D)
+wedge_11_11_BBBB_2D = Forms.Wedge(one_form_space_BB_2D, one_form_space_BB_2D)
+wedge_11_11_BBLE_2D = Forms.Wedge(one_form_space_BB_2D, one_form_space_LE_2D)
+wedge_11_11_LEBB_2D = Forms.Wedge(one_form_space_LE_2D, one_form_space_BB_2D)
+wedge_11_10_BBBB_2D = Forms.Wedge(one_form_space_BB_2D, one_form_field_BB_2D)
+wedge_11_01_BBLE_2D = Forms.Wedge(one_form_field_BB_2D, one_form_space_LE_2D)
+wedge_11_01_BBBB_2D = Forms.Wedge(one_form_field_BB_2D, one_form_space_BB_2D)
+wedge_11_00_BBBB_2D = Forms.Wedge(one_form_field_BB_2D, one_form_field_BB_2D)
+
+# 3D
+@test_opt Forms.Wedge(zero_form_space_B1_3D, zero_form_space_B1_3D)
+@test_opt Forms.Wedge(zero_form_space_B1_3D, zero_form_space_L1_3D)
+@test_opt Forms.Wedge(zero_form_space_L1_3D, zero_form_space_B1_3D)
+@test_opt Forms.Wedge(zero_form_space_B1_3D, zero_form_field_B1_3D)
+@test_opt Forms.Wedge(zero_form_field_B1_3D, zero_form_space_L1_3D)
+@test_opt Forms.Wedge(zero_form_field_B1_3D, zero_form_space_B1_3D)
+@test_opt Forms.Wedge(zero_form_field_B1_3D, zero_form_field_B1_3D)
+@test_opt Forms.Wedge(one_form_space_BBB_3D, one_form_space_BBB_3D)
+@test_opt Forms.Wedge(one_form_space_BBB_3D, one_form_space_LEL_3D)
+@test_opt Forms.Wedge(one_form_space_LEL_3D, one_form_space_BBB_3D)
+@test_opt Forms.Wedge(one_form_space_BBB_3D, one_form_field_BBB_3D)
+@test_opt Forms.Wedge(one_form_field_BBB_3D, one_form_space_LEL_3D)
+@test_opt Forms.Wedge(one_form_field_BBB_3D, one_form_space_BBB_3D)
+@test_opt Forms.Wedge(one_form_field_BBB_3D, one_form_field_BBB_3D)
+@test_opt Forms.Wedge(two_form_space_BBB_3D_2, one_form_space_BBB_3D)
+@test_opt Forms.Wedge(two_form_space_BBB_3D_2, one_form_space_LEL_3D)
+@test_opt Forms.Wedge(one_form_space_LEL_3D, two_form_space_BBB_3D_2)
+@test_opt Forms.Wedge(two_form_space_BBB_3D_2, one_form_field_BBB_3D)
+@test_opt Forms.Wedge(one_form_field_BBB_3D, two_form_space_LEE_3D)
+@test_opt Forms.Wedge(one_form_field_BBB_3D, two_form_space_BBB_3D_2)
+@test_opt Forms.Wedge(two_form_space_BBB_3D_2, one_form_field_BBB_3D)
+
+wedge_00_11_B1B1_3D = Forms.Wedge(zero_form_space_B1_3D, zero_form_space_B1_3D)
+wedge_00_11_B1L1_3D = Forms.Wedge(zero_form_space_B1_3D, zero_form_space_L1_3D)
+wedge_00_11_L1B1_3D = Forms.Wedge(zero_form_space_L1_3D, zero_form_space_B1_3D)
+wedge_00_10_B1B1_3D = Forms.Wedge(zero_form_space_B1_3D, zero_form_field_B1_3D)
+wedge_00_01_B1L1_3D = Forms.Wedge(zero_form_field_B1_3D, zero_form_space_L1_3D)
+wedge_00_01_B1B1_3D = Forms.Wedge(zero_form_field_B1_3D, zero_form_space_B1_3D)
+wedge_00_00_B1B1_3D = Forms.Wedge(zero_form_field_B1_3D, zero_form_space_B1_3D)
+wedge_11_11_BBBBBB_3D = Forms.Wedge(one_form_space_BBB_3D, one_form_space_BBB_3D)
+wedge_11_11_BBBLEL_3D = Forms.Wedge(one_form_space_BBB_3D, one_form_space_LEL_3D)
+wedge_11_11_LELBBB_3D = Forms.Wedge(one_form_space_LEL_3D, one_form_space_BBB_3D)
+wedge_11_10_BBBBBB_3D = Forms.Wedge(one_form_space_BBB_3D, one_form_field_BBB_3D)
+wedge_11_01_BBBLEL_3D = Forms.Wedge(one_form_field_BBB_3D, one_form_space_LEL_3D)
+wedge_11_01_BBBBBB_3D = Forms.Wedge(one_form_field_BBB_3D, one_form_space_BBB_3D)
+wedge_11_00_BBBBBB_3D = Forms.Wedge(one_form_field_BBB_3D, one_form_field_BBB_3D)
+wedge_21_11_BB_3D = Forms.Wedge(two_form_space_BBB_3D_2, one_form_space_BBB_3D)
+wedge_12_11_BL_3D = Forms.Wedge(one_form_space_BBB_3D, two_form_space_LEE_3D)
+wedge_21_11_LB_3D = Forms.Wedge(two_form_space_LEE_3D, one_form_space_BBB_3D)
+wedge_21_10_BB_3D = Forms.Wedge(two_form_space_BBB_3D_2, one_form_field_BBB_3D)
+wedge_12_01_BL_3D = Forms.Wedge(one_form_field_BBB_3D, two_form_space_LEE_3D)
+wedge_12_01_BB_3D = Forms.Wedge(one_form_field_BBB_3D, two_form_space_BBB_3D_2)
+wedge_21_00_BB_3D = Forms.Wedge(two_form_field_BBB_3D_2, one_form_field_BBB_3D)
+
+# 4D
+@test_opt Forms.Wedge(zero_form_space_BBBB_4D, zero_form_space_BBBB_4D)
+@test_opt Forms.Wedge(Forms.d(zero_form_space_BBBB_4D), Forms.d(zero_form_space_BBBB_4D))
+@test_opt Forms.Wedge(zero_form_space_BBBB_4D, one_form_space_BBBB_4D)
+@test_opt Forms.Wedge(one_form_space_BBBB_4D, zero_form_space_BBBB_4D)
+@test_opt Forms.Wedge(one_form_space_BBBB_4D, one_form_space_BBBB_4D)
+
+wedge_00_11_BB_4D = Forms.Wedge(zero_form_space_BBBB_4D, zero_form_space_BBBB_4D)
+wedge_01_11_BB_4D = Forms.Wedge(zero_form_space_BBBB_4D, one_form_space_BBBB_4D)
+wedge_10_11_BB_4D = Forms.Wedge(one_form_space_BBBB_4D, zero_form_space_BBBB_4D)
+wedge_11_11_BB_4D = Forms.Wedge(one_form_space_BBBB_4D, one_form_space_BBBB_4D)
+wedge_11_11_dd_4D = Forms.Wedge(
+    Forms.d(zero_form_space_BBBB_4D), Forms.d(zero_form_space_BBBB_4D)
+)
+
+# 5D
+wedge_00_11_BB_5D = Forms.Wedge(zero_form_space_BBBBB_5D, zero_form_space_BBBBB_5D)
+
+# All together now.
+wedges = (
+    wedge_00_11_B1B1_1D,
+    wedge_00_11_B1L1_1D,
+    wedge_00_11_L1B1_1D,
+    wedge_00_10_B1B1_1D,
+    wedge_00_01_B1L1_1D,
+    wedge_00_01_B1B1_1D,
+    wedge_00_00_B1B1_1D,
+    wedge_10_11_B2B1_1D,
+    wedge_10_11_B2L1_1D,
+    wedge_10_10_B2B2_1D,
+    wedge_10_01_B2E1_1D,
+    wedge_10_00_B2B2_1D,
+    wedge_01_11_L1B2_1D,
+    wedge_01_01_B2B2_1D,
+    wedge_01_00_B1B2_1D,
+    wedge_00_11_B1B1_2D,
+    wedge_00_11_B1L1_2D,
+    wedge_00_11_L1B1_2D,
+    wedge_00_10_B1B1_2D,
+    wedge_00_01_B1L1_2D,
+    wedge_00_01_B1B1_2D,
+    wedge_00_00_B1B1_2D,
+    wedge_11_11_BBBB_2D,
+    wedge_11_11_BBLE_2D,
+    wedge_11_11_LEBB_2D,
+    wedge_11_10_BBBB_2D,
+    wedge_11_01_BBLE_2D,
+    wedge_11_01_BBBB_2D,
+    wedge_11_00_BBBB_2D,
+    wedge_00_11_B1B1_3D,
+    wedge_00_11_B1L1_3D,
+    wedge_00_11_L1B1_3D,
+    wedge_00_10_B1B1_3D,
+    wedge_00_01_B1L1_3D,
+    wedge_00_01_B1B1_3D,
+    wedge_00_00_B1B1_3D,
+    wedge_11_11_BBBBBB_3D,
+    wedge_11_11_BBBLEL_3D,
+    wedge_11_11_LELBBB_3D,
+    wedge_11_10_BBBBBB_3D,
+    wedge_11_01_BBBLEL_3D,
+    wedge_11_01_BBBBBB_3D,
+    wedge_11_00_BBBBBB_3D,
+    wedge_21_11_BB_3D,
+    wedge_12_11_BL_3D,
+    wedge_21_11_LB_3D,
+    wedge_21_10_BB_3D,
+    wedge_12_01_BL_3D,
+    wedge_12_01_BB_3D,
+    wedge_21_00_BB_3D,
+    wedge_00_11_BB_4D,
+    wedge_01_11_BB_4D,
+    wedge_10_11_BB_4D,
+    wedge_11_11_BB_4D,
+    wedge_11_11_dd_4D,
+    wedge_00_11_BB_5D,
+)
+
+for wedge in wedges
+
+    # Methods defined for all forms (they can be specialised or throw an error).
+    @test_opt Forms.get_manifold_dim(wedge)
+    @test_opt Forms.get_form_rank(wedge)
+    @test_opt Forms.get_expression_rank(wedge)
+    @test_opt Forms.get_label(wedge)
+    @test_opt Forms.get_form(wedge)
+    @test_opt Forms.get_form_space_tree(wedge)
+    @test_opt Forms.get_geometry(wedge)
+    @test_opt Forms.get_num_elements(wedge)
+    @test_opt Forms.get_estimated_nnz_per_elem(wedge)
+    @test_opt Forms.get_fe_space(wedge)
+
+    # Methods defined for all AbstractForms with expression rank 1 (AbstractFormSpaces).
+    if Forms.get_expression_rank(wedge) == 1
+        @test_opt Forms.get_num_basis(wedge)
+        @test_opt Forms.get_num_basis(wedge, element_id)
+        @test_opt Forms.get_max_local_dim(wedge)
+        @test_opt Forms.get_num_basis_per_basis(wedge, element_id)
+    end
+
+    # Methods that only exist for the wedge.
+    @test_opt Forms.get_forms(wedge)
+
+    # Evaluate.
+    if Forms.get_manifold_dim(wedge) == 1
+        @test_opt Forms.evaluate(wedge, element_id_1D, xi_1D)
+    elseif Forms.get_manifold_dim(wedge) == 2
+        @test_opt Forms.evaluate(wedge, element_id_2D, xi_2D)
+    elseif Forms.get_manifold_dim(wedge) == 3
+        @test_opt Forms.evaluate(wedge, element_id_3D, xi_3D)
+    elseif Forms.get_manifold_dim(wedge) == 4
+        @test_opt Forms.evaluate(wedge, element_id_4D, xi_4D)
+    elseif Forms.get_manifold_dim(wedge) == 5
+        @test_opt Forms.evaluate(wedge, element_id_5D, xi_5D)
+    else
+        @warn "WedgeInference: The evaluate for this wedge was not tested: $(wedge)"
+    end
+end
+
+end

--- a/test/Inference/GeometryInferenceTests.jl
+++ b/test/Inference/GeometryInferenceTests.jl
@@ -1,7 +1,5 @@
 module GeometryInferenceTests
 
-import Pkg
-
 using Mantis
 using Test
 using JET
@@ -37,9 +35,7 @@ cg2d = Geometry.CartesianGeometry((
 ))
 tpgeo = Geometry.TensorProductGeometry((cg2d, cg1d))
 # 11D, TensorProduct, mixed
-tpgeo11D = Geometry.TensorProductGeometry((
-    tpgeo, geometry1p4D, cg2d, cg1d, geometry1
-))
+tpgeo11D = Geometry.TensorProductGeometry((tpgeo, geometry1p4D, cg2d, cg1d, geometry1))
 # 2D, Mapped
 # Mappings to create the deformed geometries. The mappings are defined with
 # reference to the unit square [0,1]x[0,1] as parametric domain.
@@ -119,19 +115,13 @@ geom_slanted_2patch_oneref = Geometry.MappedGeometry(
 # Mapped, multiple patches with one map.
 geom_slanted_2patch_onemap = Geometry.MappedGeometry(
     (
-        Geometry.CartesianGeometry(((
-            LinRange(0.0, 0.5, 5), LinRange(0.0, 1.0, 7)
-        ),)),
-        Geometry.CartesianGeometry(((
-            LinRange(0.5, 1.0, 4), LinRange(0.0, 1.0, 7)
-        ),)),
+        Geometry.CartesianGeometry(((LinRange(0.0, 0.5, 5), LinRange(0.0, 1.0, 7)),)),
+        Geometry.CartesianGeometry(((LinRange(0.5, 1.0, 4), LinRange(0.0, 1.0, 7)),)),
     ),
     mapping_patch_1_slanted,
 )
 # Mapped, single mapping, single patch.
-geom_slanted_2patch_11 = Geometry.MappedGeometry(
-    geom_cart_patch_1, mapping_patch_1_slanted
-)
+geom_slanted_2patch_11 = Geometry.MappedGeometry(geom_cart_patch_1, mapping_patch_1_slanted)
 
 # Unstructured
 geom_unstr = Geometry.UnstructuredGeometry((
@@ -187,9 +177,7 @@ const xi_1D = Points.TensorProductPoints(([0.0, 1.0],))
 const xi_2D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0]))
 const xi_3D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0], [0.0, 1.0]))
 const xi_3D_set = Points.PointSet(([0.0, 1.0], [0.0, 1.0], [0.0, 1.0]))
-const xi_4D = Points.TensorProductPoints((
-    [0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [0.0, 1.0]
-))
+const xi_4D = Points.TensorProductPoints(([0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [0.0, 1.0]))
 const xi_11D = Points.TensorProductPoints((
     [0.0, 1.0],
     [0.0, 1.0],
@@ -222,7 +210,7 @@ const xi_11D_set = Points.PointSet((
 @test_opt Geometry.create_curvilinear_square((0.0, 0.0), (1.0, 1.0), (3, 4); c=0.2)
 @test_opt Geometry.create_curvilinear_mapping((0.0, 0.0, 0.0), (1.0, 1.0, 1.0), 0.2)
 
-foreach(geos) do geo
+for geo in geos
     # Note that JET only uses the types of the inputs, so which numbers we pick
     # here is irrelevant.
     @test_opt Geometry.get_patch_id(geo, 14)

--- a/test/Inference/TimeIntegratorsInferenceTests.jl
+++ b/test/Inference/TimeIntegratorsInferenceTests.jl
@@ -1,7 +1,5 @@
 module TimeIntegratorsInferenceTests
 
-import Pkg
-
 using Mantis
 using Test
 using JET
@@ -150,7 +148,7 @@ const t = 0.0
     4,
 )
 
-foreach(schemes) do (scheme, startup_scheme)
+for (scheme, startup_scheme) in schemes
     if isnothing(startup_scheme)
         @test_opt TimeIntegrators.initialise_scheme([y_0], scheme)
         y_n = TimeIntegrators.initialise_scheme([y_0], scheme)

--- a/test/Inference/runtests.jl
+++ b/test/Inference/runtests.jl
@@ -2,9 +2,37 @@ module JETTests
 
 using Test
 
-@testset "TensorProducts" begin include("TensorProductsInferenceTests.jl") end
-@testset "Geometry" begin include("GeometryInferenceTests.jl") end
-@testset "FESpaces" begin include("FESpacesInferenceTests.jl") end
-@testset "TimeIntegrators" begin include("TimeIntegratorsInferenceTests.jl") end
+@testset "TensorProducts" begin
+    include("TensorProductsInferenceTests.jl")
+end
+@testset "Geometry" begin
+    include("GeometryInferenceTests.jl")
+end
+@testset "FESpaces" begin
+    include("FESpacesInferenceTests.jl")
+end
+@testset verbose=true "Forms" begin
+    @testset "CoDifferential" begin
+        include("Forms/CoDifferentialInferenceTests.jl")
+    end
+    @testset "ExteriorDerivative" begin
+        include("Forms/ExteriorDerivativeInferenceTests.jl")
+    end
+    @testset "Integral" begin
+        include("Forms/IntegralInferenceTests.jl")
+    end
+    @testset "Hodge" begin
+        include("Forms/HodgeInferenceTests.jl")
+    end
+    @testset "Sharp" begin
+        include("Forms/SharpInferenceTests.jl")
+    end
+    @testset "Wedge" begin
+        include("Forms/WedgeInferenceTests.jl")
+    end
+end
+@testset "TimeIntegrators" begin
+    include("TimeIntegratorsInferenceTests.jl")
+end
 
 end


### PR DESCRIPTION
I added some tests to check for type stability in forms. There were a few smaller things that could be improved type-stability wise, so I did. I also made one of the bspline helpers more consistent. I don't think the overall speed improved, but it also didn't get worse.

I did not create separate inference tests for the fields, spaces, and algebraic operators, because those are the inputs to the form operator and should thus be covered by JET through those calls.